### PR TITLE
role required for kubecost full functionality

### DIFF
--- a/aws/kubecost/main.tf
+++ b/aws/kubecost/main.tf
@@ -1,0 +1,32 @@
+module "kops_metadata" {
+  source       = "git::https://github.com/cloudposse/terraform-aws-kops-metadata.git?ref=tags/0.1.1"
+  dns_zone     = "${var.cluster_name}"
+  masters_name = "${var.masters_name}"
+  nodes_name   = "${var.nodes_name}"
+}
+
+locals {
+  kops_roles = [
+    "${module.kops_metadata.masters_role_arn}",
+    "${module.kops_metadata.nodes_role_arn}",
+  ]
+}
+
+data "aws_iam_policy" "ec2_read_only" {
+  arn = "arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess"
+}
+
+data "aws_iam_policy" "athena_full" {
+  arn = "arn:aws:iam::aws:policy/AmazonAthenaFullAccess"
+}
+
+module "iam_role" {
+  source = "git::https://github.com/cloudposse/terraform-aws-iam-role.git?ref=tags/0.2.0"
+  namespace = "${var.namespace}"
+  policy_description = "Policy required for Kubecost (AmazonEC2ReadOnlyAccess read and AmazonAthenaFullAccess)"
+  stage = "${var.stage}"
+  name = "kubecost"
+  principals_arns = ["${module.kops_metadata.masters_role_arn}"]
+  role_description = "Role for policy required for Kubecost (AmazonEC2ReadOnlyAccess read and AmazonAthenaFullAccess)"
+  policy_documents = ["${data.aws_iam_policy.ec2_read_only.policy}", "${data.aws_iam_policy.athena_full.policy}"]
+}

--- a/aws/kubecost/output.tf
+++ b/aws/kubecost/output.tf
@@ -1,0 +1,14 @@
+output "name" {
+  value       = "${module.iam_role.name}"
+  description = "The name of the IAM role created"
+}
+
+output "id" {
+  value       = "${module.iam_role.id}"
+  description = "The stable and unique string identifying the role"
+}
+
+output "arn" {
+  value       = "${module.iam_role.arn}"
+  description = "The Amazon Resource Name (ARN) specifying the role"
+}

--- a/aws/kubecost/variables.tf
+++ b/aws/kubecost/variables.tf
@@ -1,0 +1,26 @@
+variable "namespace" {
+  type        = "string"
+  description = "Namespace (e.g. `eg` or `cp`)"
+}
+
+variable "cluster_name" {
+  type        = "string"
+  description = "Kops cluster name (e.g. `us-east-1.cloudposse.com` or `cluster-1.cloudposse.com`)"
+}
+
+variable "masters_name" {
+  type        = "string"
+  default     = "masters"
+  description = "Kops masters subdomain name in the cluster DNS zone"
+}
+
+variable "nodes_name" {
+  type        = "string"
+  default     = "nodes"
+  description = "Kops nodes subdomain name in the cluster DNS zone"
+}
+
+variable "stage" {
+  type        = "string"
+  description = "Stage (e.g. `prod`, `dev`, `staging`)"
+}


### PR DESCRIPTION
`WIP`

## what
* creating role to use for Kubecost pods (in pods annotations)

## why
* some functions of kubecost might require specific aws access