### PR TITLE
feat: updates EKS component to latest

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
       - id: check-yaml
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.45.0
+    rev: v1.48.0
     hooks:
       - id: terraform_fmt
       - id: terraform_docs

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@ export DOCKER_BUILD_FLAGS =
 export README_DEPS ?= docs/targets.md docs/terraform.md
 -include $(shell curl -sSL -o .build-harness "https://git.io/build-harness"; echo .build-harness)
 
+UPSTREAM_PATH := "NONE"
+COMPONENT    := "NONE"
+
 all: init deps build install run
 
 deps:
@@ -23,3 +26,17 @@ run:
 ## Rebuild README for all Terraform components
 rebuild-docs:
 	@pre-commit run --all-files terraform_docs
+
+# Upstream a given component
+# Requires:
+# UPSTREAM_PATH -- The relative or absolute path to the upstream project directory
+# COMPONENT     -- The name of the component to upstream into this repository
+upstream-component:
+	@test "$(UPSTREAM_PATH)" != "NONE" || { echo "Please set UPSTREAM_PATH"; exit 1; }
+	@test "$(COMPONENT)" != "NONE" || { echo "Please set COMPONENT"; exit 1; }
+
+	@cp -r $(UPSTREAM_PATH)/components/terraform/$(COMPONENT) ./modules/; \
+		test -f "./modules/$(COMPONENT)/backend.tf.json" && rm ./modules/$(COMPONENT)/backend.tf.json; \
+		test -d "./modules/$(COMPONENT)/.terraform" && rm -rf ./modules/$(COMPONENT)/.terraform; \
+		echo "Upstreamed ./modules/$(COMPONENT)";
+

--- a/modules/eks/README.md
+++ b/modules/eks/README.md
@@ -36,89 +36,158 @@ components:
             tags: null
 ```
 
+### Instance types
+When provisioning a pool of instances, usually it is not especially important exactly which kind you get. When paying spot prices, you can save a lot of money by being flexible about which ones you use, so if for some reason r5a.large is cheaper than r5.large you can get the r5a.large. To help you select which instances to use, Geodesic includes the [`ec2-instance-selector` tool](https://github.com/aws/amazon-ec2-instance-selector). See the documentation for details, but for example:
+```text
+ ⧉  Geodesic
+ √ . [example-gbl-identity] components ⨠ ec2-instance-selector --gpus 0 --vcpus-min 2 --vcpus-max 4 -a amd64 --flexible --memory-min 16 -u spot
+m4.xlarge
+m5.xlarge
+m5a.xlarge
+r3.xlarge
+r4.xlarge
+r5.large
+r5.xlarge
+r5a.large
+r5a.xlarge
+t2.xlarge
+t3.xlarge
+
+```
+
+You can plug that list into `instance_types` in the stack configuration. Keep in mind that the list may vary slightly from region to region, so be sure to run the command in the region the EKS cluster will be running.
+
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13 |
-| aws | >= 3.0 |
-| local | >= 1.3 |
-| template | >= 2.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.3 |
+| <a name="requirement_spotinst"></a> [spotinst](#requirement\_spotinst) | >= 1.30 |
+| <a name="requirement_template"></a> [template](#requirement\_template) | >= 2.0 |
+| <a name="requirement_utils"></a> [utils](#requirement\_utils) | >= 0.3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| terraform | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
+| <a name="provider_aws.spotinst_secrets"></a> [aws.spotinst\_secrets](#provider\_aws.spotinst\_secrets) | >= 3.0 |
+| <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_delegated_roles"></a> [delegated\_roles](#module\_delegated\_roles) | cloudposse/stack-config/yaml//modules/remote-state | 0.10.0 |
+| <a name="module_eks"></a> [eks](#module\_eks) | cloudposse/stack-config/yaml//modules/remote-state | 0.10.0 |
+| <a name="module_eks_cluster"></a> [eks\_cluster](#module\_eks\_cluster) | cloudposse/eks-cluster/aws | 0.34.1 |
+| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles |  |
+| <a name="module_primary_roles"></a> [primary\_roles](#module\_primary\_roles) | cloudposse/stack-config/yaml//modules/remote-state | 0.10.0 |
+| <a name="module_region_node_group"></a> [region\_node\_group](#module\_region\_node\_group) | ./modules/node_group_by_region |  |
+| <a name="module_spotinst_oceans"></a> [spotinst\_oceans](#module\_spotinst\_oceans) | cloudposse/eks-spotinst-ocean-nodepool/aws | 0.1.1 |
+| <a name="module_spotinst_role"></a> [spotinst\_role](#module\_spotinst\_role) | cloudposse/stack-config/yaml//modules/remote-state | 0.10.0 |
+| <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.24.1 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | cloudposse/stack-config/yaml//modules/remote-state | 0.10.0 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_iam_role_policy_attachment.cloudwatch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.ssm_core](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_arn.roles](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/arn) | data source |
+| [aws_iam_instance_profile.spotinst_worker](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_instance_profile) | data source |
+| [aws_ssm_parameter.spotinst_account](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
+| [aws_ssm_parameter.spotinst_token](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
+| [terraform_remote_state.delegated_roles](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
+| [terraform_remote_state.eks](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
+| [terraform_remote_state.primary_roles](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
+| [terraform_remote_state.vpc](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| additional\_tag\_map | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
-| allowed\_cidr\_blocks | List of CIDR blocks to be allowed to connect to the EKS cluster | `list(string)` | `[]` | no |
-| allowed\_security\_groups | List of Security Group IDs to be allowed to connect to the EKS cluster | `list(string)` | `[]` | no |
-| apply\_config\_map\_aws\_auth | Whether to execute `kubectl apply` to apply the ConfigMap to allow worker nodes to join the EKS cluster | `bool` | `true` | no |
-| attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
-| cluster\_endpoint\_private\_access | Indicates whether or not the Amazon EKS private API server endpoint is enabled. Default to AWS EKS resource and it is `false` | `bool` | `false` | no |
-| cluster\_endpoint\_public\_access | Indicates whether or not the Amazon EKS public API server endpoint is enabled. Default to AWS EKS resource and it is `true` | `bool` | `true` | no |
-| cluster\_kubernetes\_version | Desired Kubernetes master version. If you do not specify a value, the latest available version is used | `string` | `null` | no |
-| cluster\_log\_retention\_period | Number of days to retain cluster logs. Requires `enabled_cluster_log_types` to be set. See https://docs.aws.amazon.com/en_us/eks/latest/userguide/control-plane-logs.html. | `number` | `0` | no |
-| color | The cluster stage represented by a color; e.g. blue, green | `string` | `""` | no |
-| context | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | <pre>object({<br>    enabled             = bool<br>    namespace           = string<br>    environment         = string<br>    stage               = string<br>    name                = string<br>    delimiter           = string<br>    attributes          = list(string)<br>    tags                = map(string)<br>    additional_tag_map  = map(string)<br>    regex_replace_chars = string<br>    label_order         = list(string)<br>    id_length_limit     = number<br>  })</pre> | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_order": [],<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
-| delegated\_iam\_roles | Delegated IAM roles to add to `config-map-aws-auth` ConfigMap | <pre>list(object({<br>    role   = string<br>    groups = list(string)<br>  }))</pre> | `[]` | no |
-| delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
-| enable\_vpn\_access | Enable VPN access via the HAL VPN; see vpn project | `bool` | `false` | no |
-| enabled | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
-| enabled\_cluster\_log\_types | A list of the desired control plane logging to enable. For more information, see https://docs.aws.amazon.com/en_us/eks/latest/userguide/control-plane-logs.html. Possible values [`api`, `audit`, `authenticator`, `controllerManager`, `scheduler`] | `list(string)` | `[]` | no |
-| environment | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
-| iam\_primary\_roles\_stage\_name | The name of the stage where the IAM primary roles are provisioned | `string` | `"identity"` | no |
-| iam\_roles\_environment\_name | The name of the environment where the IAM roles are provisioned | `string` | `"gbl"` | no |
-| id\_length\_limit | Limit `id` to this many characters.<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
-| import\_role\_arn | IAM Role ARN to use when importing a resource | `string` | `null` | no |
-| label\_order | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
-| map\_additional\_aws\_accounts | Additional AWS account numbers to add to `config-map-aws-auth` ConfigMap | `list(string)` | `[]` | no |
-| map\_additional\_iam\_users | Additional IAM users to add to `config-map-aws-auth` ConfigMap | <pre>list(object({<br>    userarn  = string<br>    username = string<br>    groups   = list(string)<br>  }))</pre> | `[]` | no |
-| name | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
-| namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
-| node\_group\_defaults | Defaults for node groups in the cluster | <pre>object({<br>    availability_zones        = list(string) # set to null to use var.region_availability_zones<br>    attributes                = list(string)<br>    create_before_destroy     = bool<br>    desired_group_size        = number<br>    disk_size                 = number<br>    enable_cluster_autoscaler = bool<br>    instance_types            = list(string)<br>    ami_type                  = string<br>    ami_release_version       = string<br>    kubernetes_version        = string # set to null to use cluster_kubernetes_version<br>    kubernetes_labels         = map(string)<br>    kubernetes_taints         = map(string)<br>    max_group_size            = number<br>    min_group_size            = number<br>    resources_to_tag          = list(string)<br>    tags                      = map(string)<br>  })</pre> | n/a | yes |
-| node\_groups | List of objects defining a node group for the cluster | <pre>map(object({<br>    # will create 1 auto scaling group in each specified availability zone<br>    availability_zones = list(string)<br>    # Additional attributes (e.g. `1`) for the node group<br>    attributes = list(string)<br>    # True to create new node_groups before deleting old ones, avoiding a temporary outage<br>    create_before_destroy = bool<br>    # Desired number of worker nodes when initially provisioned<br>    desired_group_size = number<br>    # Disk size in GiB for worker nodes. Terraform will only perform drift detection if a configuration value is provided.<br>    disk_size = number<br>    # Whether to enable Node Group to scale its AutoScaling Group<br>    enable_cluster_autoscaler = bool<br>    # Set of instance types associated with the EKS Node Group. Terraform will only perform drift detection if a configuration value is provided.<br>    instance_types = list(string)<br>    # Type of Amazon Machine Image (AMI) associated with the EKS Node Group<br>    ami_type = string<br>    # EKS AMI version to use, e.g. "1.16.13-20200821" (no "v").<br>    ami_release_version = string<br>    # Key-value mapping of Kubernetes labels. Only labels that are applied with the EKS API are managed by this argument. Other Kubernetes labels applied to the EKS Node Group will not be managed<br>    kubernetes_labels = map(string)<br>    # Key-value mapping of Kubernetes taints.<br>    kubernetes_taints = map(string)<br>    # Desired Kubernetes master version. If you do not specify a value, the latest available version is used<br>    kubernetes_version = string<br>    # The maximum size of the AutoScaling Group<br>    max_group_size = number<br>    # The minimum size of the AutoScaling Group<br>    min_group_size = number<br>    # List of auto-launched resource types to tag<br>    resources_to_tag = list(string)<br>    tags             = map(string)<br>  }))</pre> | `null` | no |
-| oidc\_provider\_enabled | Create an IAM OIDC identity provider for the cluster, then you can create IAM roles to associate with a service account in the cluster, instead of using kiam or kube2iam. For more information, see https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html | `bool` | n/a | yes |
-| primary\_iam\_roles | Primary IAM roles to add to `config-map-aws-auth` ConfigMap | <pre>list(object({<br>    role   = string<br>    groups = list(string)<br>  }))</pre> | `[]` | no |
-| public\_access\_cidrs | Indicates which CIDR blocks can access the Amazon EKS public API server endpoint when enabled. EKS defaults this to a list with 0.0.0.0/0. | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
-| regex\_replace\_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
-| region | AWS Region | `string` | n/a | yes |
-| region\_availability\_zones | AWS Availability Zones in which to deploy multi-AZ resources | `list(string)` | n/a | yes |
-| stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
-| subnet\_type\_tag\_key | The tag used to find the private subnets to find by availability zone | `string` | n/a | yes |
-| tags | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
-| tfstate\_account\_id | The ID of the account where the Terraform remote state backend is provisioned | `string` | `""` | no |
-| tfstate\_assume\_role | Set to false to use the caller's role to access the Terraform remote state | `bool` | `true` | no |
-| tfstate\_bucket\_environment\_name | The name of the environment for Terraform state bucket | `string` | `""` | no |
-| tfstate\_bucket\_stage\_name | The name of the stage for Terraform state bucket | `string` | `"root"` | no |
-| tfstate\_existing\_role\_arn | The ARN of the existing IAM Role to access the Terraform remote state. If not provided and `remote_state_assume_role` is `true`, a role will be constructed from `remote_state_role_arn_template` | `string` | `""` | no |
-| tfstate\_role\_arn\_template | IAM Role ARN template for accessing the Terraform remote state | `string` | `"arn:aws:iam::%s:role/%s-%s-%s-%s"` | no |
-| tfstate\_role\_environment\_name | The name of the environment for Terraform state IAM role | `string` | `"gbl"` | no |
-| tfstate\_role\_name | IAM Role name for accessing the Terraform remote state | `string` | `"terraform"` | no |
-| tfstate\_role\_stage\_name | The name of the stage for Terraform state IAM role | `string` | `"root"` | no |
+| <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
+| <a name="input_allowed_cidr_blocks"></a> [allowed\_cidr\_blocks](#input\_allowed\_cidr\_blocks) | List of CIDR blocks to be allowed to connect to the EKS cluster | `list(string)` | `[]` | no |
+| <a name="input_allowed_security_groups"></a> [allowed\_security\_groups](#input\_allowed\_security\_groups) | List of Security Group IDs to be allowed to connect to the EKS cluster | `list(string)` | `[]` | no |
+| <a name="input_apply_config_map_aws_auth"></a> [apply\_config\_map\_aws\_auth](#input\_apply\_config\_map\_aws\_auth) | Whether to execute `kubectl apply` to apply the ConfigMap to allow worker nodes to join the EKS cluster | `bool` | `true` | no |
+| <a name="input_attributes"></a> [attributes](#input\_attributes) | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
+| <a name="input_aws_ssm_enabled"></a> [aws\_ssm\_enabled](#input\_aws\_ssm\_enabled) | Set true to install the AWS SSM agent on each EC2 instance | `bool` | `false` | no |
+| <a name="input_cluster_endpoint_private_access"></a> [cluster\_endpoint\_private\_access](#input\_cluster\_endpoint\_private\_access) | Indicates whether or not the Amazon EKS private API server endpoint is enabled. Default to AWS EKS resource and it is `false` | `bool` | `false` | no |
+| <a name="input_cluster_endpoint_public_access"></a> [cluster\_endpoint\_public\_access](#input\_cluster\_endpoint\_public\_access) | Indicates whether or not the Amazon EKS public API server endpoint is enabled. Default to AWS EKS resource and it is `true` | `bool` | `true` | no |
+| <a name="input_cluster_kubernetes_version"></a> [cluster\_kubernetes\_version](#input\_cluster\_kubernetes\_version) | Desired Kubernetes master version. If you do not specify a value, the latest available version is used | `string` | `null` | no |
+| <a name="input_cluster_log_retention_period"></a> [cluster\_log\_retention\_period](#input\_cluster\_log\_retention\_period) | Number of days to retain cluster logs. Requires `enabled_cluster_log_types` to be set. See https://docs.aws.amazon.com/en_us/eks/latest/userguide/control-plane-logs.html. | `number` | `0` | no |
+| <a name="input_color"></a> [color](#input\_color) | The cluster stage represented by a color; e.g. blue, green | `string` | `""` | no |
+| <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
+| <a name="input_delegated_iam_roles"></a> [delegated\_iam\_roles](#input\_delegated\_iam\_roles) | Delegated IAM roles to add to `aws-auth` ConfigMap | <pre>list(object({<br>    role   = string<br>    groups = list(string)<br>  }))</pre> | `[]` | no |
+| <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
+| <a name="input_enable_vpn_access"></a> [enable\_vpn\_access](#input\_enable\_vpn\_access) | Enable VPN access via the HAL VPN; see vpn project | `bool` | `false` | no |
+| <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
+| <a name="input_enabled_cluster_log_types"></a> [enabled\_cluster\_log\_types](#input\_enabled\_cluster\_log\_types) | A list of the desired control plane logging to enable. For more information, see https://docs.aws.amazon.com/en_us/eks/latest/userguide/control-plane-logs.html. Possible values [`api`, `audit`, `authenticator`, `controllerManager`, `scheduler`] | `list(string)` | `[]` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
+| <a name="input_iam_primary_roles_stage_name"></a> [iam\_primary\_roles\_stage\_name](#input\_iam\_primary\_roles\_stage\_name) | The name of the stage where the IAM primary roles are provisioned | `string` | `"identity"` | no |
+| <a name="input_iam_roles_environment_name"></a> [iam\_roles\_environment\_name](#input\_iam\_roles\_environment\_name) | The name of the environment where the IAM roles are provisioned | `string` | `"gbl"` | no |
+| <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
+| <a name="input_import_role_arn"></a> [import\_role\_arn](#input\_import\_role\_arn) | IAM Role ARN to use when importing a resource | `string` | `null` | no |
+| <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | The letter case of label keys (`tag` names) (i.e. `name`, `namespace`, `environment`, `stage`, `attributes`) to use in `tags`.<br>Possible values: `lower`, `title`, `upper`.<br>Default value: `title`. | `string` | `null` | no |
+| <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
+| <a name="input_label_value_case"></a> [label\_value\_case](#input\_label\_value\_case) | The letter case of output label values (also used in `tags` and `id`).<br>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br>Default value: `lower`. | `string` | `null` | no |
+| <a name="input_map_additional_aws_accounts"></a> [map\_additional\_aws\_accounts](#input\_map\_additional\_aws\_accounts) | Additional AWS account numbers to add to `aws-auth` ConfigMap | `list(string)` | `[]` | no |
+| <a name="input_map_additional_iam_users"></a> [map\_additional\_iam\_users](#input\_map\_additional\_iam\_users) | Additional IAM users to add to `aws-auth` ConfigMap | <pre>list(object({<br>    userarn  = string<br>    username = string<br>    groups   = list(string)<br>  }))</pre> | `[]` | no |
+| <a name="input_map_additional_worker_roles"></a> [map\_additional\_worker\_roles](#input\_map\_additional\_worker\_roles) | AWS IAM Role ARNs of worker nodes to add to `aws-auth` ConfigMap | `list(string)` | `[]` | no |
+| <a name="input_name"></a> [name](#input\_name) | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
+| <a name="input_node_group_defaults"></a> [node\_group\_defaults](#input\_node\_group\_defaults) | Defaults for node groups in the cluster | <pre>object({<br>    availability_zones         = list(string) # set to null to use var.region_availability_zones<br>    attributes                 = list(string)<br>    create_before_destroy      = bool<br>    desired_group_size         = number<br>    disk_size                  = number<br>    cluster_autoscaler_enabled = bool<br>    instance_types             = list(string)<br>    ami_type                   = string<br>    ami_release_version        = string<br>    kubernetes_version         = string # set to null to use cluster_kubernetes_version<br>    kubernetes_labels          = map(string)<br>    kubernetes_taints          = map(string)<br>    max_group_size             = number<br>    min_group_size             = number<br>    resources_to_tag           = list(string)<br>    tags                       = map(string)<br>  })</pre> | <pre>{<br>  "ami_release_version": null,<br>  "ami_type": null,<br>  "attributes": null,<br>  "availability_zones": null,<br>  "cluster_autoscaler_enabled": true,<br>  "create_before_destroy": true,<br>  "desired_group_size": 1,<br>  "disk_size": 20,<br>  "instance_types": [<br>    "t3.medium"<br>  ],<br>  "kubernetes_labels": null,<br>  "kubernetes_taints": null,<br>  "kubernetes_version": null,<br>  "max_group_size": 100,<br>  "min_group_size": null,<br>  "resources_to_tag": null,<br>  "tags": null<br>}</pre> | no |
+| <a name="input_node_groups"></a> [node\_groups](#input\_node\_groups) | List of objects defining a node group for the cluster | <pre>map(object({<br>    # will create 1 auto scaling group in each specified availability zone<br>    availability_zones = list(string)<br>    # Additional attributes (e.g. `1`) for the node group<br>    attributes = list(string)<br>    # True to create new node_groups before deleting old ones, avoiding a temporary outage<br>    create_before_destroy = bool<br>    # Desired number of worker nodes when initially provisioned<br>    desired_group_size = number<br>    # Disk size in GiB for worker nodes. Terraform will only perform drift detection if a configuration value is provided.<br>    disk_size = number<br>    # Whether to enable Node Group to scale its AutoScaling Group<br>    cluster_autoscaler_enabled = bool<br>    # Set of instance types associated with the EKS Node Group. Terraform will only perform drift detection if a configuration value is provided.<br>    instance_types = list(string)<br>    # Type of Amazon Machine Image (AMI) associated with the EKS Node Group<br>    ami_type = string<br>    # EKS AMI version to use, e.g. "1.16.13-20200821" (no "v").<br>    ami_release_version = string<br>    # Key-value mapping of Kubernetes labels. Only labels that are applied with the EKS API are managed by this argument. Other Kubernetes labels applied to the EKS Node Group will not be managed<br>    kubernetes_labels = map(string)<br>    # Key-value mapping of Kubernetes taints.<br>    kubernetes_taints = map(string)<br>    # Desired Kubernetes master version. If you do not specify a value, the latest available version is used<br>    kubernetes_version = string<br>    # The maximum size of the AutoScaling Group<br>    max_group_size = number<br>    # The minimum size of the AutoScaling Group<br>    min_group_size = number<br>    # List of auto-launched resource types to tag<br>    resources_to_tag = list(string)<br>    tags             = map(string)<br>  }))</pre> | `{}` | no |
+| <a name="input_oidc_provider_enabled"></a> [oidc\_provider\_enabled](#input\_oidc\_provider\_enabled) | Create an IAM OIDC identity provider for the cluster, then you can create IAM roles to associate with a service account in the cluster, instead of using kiam or kube2iam. For more information, see https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html | `bool` | n/a | yes |
+| <a name="input_primary_iam_roles"></a> [primary\_iam\_roles](#input\_primary\_iam\_roles) | Primary IAM roles to add to `aws-auth` ConfigMap | <pre>list(object({<br>    role   = string<br>    groups = list(string)<br>  }))</pre> | `[]` | no |
+| <a name="input_public_access_cidrs"></a> [public\_access\_cidrs](#input\_public\_access\_cidrs) | Indicates which CIDR blocks can access the Amazon EKS public API server endpoint when enabled. EKS defaults this to a list with 0.0.0.0/0. | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
+| <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
+| <a name="input_region"></a> [region](#input\_region) | AWS Region | `string` | n/a | yes |
+| <a name="input_region_availability_zones"></a> [region\_availability\_zones](#input\_region\_availability\_zones) | AWS Availability Zones in which to deploy multi-AZ resources | `list(string)` | n/a | yes |
+| <a name="input_spotinst_account_ssm_key"></a> [spotinst\_account\_ssm\_key](#input\_spotinst\_account\_ssm\_key) | SSM key for Spot account ID | `string` | `"/spotinst/spotinst_account"` | no |
+| <a name="input_spotinst_instance_profile_pattern"></a> [spotinst\_instance\_profile\_pattern](#input\_spotinst\_instance\_profile\_pattern) | Pattern for the name of the AWS Instance Profile to use for Spotinst Worker instances:<br>`format(spotinst_instance_profile_pattern, var.namespace, var.environment, var.stage)`<br>If empty or null, a new instance profile will be created. | `string` | `"%v-gbl-%[3]v-spotinst-worker"` | no |
+| <a name="input_spotinst_ocean_defaults"></a> [spotinst\_ocean\_defaults](#input\_spotinst\_ocean\_defaults) | Defaults for node groups in the cluster | <pre>object({<br>    attributes          = list(string)<br>    desired_group_size  = number<br>    disk_size           = number<br>    instance_types      = list(string)<br>    ami_type            = string<br>    ami_release_version = string<br>    kubernetes_version  = string # set to null to use cluster_kubernetes_version<br>    max_group_size      = number<br>    min_group_size      = number<br>    tags                = map(string)<br>  })</pre> | <pre>{<br>  "ami_release_version": null,<br>  "ami_type": "AL2_x86_64",<br>  "attributes": [],<br>  "desired_group_size": 1,<br>  "disk_size": 20,<br>  "instance_types": null,<br>  "kubernetes_version": null,<br>  "max_group_size": 100,<br>  "min_group_size": null,<br>  "tags": {}<br>}</pre> | no |
+| <a name="input_spotinst_oceans"></a> [spotinst\_oceans](#input\_spotinst\_oceans) | List of objects defining a Spotinst Ocean for the cluster | <pre>map(object({<br>    # Additional attributes (e.g. `1`) for the ocean<br>    attributes         = list(string)<br>    desired_group_size = number<br>    # Disk size in GiB for worker nodes. Terraform will only perform drift detection if a configuration value is provided.<br>    disk_size = number<br>    # List of allowed instance types. Leave null to allow Spot to choose any type.<br>    instance_types = list(string)<br>    # Type of Amazon Machine Image (AMI) associated with the EKS Node Group<br>    ami_type = string<br>    # EKS AMI version to use, e.g. "1.16.13-20200821" (no "v").<br>    ami_release_version = string<br>    # Desired Kubernetes master version. If you do not specify a value, the cluster version is used<br>    kubernetes_version = string # set to null to use cluster_kubernetes_version<br>    max_group_size     = number<br>    min_group_size     = number<br>    tags               = map(string)<br>  }))</pre> | `{}` | no |
+| <a name="input_spotinst_secrets_region"></a> [spotinst\_secrets\_region](#input\_spotinst\_secrets\_region) | The region to retrieve the spotinst secrets from | `string` | `"us-west-2"` | no |
+| <a name="input_spotinst_token_ssm_key"></a> [spotinst\_token\_ssm\_key](#input\_spotinst\_token\_ssm\_key) | SSM key for Spot Personal Access token | `string` | `"/spotinst/spotinst_token"` | no |
+| <a name="input_ssm_installer"></a> [ssm\_installer](#input\_ssm\_installer) | Command to install AWS SSM agent on EC2 instance | `string` | `"yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpmn"` | no |
+| <a name="input_stage"></a> [stage](#input\_stage) | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
+| <a name="input_subnet_type_tag_key"></a> [subnet\_type\_tag\_key](#input\_subnet\_type\_tag\_key) | The tag used to find the private subnets to find by availability zone. If null, will be looked up in vpc outputs. | `string` | `null` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
+| <a name="input_tfstate_account_id"></a> [tfstate\_account\_id](#input\_tfstate\_account\_id) | The ID of the account where the Terraform remote state backend is provisioned | `string` | `""` | no |
+| <a name="input_tfstate_assume_role"></a> [tfstate\_assume\_role](#input\_tfstate\_assume\_role) | Set to false to use the caller's role to access the Terraform remote state | `bool` | `true` | no |
+| <a name="input_tfstate_bucket_environment_name"></a> [tfstate\_bucket\_environment\_name](#input\_tfstate\_bucket\_environment\_name) | The name of the environment for Terraform state bucket | `string` | `""` | no |
+| <a name="input_tfstate_bucket_stage_name"></a> [tfstate\_bucket\_stage\_name](#input\_tfstate\_bucket\_stage\_name) | The name of the stage for Terraform state bucket | `string` | `"root"` | no |
+| <a name="input_tfstate_existing_role_arn"></a> [tfstate\_existing\_role\_arn](#input\_tfstate\_existing\_role\_arn) | The ARN of the existing IAM Role to access the Terraform remote state. If not provided and `remote_state_assume_role` is `true`, a role will be constructed from `remote_state_role_arn_template` | `string` | `""` | no |
+| <a name="input_tfstate_role_arn_template"></a> [tfstate\_role\_arn\_template](#input\_tfstate\_role\_arn\_template) | IAM Role ARN template for accessing the Terraform remote state | `string` | `"arn:aws:iam::%s:role/%s-%s-%s-%s"` | no |
+| <a name="input_tfstate_role_environment_name"></a> [tfstate\_role\_environment\_name](#input\_tfstate\_role\_environment\_name) | The name of the environment for Terraform state IAM role | `string` | `"gbl"` | no |
+| <a name="input_tfstate_role_name"></a> [tfstate\_role\_name](#input\_tfstate\_role\_name) | IAM Role name for accessing the Terraform remote state | `string` | `"terraform"` | no |
+| <a name="input_tfstate_role_stage_name"></a> [tfstate\_role\_stage\_name](#input\_tfstate\_role\_stage\_name) | The name of the stage for Terraform state IAM role | `string` | `"root"` | no |
+| <a name="input_update_policy_batch_size_percentage"></a> [update\_policy\_batch\_size\_percentage](#input\_update\_policy\_batch\_size\_percentage) | When rolling the cluster due to an update, the percentage of the instances to deploy in each batch. | `number` | `25` | no |
+| <a name="input_update_policy_should_roll"></a> [update\_policy\_should\_roll](#input\_update\_policy\_should\_roll) | If true, roll the cluster when its configuration is updated | `bool` | `true` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| eks\_cluster\_arn | The Amazon Resource Name (ARN) of the cluster |
-| eks\_cluster\_endpoint | The endpoint for the Kubernetes API server |
-| eks\_cluster\_id | The name of the cluster |
-| eks\_cluster\_identity\_oidc\_issuer | The OIDC Identity issuer for the cluster |
-| eks\_cluster\_managed\_security\_group\_id | Security Group ID that was created by EKS for the cluster. EKS creates a Security Group and applies it to ENI that is attached to EKS Control Plane master nodes and to any managed workloads |
-| eks\_cluster\_version | The Kubernetes server version of the cluster |
-| eks\_managed\_node\_workers\_role\_arns | List of ARNs for workers in managed node groups |
-| eks\_node\_group\_arns | ARN of the worker nodes IAM role |
-| eks\_node\_group\_count | Count of the worker nodes |
-| eks\_node\_group\_ids | EKS Cluster name and EKS Node Group name separated by a colon |
-| eks\_node\_group\_role\_names | Name of the worker nodes IAM role |
-
+| <a name="output_eks_auth_worker_roles"></a> [eks\_auth\_worker\_roles](#output\_eks\_auth\_worker\_roles) | List of worker IAM roles that were included in the `auth-map` ConfigMap. |
+| <a name="output_eks_cluster_arn"></a> [eks\_cluster\_arn](#output\_eks\_cluster\_arn) | The Amazon Resource Name (ARN) of the cluster |
+| <a name="output_eks_cluster_endpoint"></a> [eks\_cluster\_endpoint](#output\_eks\_cluster\_endpoint) | The endpoint for the Kubernetes API server |
+| <a name="output_eks_cluster_id"></a> [eks\_cluster\_id](#output\_eks\_cluster\_id) | The name of the cluster |
+| <a name="output_eks_cluster_identity_oidc_issuer"></a> [eks\_cluster\_identity\_oidc\_issuer](#output\_eks\_cluster\_identity\_oidc\_issuer) | The OIDC Identity issuer for the cluster |
+| <a name="output_eks_cluster_managed_security_group_id"></a> [eks\_cluster\_managed\_security\_group\_id](#output\_eks\_cluster\_managed\_security\_group\_id) | Security Group ID that was created by EKS for the cluster. EKS creates a Security Group and applies it to ENI that is attached to EKS Control Plane master nodes and to any managed workloads |
+| <a name="output_eks_cluster_version"></a> [eks\_cluster\_version](#output\_eks\_cluster\_version) | The Kubernetes server version of the cluster |
+| <a name="output_eks_managed_node_workers_role_arns"></a> [eks\_managed\_node\_workers\_role\_arns](#output\_eks\_managed\_node\_workers\_role\_arns) | List of ARNs for workers in managed node groups |
+| <a name="output_eks_node_group_arns"></a> [eks\_node\_group\_arns](#output\_eks\_node\_group\_arns) | ARN of the worker nodes IAM role |
+| <a name="output_eks_node_group_count"></a> [eks\_node\_group\_count](#output\_eks\_node\_group\_count) | Count of the worker nodes |
+| <a name="output_eks_node_group_ids"></a> [eks\_node\_group\_ids](#output\_eks\_node\_group\_ids) | EKS Cluster name and EKS Node Group name separated by a colon |
+| <a name="output_eks_node_group_role_names"></a> [eks\_node\_group\_role\_names](#output\_eks\_node\_group\_role\_names) | Name of the worker nodes IAM role |
+| <a name="output_eks_spotinst_ocean_controller_ids"></a> [eks\_spotinst\_ocean\_controller\_ids](#output\_eks\_spotinst\_ocean\_controller\_ids) | The ID of the Ocean controller |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 

--- a/modules/eks/README.md
+++ b/modules/eks/README.md
@@ -1,6 +1,6 @@
 # Component: `eks`
 
-This component is responsible for provisioning an end-to-end EKS Cluster, including managed node groups and [spotinst ocean](https://spot.io/products/ocean/) node pools.
+This component is responsible for provisioning an end-to-end EKS Cluster, including managed node groups.
 
 ## Usage
 
@@ -15,82 +15,75 @@ components:
       vars:
         cluster_kubernetes_version: "1.19"
         region_availability_zones: ["us-east-1b", "us-east-1c", "us-east-1d"]
-        spotinst_instance_profile: example-gbl-dev-spotinst-worker
-        map_additional_worker_roles: ["arn:aws:iam::xxxxxxxxxx:role/example-ue1-dev-spotinst-worker"]
         public_access_cidrs: ["72.107.0.0/24"]
-        spotinst_oceans:
-          main: &standard_node_group
-            desired_group_size: 1
-            max_group_size: 10
-            min_group_size: 1
+        managed_node_groups_enabled: true
+        node_groups: # null means use default set in defaults.auto.tf.vars
+          main:
+            # values of `null` will be replaced with default values
+            # availability_zones = null will create 1 auto scaling group in
+            # each availability zone in region_availability_zones
+            availability_zones: null
+
+            desired_group_size: 3 # number of instances to start with, must be >= number of AZs
+            min_group_size: 3 # must be  >= number of AZs
+            max_group_size: 6
 
             # Can only set one of ami_release_version or kubernetes_version
             # Leave both null to use latest AMI for Cluster Kubernetes version
-            kubernetes_version: null   # use cluster Kubernetes version
-            ami_release_version: null  # use latest AMI for Kubernetes version
+            kubernetes_version: null # use cluster Kubernetes version
+            ami_release_version: null # use latest AMI for Kubernetes version
 
-            attributes: null
+            attributes: []
+            create_before_destroy: true
             disk_size: 100
-            instance_types: null
-            ami_type: null # use "AL2_x86_64" for standard instances, "AL2_x86_64_GPU" for GPU instances
+            cluster_autoscaler_enabled: true
+            instance_types:
+              - t3.medium
+            ami_type: AL2_x86_64 # use "AL2_x86_64" for standard instances, "AL2_x86_64_GPU" for GPU instances
+            kubernetes_labels: {}
+            kubernetes_taints: {}
+            resources_to_tag:
+              - instance
+              - volume
             tags: null
 ```
-
-### Instance types
-When provisioning a pool of instances, usually it is not especially important exactly which kind you get. When paying spot prices, you can save a lot of money by being flexible about which ones you use, so if for some reason r5a.large is cheaper than r5.large you can get the r5a.large. To help you select which instances to use, Geodesic includes the [`ec2-instance-selector` tool](https://github.com/aws/amazon-ec2-instance-selector). See the documentation for details, but for example:
-```text
- ⧉  Geodesic
- √ . [example-gbl-identity] components ⨠ ec2-instance-selector --gpus 0 --vcpus-min 2 --vcpus-max 4 -a amd64 --flexible --memory-min 16 -u spot
-m4.xlarge
-m5.xlarge
-m5a.xlarge
-r3.xlarge
-r4.xlarge
-r5.large
-r5.xlarge
-r5a.large
-r5a.xlarge
-t2.xlarge
-t3.xlarge
-
-```
-
-You can plug that list into `instance_types` in the stack configuration. Keep in mind that the list may vary slightly from region to region, so be sure to run the command in the region the EKS cluster will be running.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
-| <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.3 |
-| <a name="requirement_spotinst"></a> [spotinst](#requirement\_spotinst) | >= 1.30 |
-| <a name="requirement_template"></a> [template](#requirement\_template) | >= 2.0 |
-| <a name="requirement_utils"></a> [utils](#requirement\_utils) | >= 0.3.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 0.14 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.32 |
+| <a name="requirement_external"></a> [external](#requirement\_external) | ~> 2.1 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 1.13 |
+| <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.1 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.1 |
+| <a name="requirement_template"></a> [template](#requirement\_template) | ~> 2.2 |
+| <a name="requirement_utils"></a> [utils](#requirement\_utils) | ~> 0.3 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
-| <a name="provider_aws.spotinst_secrets"></a> [aws.spotinst\_secrets](#provider\_aws.spotinst\_secrets) | >= 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.32 |
+| <a name="provider_external"></a> [external](#provider\_external) | ~> 2.1 |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_delegated_roles"></a> [delegated\_roles](#module\_delegated\_roles) | cloudposse/stack-config/yaml//modules/remote-state | 0.10.0 |
-| <a name="module_eks"></a> [eks](#module\_eks) | cloudposse/stack-config/yaml//modules/remote-state | 0.10.0 |
-| <a name="module_eks_cluster"></a> [eks\_cluster](#module\_eks\_cluster) | cloudposse/eks-cluster/aws | 0.34.1 |
+| <a name="module_delegated_roles"></a> [delegated\_roles](#module\_delegated\_roles) | cloudposse/stack-config/yaml//modules/remote-state | 0.13.0 |
+| <a name="module_eks"></a> [eks](#module\_eks) | cloudposse/stack-config/yaml//modules/remote-state | 0.13.0 |
+| <a name="module_eks_cluster"></a> [eks\_cluster](#module\_eks\_cluster) | cloudposse/eks-cluster/aws | 0.37.0 |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles |  |
-| <a name="module_primary_roles"></a> [primary\_roles](#module\_primary\_roles) | cloudposse/stack-config/yaml//modules/remote-state | 0.10.0 |
+| <a name="module_primary_roles"></a> [primary\_roles](#module\_primary\_roles) | cloudposse/stack-config/yaml//modules/remote-state | 0.13.0 |
 | <a name="module_region_node_group"></a> [region\_node\_group](#module\_region\_node\_group) | ./modules/node_group_by_region |  |
-| <a name="module_spotinst_oceans"></a> [spotinst\_oceans](#module\_spotinst\_oceans) | cloudposse/eks-spotinst-ocean-nodepool/aws | 0.1.1 |
-| <a name="module_spotinst_role"></a> [spotinst\_role](#module\_spotinst\_role) | cloudposse/stack-config/yaml//modules/remote-state | 0.10.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.24.1 |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | cloudposse/stack-config/yaml//modules/remote-state | 0.10.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | cloudposse/stack-config/yaml//modules/remote-state | 0.13.0 |
+| <a name="module_workers_role"></a> [workers\_role](#module\_workers\_role) | cloudposse/stack-config/yaml//modules/remote-state | 0.13.0 |
 
 ## Resources
 
@@ -99,9 +92,8 @@ You can plug that list into `instance_types` in the stack configuration. Keep in
 | [aws_iam_role_policy_attachment.cloudwatch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.ssm_core](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_arn.roles](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/arn) | data source |
-| [aws_iam_instance_profile.spotinst_worker](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_instance_profile) | data source |
-| [aws_ssm_parameter.spotinst_account](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
-| [aws_ssm_parameter.spotinst_token](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [external_external.awscli](https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/external) | data source |
 | [terraform_remote_state.delegated_roles](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 | [terraform_remote_state.eks](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 | [terraform_remote_state.primary_roles](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
@@ -116,13 +108,19 @@ You can plug that list into `instance_types` in the stack configuration. Keep in
 | <a name="input_allowed_security_groups"></a> [allowed\_security\_groups](#input\_allowed\_security\_groups) | List of Security Group IDs to be allowed to connect to the EKS cluster | `list(string)` | `[]` | no |
 | <a name="input_apply_config_map_aws_auth"></a> [apply\_config\_map\_aws\_auth](#input\_apply\_config\_map\_aws\_auth) | Whether to execute `kubectl apply` to apply the ConfigMap to allow worker nodes to join the EKS cluster | `bool` | `true` | no |
 | <a name="input_attributes"></a> [attributes](#input\_attributes) | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
-| <a name="input_aws_ssm_enabled"></a> [aws\_ssm\_enabled](#input\_aws\_ssm\_enabled) | Set true to install the AWS SSM agent on each EC2 instance | `bool` | `false` | no |
+| <a name="input_availability_zone_abbreviation_type"></a> [availability\_zone\_abbreviation\_type](#input\_availability\_zone\_abbreviation\_type) | Type of Availability Zone abbreviation (either `fixed` or `short`) to use in names. See https://github.com/cloudposse/terraform-aws-utils for details. | `string` | `"fixed"` | no |
+| <a name="input_cluster_encryption_config_enabled"></a> [cluster\_encryption\_config\_enabled](#input\_cluster\_encryption\_config\_enabled) | Set to `true` to enable Cluster Encryption Configuration | `bool` | `false` | no |
+| <a name="input_cluster_encryption_config_kms_key_deletion_window_in_days"></a> [cluster\_encryption\_config\_kms\_key\_deletion\_window\_in\_days](#input\_cluster\_encryption\_config\_kms\_key\_deletion\_window\_in\_days) | Cluster Encryption Config KMS Key Resource argument - key deletion windows in days post destruction | `number` | `10` | no |
+| <a name="input_cluster_encryption_config_kms_key_enable_key_rotation"></a> [cluster\_encryption\_config\_kms\_key\_enable\_key\_rotation](#input\_cluster\_encryption\_config\_kms\_key\_enable\_key\_rotation) | Cluster Encryption Config KMS Key Resource argument - enable kms key rotation | `bool` | `true` | no |
+| <a name="input_cluster_encryption_config_kms_key_id"></a> [cluster\_encryption\_config\_kms\_key\_id](#input\_cluster\_encryption\_config\_kms\_key\_id) | Specify KMS Key Id ARN to use for cluster encryption config | `string` | `""` | no |
+| <a name="input_cluster_encryption_config_kms_key_policy"></a> [cluster\_encryption\_config\_kms\_key\_policy](#input\_cluster\_encryption\_config\_kms\_key\_policy) | Cluster Encryption Config KMS Key Resource argument - key policy | `string` | `null` | no |
+| <a name="input_cluster_encryption_config_resources"></a> [cluster\_encryption\_config\_resources](#input\_cluster\_encryption\_config\_resources) | Cluster Encryption Config Resources to encrypt, e.g. ['secrets'] | `list(any)` | <pre>[<br>  "secrets"<br>]</pre> | no |
 | <a name="input_cluster_endpoint_private_access"></a> [cluster\_endpoint\_private\_access](#input\_cluster\_endpoint\_private\_access) | Indicates whether or not the Amazon EKS private API server endpoint is enabled. Default to AWS EKS resource and it is `false` | `bool` | `false` | no |
 | <a name="input_cluster_endpoint_public_access"></a> [cluster\_endpoint\_public\_access](#input\_cluster\_endpoint\_public\_access) | Indicates whether or not the Amazon EKS public API server endpoint is enabled. Default to AWS EKS resource and it is `true` | `bool` | `true` | no |
 | <a name="input_cluster_kubernetes_version"></a> [cluster\_kubernetes\_version](#input\_cluster\_kubernetes\_version) | Desired Kubernetes master version. If you do not specify a value, the latest available version is used | `string` | `null` | no |
 | <a name="input_cluster_log_retention_period"></a> [cluster\_log\_retention\_period](#input\_cluster\_log\_retention\_period) | Number of days to retain cluster logs. Requires `enabled_cluster_log_types` to be set. See https://docs.aws.amazon.com/en_us/eks/latest/userguide/control-plane-logs.html. | `number` | `0` | no |
 | <a name="input_color"></a> [color](#input\_color) | The cluster stage represented by a color; e.g. blue, green | `string` | `""` | no |
-| <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
+| <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | <pre>object({<br>    enabled             = bool<br>    namespace           = string<br>    environment         = string<br>    stage               = string<br>    name                = string<br>    delimiter           = string<br>    attributes          = list(string)<br>    tags                = map(string)<br>    additional_tag_map  = map(string)<br>    regex_replace_chars = string<br>    label_order         = list(string)<br>    id_length_limit     = number<br>  })</pre> | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_order": [],<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
 | <a name="input_delegated_iam_roles"></a> [delegated\_iam\_roles](#input\_delegated\_iam\_roles) | Delegated IAM roles to add to `aws-auth` ConfigMap | <pre>list(object({<br>    role   = string<br>    groups = list(string)<br>  }))</pre> | `[]` | no |
 | <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
 | <a name="input_enable_vpn_access"></a> [enable\_vpn\_access](#input\_enable\_vpn\_access) | Enable VPN access via the HAL VPN; see vpn project | `bool` | `false` | no |
@@ -131,31 +129,23 @@ You can plug that list into `instance_types` in the stack configuration. Keep in
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | <a name="input_iam_primary_roles_stage_name"></a> [iam\_primary\_roles\_stage\_name](#input\_iam\_primary\_roles\_stage\_name) | The name of the stage where the IAM primary roles are provisioned | `string` | `"identity"` | no |
 | <a name="input_iam_roles_environment_name"></a> [iam\_roles\_environment\_name](#input\_iam\_roles\_environment\_name) | The name of the environment where the IAM roles are provisioned | `string` | `"gbl"` | no |
-| <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
+| <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters.<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
 | <a name="input_import_role_arn"></a> [import\_role\_arn](#input\_import\_role\_arn) | IAM Role ARN to use when importing a resource | `string` | `null` | no |
-| <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | The letter case of label keys (`tag` names) (i.e. `name`, `namespace`, `environment`, `stage`, `attributes`) to use in `tags`.<br>Possible values: `lower`, `title`, `upper`.<br>Default value: `title`. | `string` | `null` | no |
 | <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
-| <a name="input_label_value_case"></a> [label\_value\_case](#input\_label\_value\_case) | The letter case of output label values (also used in `tags` and `id`).<br>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br>Default value: `lower`. | `string` | `null` | no |
+| <a name="input_managed_node_groups_enabled"></a> [managed\_node\_groups\_enabled](#input\_managed\_node\_groups\_enabled) | Set false to prevent the creation of EKS managed node groups. | `bool` | `true` | no |
 | <a name="input_map_additional_aws_accounts"></a> [map\_additional\_aws\_accounts](#input\_map\_additional\_aws\_accounts) | Additional AWS account numbers to add to `aws-auth` ConfigMap | `list(string)` | `[]` | no |
 | <a name="input_map_additional_iam_users"></a> [map\_additional\_iam\_users](#input\_map\_additional\_iam\_users) | Additional IAM users to add to `aws-auth` ConfigMap | <pre>list(object({<br>    userarn  = string<br>    username = string<br>    groups   = list(string)<br>  }))</pre> | `[]` | no |
 | <a name="input_map_additional_worker_roles"></a> [map\_additional\_worker\_roles](#input\_map\_additional\_worker\_roles) | AWS IAM Role ARNs of worker nodes to add to `aws-auth` ConfigMap | `list(string)` | `[]` | no |
 | <a name="input_name"></a> [name](#input\_name) | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
-| <a name="input_node_group_defaults"></a> [node\_group\_defaults](#input\_node\_group\_defaults) | Defaults for node groups in the cluster | <pre>object({<br>    availability_zones         = list(string) # set to null to use var.region_availability_zones<br>    attributes                 = list(string)<br>    create_before_destroy      = bool<br>    desired_group_size         = number<br>    disk_size                  = number<br>    cluster_autoscaler_enabled = bool<br>    instance_types             = list(string)<br>    ami_type                   = string<br>    ami_release_version        = string<br>    kubernetes_version         = string # set to null to use cluster_kubernetes_version<br>    kubernetes_labels          = map(string)<br>    kubernetes_taints          = map(string)<br>    max_group_size             = number<br>    min_group_size             = number<br>    resources_to_tag           = list(string)<br>    tags                       = map(string)<br>  })</pre> | <pre>{<br>  "ami_release_version": null,<br>  "ami_type": null,<br>  "attributes": null,<br>  "availability_zones": null,<br>  "cluster_autoscaler_enabled": true,<br>  "create_before_destroy": true,<br>  "desired_group_size": 1,<br>  "disk_size": 20,<br>  "instance_types": [<br>    "t3.medium"<br>  ],<br>  "kubernetes_labels": null,<br>  "kubernetes_taints": null,<br>  "kubernetes_version": null,<br>  "max_group_size": 100,<br>  "min_group_size": null,<br>  "resources_to_tag": null,<br>  "tags": null<br>}</pre> | no |
-| <a name="input_node_groups"></a> [node\_groups](#input\_node\_groups) | List of objects defining a node group for the cluster | <pre>map(object({<br>    # will create 1 auto scaling group in each specified availability zone<br>    availability_zones = list(string)<br>    # Additional attributes (e.g. `1`) for the node group<br>    attributes = list(string)<br>    # True to create new node_groups before deleting old ones, avoiding a temporary outage<br>    create_before_destroy = bool<br>    # Desired number of worker nodes when initially provisioned<br>    desired_group_size = number<br>    # Disk size in GiB for worker nodes. Terraform will only perform drift detection if a configuration value is provided.<br>    disk_size = number<br>    # Whether to enable Node Group to scale its AutoScaling Group<br>    cluster_autoscaler_enabled = bool<br>    # Set of instance types associated with the EKS Node Group. Terraform will only perform drift detection if a configuration value is provided.<br>    instance_types = list(string)<br>    # Type of Amazon Machine Image (AMI) associated with the EKS Node Group<br>    ami_type = string<br>    # EKS AMI version to use, e.g. "1.16.13-20200821" (no "v").<br>    ami_release_version = string<br>    # Key-value mapping of Kubernetes labels. Only labels that are applied with the EKS API are managed by this argument. Other Kubernetes labels applied to the EKS Node Group will not be managed<br>    kubernetes_labels = map(string)<br>    # Key-value mapping of Kubernetes taints.<br>    kubernetes_taints = map(string)<br>    # Desired Kubernetes master version. If you do not specify a value, the latest available version is used<br>    kubernetes_version = string<br>    # The maximum size of the AutoScaling Group<br>    max_group_size = number<br>    # The minimum size of the AutoScaling Group<br>    min_group_size = number<br>    # List of auto-launched resource types to tag<br>    resources_to_tag = list(string)<br>    tags             = map(string)<br>  }))</pre> | `{}` | no |
+| <a name="input_node_group_defaults"></a> [node\_group\_defaults](#input\_node\_group\_defaults) | Defaults for node groups in the cluster | <pre>object({<br>    ami_release_version        = string<br>    ami_type                   = string<br>    attributes                 = list(string)<br>    availability_zones         = list(string) # set to null to use var.region_availability_zones<br>    cluster_autoscaler_enabled = bool<br>    create_before_destroy      = bool<br>    desired_group_size         = number<br>    disk_encryption_enabled    = bool<br>    disk_size                  = number<br>    instance_types             = list(string)<br>    kubernetes_labels          = map(string)<br>    kubernetes_taints          = map(string)<br>    kubernetes_version         = string # set to null to use cluster_kubernetes_version<br>    max_group_size             = number<br>    min_group_size             = number<br>    resources_to_tag           = list(string)<br>    tags                       = map(string)<br>  })</pre> | <pre>{<br>  "ami_release_version": null,<br>  "ami_type": null,<br>  "attributes": null,<br>  "availability_zones": null,<br>  "cluster_autoscaler_enabled": true,<br>  "create_before_destroy": true,<br>  "desired_group_size": 1,<br>  "disk_encryption_enabled": true,<br>  "disk_size": 20,<br>  "instance_types": [<br>    "t3.medium"<br>  ],<br>  "kubernetes_labels": null,<br>  "kubernetes_taints": null,<br>  "kubernetes_version": null,<br>  "max_group_size": 100,<br>  "min_group_size": null,<br>  "resources_to_tag": null,<br>  "tags": null<br>}</pre> | no |
+| <a name="input_node_groups"></a> [node\_groups](#input\_node\_groups) | List of objects defining a node group for the cluster | <pre>map(object({<br>    # EKS AMI version to use, e.g. "1.16.13-20200821" (no "v").<br>    ami_release_version = string<br>    # Type of Amazon Machine Image (AMI) associated with the EKS Node Group<br>    ami_type = string<br>    # Additional attributes (e.g. `1`) for the node group<br>    attributes = list(string)<br>    # will create 1 auto scaling group in each specified availability zone<br>    availability_zones = list(string)<br>    # Whether to enable Node Group to scale its AutoScaling Group<br>    cluster_autoscaler_enabled = bool<br>    # True to create new node_groups before deleting old ones, avoiding a temporary outage<br>    create_before_destroy = bool<br>    # Desired number of worker nodes when initially provisioned<br>    desired_group_size = number<br>    # Enable disk encryption for the created launch template (if we aren't provided with an existing launch template)<br>    disk_encryption_enabled = bool<br>    # Disk size in GiB for worker nodes. Terraform will only perform drift detection if a configuration value is provided.<br>    disk_size = number<br>    # Set of instance types associated with the EKS Node Group. Terraform will only perform drift detection if a configuration value is provided.<br>    instance_types = list(string)<br>    # Key-value mapping of Kubernetes labels. Only labels that are applied with the EKS API are managed by this argument. Other Kubernetes labels applied to the EKS Node Group will not be managed<br>    kubernetes_labels = map(string)<br>    # Key-value mapping of Kubernetes taints.<br>    kubernetes_taints = map(string)<br>    # Desired Kubernetes master version. If you do not specify a value, the latest available version is used<br>    kubernetes_version = string<br>    # The maximum size of the AutoScaling Group<br>    max_group_size = number<br>    # The minimum size of the AutoScaling Group<br>    min_group_size = number<br>    # List of auto-launched resource types to tag<br>    resources_to_tag = list(string)<br>    tags             = map(string)<br>  }))</pre> | `{}` | no |
 | <a name="input_oidc_provider_enabled"></a> [oidc\_provider\_enabled](#input\_oidc\_provider\_enabled) | Create an IAM OIDC identity provider for the cluster, then you can create IAM roles to associate with a service account in the cluster, instead of using kiam or kube2iam. For more information, see https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html | `bool` | n/a | yes |
 | <a name="input_primary_iam_roles"></a> [primary\_iam\_roles](#input\_primary\_iam\_roles) | Primary IAM roles to add to `aws-auth` ConfigMap | <pre>list(object({<br>    role   = string<br>    groups = list(string)<br>  }))</pre> | `[]` | no |
 | <a name="input_public_access_cidrs"></a> [public\_access\_cidrs](#input\_public\_access\_cidrs) | Indicates which CIDR blocks can access the Amazon EKS public API server endpoint when enabled. EKS defaults this to a list with 0.0.0.0/0. | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
 | <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS Region | `string` | n/a | yes |
 | <a name="input_region_availability_zones"></a> [region\_availability\_zones](#input\_region\_availability\_zones) | AWS Availability Zones in which to deploy multi-AZ resources | `list(string)` | n/a | yes |
-| <a name="input_spotinst_account_ssm_key"></a> [spotinst\_account\_ssm\_key](#input\_spotinst\_account\_ssm\_key) | SSM key for Spot account ID | `string` | `"/spotinst/spotinst_account"` | no |
-| <a name="input_spotinst_instance_profile_pattern"></a> [spotinst\_instance\_profile\_pattern](#input\_spotinst\_instance\_profile\_pattern) | Pattern for the name of the AWS Instance Profile to use for Spotinst Worker instances:<br>`format(spotinst_instance_profile_pattern, var.namespace, var.environment, var.stage)`<br>If empty or null, a new instance profile will be created. | `string` | `"%v-gbl-%[3]v-spotinst-worker"` | no |
-| <a name="input_spotinst_ocean_defaults"></a> [spotinst\_ocean\_defaults](#input\_spotinst\_ocean\_defaults) | Defaults for node groups in the cluster | <pre>object({<br>    attributes          = list(string)<br>    desired_group_size  = number<br>    disk_size           = number<br>    instance_types      = list(string)<br>    ami_type            = string<br>    ami_release_version = string<br>    kubernetes_version  = string # set to null to use cluster_kubernetes_version<br>    max_group_size      = number<br>    min_group_size      = number<br>    tags                = map(string)<br>  })</pre> | <pre>{<br>  "ami_release_version": null,<br>  "ami_type": "AL2_x86_64",<br>  "attributes": [],<br>  "desired_group_size": 1,<br>  "disk_size": 20,<br>  "instance_types": null,<br>  "kubernetes_version": null,<br>  "max_group_size": 100,<br>  "min_group_size": null,<br>  "tags": {}<br>}</pre> | no |
-| <a name="input_spotinst_oceans"></a> [spotinst\_oceans](#input\_spotinst\_oceans) | List of objects defining a Spotinst Ocean for the cluster | <pre>map(object({<br>    # Additional attributes (e.g. `1`) for the ocean<br>    attributes         = list(string)<br>    desired_group_size = number<br>    # Disk size in GiB for worker nodes. Terraform will only perform drift detection if a configuration value is provided.<br>    disk_size = number<br>    # List of allowed instance types. Leave null to allow Spot to choose any type.<br>    instance_types = list(string)<br>    # Type of Amazon Machine Image (AMI) associated with the EKS Node Group<br>    ami_type = string<br>    # EKS AMI version to use, e.g. "1.16.13-20200821" (no "v").<br>    ami_release_version = string<br>    # Desired Kubernetes master version. If you do not specify a value, the cluster version is used<br>    kubernetes_version = string # set to null to use cluster_kubernetes_version<br>    max_group_size     = number<br>    min_group_size     = number<br>    tags               = map(string)<br>  }))</pre> | `{}` | no |
-| <a name="input_spotinst_secrets_region"></a> [spotinst\_secrets\_region](#input\_spotinst\_secrets\_region) | The region to retrieve the spotinst secrets from | `string` | `"us-west-2"` | no |
-| <a name="input_spotinst_token_ssm_key"></a> [spotinst\_token\_ssm\_key](#input\_spotinst\_token\_ssm\_key) | SSM key for Spot Personal Access token | `string` | `"/spotinst/spotinst_token"` | no |
-| <a name="input_ssm_installer"></a> [ssm\_installer](#input\_ssm\_installer) | Command to install AWS SSM agent on EC2 instance | `string` | `"yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpmn"` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | <a name="input_subnet_type_tag_key"></a> [subnet\_type\_tag\_key](#input\_subnet\_type\_tag\_key) | The tag used to find the private subnets to find by availability zone. If null, will be looked up in vpc outputs. | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
@@ -168,8 +158,6 @@ You can plug that list into `instance_types` in the stack configuration. Keep in
 | <a name="input_tfstate_role_environment_name"></a> [tfstate\_role\_environment\_name](#input\_tfstate\_role\_environment\_name) | The name of the environment for Terraform state IAM role | `string` | `"gbl"` | no |
 | <a name="input_tfstate_role_name"></a> [tfstate\_role\_name](#input\_tfstate\_role\_name) | IAM Role name for accessing the Terraform remote state | `string` | `"terraform"` | no |
 | <a name="input_tfstate_role_stage_name"></a> [tfstate\_role\_stage\_name](#input\_tfstate\_role\_stage\_name) | The name of the stage for Terraform state IAM role | `string` | `"root"` | no |
-| <a name="input_update_policy_batch_size_percentage"></a> [update\_policy\_batch\_size\_percentage](#input\_update\_policy\_batch\_size\_percentage) | When rolling the cluster due to an update, the percentage of the instances to deploy in each batch. | `number` | `25` | no |
-| <a name="input_update_policy_should_roll"></a> [update\_policy\_should\_roll](#input\_update\_policy\_should\_roll) | If true, roll the cluster when its configuration is updated | `bool` | `true` | no |
 
 ## Outputs
 
@@ -187,12 +175,11 @@ You can plug that list into `instance_types` in the stack configuration. Keep in
 | <a name="output_eks_node_group_count"></a> [eks\_node\_group\_count](#output\_eks\_node\_group\_count) | Count of the worker nodes |
 | <a name="output_eks_node_group_ids"></a> [eks\_node\_group\_ids](#output\_eks\_node\_group\_ids) | EKS Cluster name and EKS Node Group name separated by a colon |
 | <a name="output_eks_node_group_role_names"></a> [eks\_node\_group\_role\_names](#output\_eks\_node\_group\_role\_names) | Name of the worker nodes IAM role |
-| <a name="output_eks_spotinst_ocean_controller_ids"></a> [eks\_spotinst\_ocean\_controller\_ids](#output\_eks\_spotinst\_ocean\_controller\_ids) | The ID of the Ocean controller |
+| <a name="output_eks_node_group_statuses"></a> [eks\_node\_group\_statuses](#output\_eks\_node\_group\_statuses) | Status of the EKS Node Group |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
-
 ## References
-* [cloudposse/terraform-aws-components](https://github.com/cloudposse/terraform-aws-components/tree/master/modules/eks) - Cloud Posse's upstream component
 
+- [cloudposse/terraform-aws-components](https://github.com/cloudposse/terraform-aws-components/tree/master/modules/eks) - Cloud Posse's upstream component
 
 [<img src="https://cloudposse.com/logo-300x69.svg" height="32" align="right"/>](https://cpco.io/component)

--- a/modules/eks/auth-sso.tf
+++ b/modules/eks/auth-sso.tf
@@ -1,0 +1,33 @@
+
+data "aws_caller_identity" "current" {}
+
+# Run the equivalent of
+# aws --no-cli-pager iam list-roles --path-prefix /aws-reserved/sso.amazonaws.com/ --query 'Roles[].RoleName'
+#module "cli" {
+#  source  = "digitickets/cli/aws"
+#  version = "3.0.0"
+#
+#  aws_cli_commands = ["iam", "list-roles", "--path-prefix", "/aws-reserved/sso.amazonaws.com/"]
+#  aws_cli_query = "Roles[].RoleName"
+#  assume_role_arn = data.aws_caller_identity.current.arn
+#}
+
+data "external" "awscli" {
+  program = ["${path.module}/scripts/list-sso-roles"]
+  query = {
+    assume_role_arn = data.aws_caller_identity.current.arn
+  }
+}
+
+locals {
+  # We are hard coding the mapping for now. This needs to be moved to YAML config.
+  sso_roles                 = jsondecode(data.external.awscli.result.output)
+  sso_authorized_role_names = [for name in local.sso_roles : name if length(regexall("^AWSReservedSSO_AdministratorAccess_", name)) > 0]
+  sso_authorized_roles      = { for name in local.sso_authorized_role_names : name => format("arn:aws:iam::%s:role/%s", data.aws_caller_identity.current.account_id, name) }
+  sso_auths = [for role, arn in local.sso_authorized_roles :
+    { rolearn  = arn
+      username = "${role}:{{SessionName}}"
+      groups   = ["system:masters", "idp:ops"]
+    }
+  ]
+}

--- a/modules/eks/context.tf
+++ b/modules/eks/context.tf
@@ -34,8 +34,6 @@ module "this" {
   label_order         = var.label_order
   regex_replace_chars = var.regex_replace_chars
   id_length_limit     = var.id_length_limit
-  label_key_case      = var.label_key_case
-  label_value_case    = var.label_value_case
 
   context = var.context
 }
@@ -43,7 +41,20 @@ module "this" {
 # Copy contents of cloudposse/terraform-null-label/variables.tf here
 
 variable "context" {
-  type = any
+  type = object({
+    enabled             = bool
+    namespace           = string
+    environment         = string
+    stage               = string
+    name                = string
+    delimiter           = string
+    attributes          = list(string)
+    tags                = map(string)
+    additional_tag_map  = map(string)
+    regex_replace_chars = string
+    label_order         = list(string)
+    id_length_limit     = number
+  })
   default = {
     enabled             = true
     namespace           = null
@@ -57,8 +68,6 @@ variable "context" {
     regex_replace_chars = null
     label_order         = []
     id_length_limit     = null
-    label_key_case      = null
-    label_value_case    = null
   }
   description = <<-EOT
     Single object for setting entire context at once.
@@ -67,16 +76,6 @@ variable "context" {
     Individual variable settings (non-null) override settings in context object,
     except for attributes, tags, and additional_tag_map, which are merged.
   EOT
-
-  validation {
-    condition     = lookup(var.context, "label_key_case", null) == null ? true : contains(["lower", "title", "upper"], var.context["label_key_case"])
-    error_message = "Allowed values: `lower`, `title`, `upper`."
-  }
-
-  validation {
-    condition     = lookup(var.context, "label_value_case", null) == null ? true : contains(["lower", "title", "upper", "none"], var.context["label_value_case"])
-    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
-  }
 }
 
 variable "enabled" {
@@ -159,44 +158,11 @@ variable "id_length_limit" {
   type        = number
   default     = null
   description = <<-EOT
-    Limit `id` to this many characters (minimum 6).
+    Limit `id` to this many characters.
     Set to `0` for unlimited length.
     Set to `null` for default, which is `0`.
     Does not affect `id_full`.
   EOT
-  validation {
-    condition     = var.id_length_limit == null ? true : var.id_length_limit >= 6 || var.id_length_limit == 0
-    error_message = "The id_length_limit must be >= 6 if supplied (not null), or 0 for unlimited length."
-  }
 }
 
-variable "label_key_case" {
-  type        = string
-  default     = null
-  description = <<-EOT
-    The letter case of label keys (`tag` names) (i.e. `name`, `namespace`, `environment`, `stage`, `attributes`) to use in `tags`.
-    Possible values: `lower`, `title`, `upper`.
-    Default value: `title`.
-  EOT
-
-  validation {
-    condition     = var.label_key_case == null ? true : contains(["lower", "title", "upper"], var.label_key_case)
-    error_message = "Allowed values: `lower`, `title`, `upper`."
-  }
-}
-
-variable "label_value_case" {
-  type        = string
-  default     = null
-  description = <<-EOT
-    The letter case of output label values (also used in `tags` and `id`).
-    Possible values: `lower`, `title`, `upper` and `none` (no transformation).
-    Default value: `lower`.
-  EOT
-
-  validation {
-    condition     = var.label_value_case == null ? true : contains(["lower", "title", "upper", "none"], var.label_value_case)
-    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
-  }
-}
 #### End of copy of cloudposse/terraform-null-label/variables.tf

--- a/modules/eks/default.auto.tfvars
+++ b/modules/eks/default.auto.tfvars
@@ -14,7 +14,7 @@ cluster_endpoint_private_access = true
 
 cluster_endpoint_public_access = true
 
-cluster_kubernetes_version = "1.17"
+cluster_kubernetes_version = "1.18"
 
 enabled_cluster_log_types = ["api", "audit", "authenticator", "controllerManager", "scheduler"]
 

--- a/modules/eks/default.auto.tfvars
+++ b/modules/eks/default.auto.tfvars
@@ -4,6 +4,8 @@ enabled = true
 
 name = "eks"
 
+availability_zone_abbreviation_type = "short"
+
 allowed_security_groups = []
 
 allowed_cidr_blocks = []
@@ -14,7 +16,7 @@ cluster_endpoint_private_access = true
 
 cluster_endpoint_public_access = true
 
-cluster_kubernetes_version = "1.18"
+cluster_kubernetes_version = "1.19"
 
 enabled_cluster_log_types = ["api", "audit", "authenticator", "controllerManager", "scheduler"]
 
@@ -92,14 +94,15 @@ node_group_defaults = {
   kubernetes_version  = null # use cluster_kubernetes_version
   ami_release_version = null # use latest for given Kubernetes version
 
-  attributes                = []
-  create_before_destroy     = true
-  disk_size                 = 100 # root EBS volume size in GB
-  enable_cluster_autoscaler = true
-  instance_types            = ["t3.medium"]
-  ami_type                  = "AL2_x86_64"
-  kubernetes_labels         = {}
-  kubernetes_taints         = {}
-  resources_to_tag          = ["instance", "volume"]
-  tags                      = null
+  attributes                 = []
+  create_before_destroy      = true
+  disk_size                  = 100 # root EBS volume size in GB
+  cluster_autoscaler_enabled = true
+  instance_types             = ["t3.medium"]
+  ami_type                   = "AL2_x86_64"
+  kubernetes_labels          = {}
+  kubernetes_taints          = {}
+  disk_encryption_enabled    = true
+  resources_to_tag           = ["instance", "volume"]
+  tags                       = null
 }

--- a/modules/eks/eks-node-groups.tf
+++ b/modules/eks/eks-node-groups.tf
@@ -1,0 +1,56 @@
+
+locals {
+  node_group_default_availability_zones = var.node_group_defaults.availability_zones == null ? var.region_availability_zones : var.node_group_defaults.availability_zones
+  node_group_default_kubernetes_version = var.node_group_defaults.kubernetes_version == null ? var.cluster_kubernetes_version : var.node_group_defaults.kubernetes_version
+
+  # values(module.region_node_group) is an array of `region_node_group` objects
+  # values(module.region_node_group)[*].region_node_groups is an array of
+  #   maps with keys availability zones and values the output map of terraform-aws-eks-node-group
+  # node_groups is a flattened array of output maps of terraform-aws-eks-node-group
+  node_groups = flatten([for m in values(module.region_node_group)[*].region_node_groups : values(m)])
+
+  # node_group_arns is a list of all the node group ARNs in the cluster
+  node_group_arns      = compact([for group in local.node_groups : group.eks_node_group_arn])
+  node_group_role_arns = compact([for group in local.node_groups : group.eks_node_group_role_arn])
+}
+
+module "region_node_group" {
+  for_each = module.this.enabled ? var.node_groups : {}
+
+  source = "./modules/node_group_by_region"
+
+  availability_zones = each.value.availability_zones == null ? local.node_group_default_availability_zones : each.value.availability_zones
+  attributes         = flatten(concat(var.attributes, [each.key], [var.color], each.value.attributes == null ? var.node_group_defaults.attributes : each.value.attributes))
+
+  node_group_size = module.this.enabled ? {
+    desired_size = each.value.desired_group_size == null ? var.node_group_defaults.desired_group_size : each.value.desired_group_size
+    min_size = each.value.min_group_size == null ? (
+      var.node_group_defaults.min_group_size == null ? (
+        length(each.value.availability_zones == null ? local.node_group_default_availability_zones : each.value.availability_zones)
+      ) : var.node_group_defaults.min_group_size
+    ) : each.value.min_group_size
+    max_size = each.value.max_group_size == null ? var.node_group_defaults.max_group_size : each.value.max_group_size
+  } : null
+
+  cluster_context = module.this.enabled ? {
+    cluster_name               = module.eks_cluster.eks_cluster_id
+    create_before_destroy      = each.value.create_before_destroy == null ? var.node_group_defaults.create_before_destroy : each.value.create_before_destroy
+    disk_size                  = each.value.disk_size == null ? var.node_group_defaults.disk_size : each.value.disk_size
+    cluster_autoscaler_enabled = each.value.cluster_autoscaler_enabled == null ? var.node_group_defaults.cluster_autoscaler_enabled : each.value.cluster_autoscaler_enabled
+    instance_types             = each.value.instance_types == null ? var.node_group_defaults.instance_types : each.value.instance_types
+    ami_type                   = each.value.ami_type == null ? var.node_group_defaults.ami_type : each.value.ami_type
+    ami_release_version        = each.value.ami_release_version == null ? var.node_group_defaults.ami_release_version : each.value.ami_release_version
+    kubernetes_version         = each.value.kubernetes_version == null ? local.node_group_default_kubernetes_version : each.value.kubernetes_version
+    kubernetes_labels          = each.value.kubernetes_labels == null ? var.node_group_defaults.kubernetes_labels : each.value.kubernetes_labels
+    kubernetes_taints          = each.value.kubernetes_taints == null ? var.node_group_defaults.kubernetes_taints : each.value.kubernetes_taints
+    resources_to_tag           = each.value.resources_to_tag == null ? var.node_group_defaults.resources_to_tag : each.value.resources_to_tag
+    subnet_type_tag_key        = local.subnet_type_tag_key
+    vpc_id                     = local.vpc_id
+
+    # See "Ensure ordering of resource creation" comment above for explanation
+    # of "module_depends_on"
+    module_depends_on = module.eks_cluster.kubernetes_config_map_id
+  } : null
+
+  context = module.this.context
+}

--- a/modules/eks/main.tf
+++ b/modules/eks/main.tf
@@ -21,10 +21,10 @@ locals {
     groups   = role.groups
   }]
 
-  map_additional_iam_roles = concat(local.primary_iam_roles, local.delegated_iam_roles)
+  map_additional_iam_roles = concat(local.primary_iam_roles, local.delegated_iam_roles, local.sso_auths)
   managed_worker_role_arns = local.eks_outputs.eks_managed_node_workers_role_arns
   worker_role_arns = compact(concat([
-    module.spotinst_role.outputs.workers_role_arn
+    module.workers_role.outputs.workers_role_arn,
   ], var.map_additional_worker_roles, local.managed_worker_role_arns))
 
   subnet_type_tag_key = var.subnet_type_tag_key != null ? var.subnet_type_tag_key : local.vpc_outputs.vpc.subnet_type_tag_key
@@ -32,7 +32,7 @@ locals {
 
 module "eks_cluster" {
   source  = "cloudposse/eks-cluster/aws"
-  version = "0.34.1"
+  version = "0.37.0"
 
   region     = var.region
   attributes = local.attributes
@@ -52,6 +52,8 @@ module "eks_cluster" {
   public_access_cidrs          = var.public_access_cidrs
   subnet_ids                   = concat(local.private_subnet_ids, local.public_subnet_ids)
   vpc_id                       = local.vpc_id
+
+  cluster_encryption_config_enabled = var.cluster_encryption_config_enabled
 
   kubernetes_config_map_ignore_role_changes = false
 

--- a/modules/eks/modules/node_group_by_az/context.tf
+++ b/modules/eks/modules/node_group_by_az/context.tf
@@ -34,8 +34,6 @@ module "this" {
   label_order         = var.label_order
   regex_replace_chars = var.regex_replace_chars
   id_length_limit     = var.id_length_limit
-  label_key_case      = var.label_key_case
-  label_value_case    = var.label_value_case
 
   context = var.context
 }
@@ -43,7 +41,20 @@ module "this" {
 # Copy contents of cloudposse/terraform-null-label/variables.tf here
 
 variable "context" {
-  type = any
+  type = object({
+    enabled             = bool
+    namespace           = string
+    environment         = string
+    stage               = string
+    name                = string
+    delimiter           = string
+    attributes          = list(string)
+    tags                = map(string)
+    additional_tag_map  = map(string)
+    regex_replace_chars = string
+    label_order         = list(string)
+    id_length_limit     = number
+  })
   default = {
     enabled             = true
     namespace           = null
@@ -57,8 +68,6 @@ variable "context" {
     regex_replace_chars = null
     label_order         = []
     id_length_limit     = null
-    label_key_case      = null
-    label_value_case    = null
   }
   description = <<-EOT
     Single object for setting entire context at once.
@@ -67,16 +76,6 @@ variable "context" {
     Individual variable settings (non-null) override settings in context object,
     except for attributes, tags, and additional_tag_map, which are merged.
   EOT
-
-  validation {
-    condition     = lookup(var.context, "label_key_case", null) == null ? true : contains(["lower", "title", "upper"], var.context["label_key_case"])
-    error_message = "Allowed values: `lower`, `title`, `upper`."
-  }
-
-  validation {
-    condition     = lookup(var.context, "label_value_case", null) == null ? true : contains(["lower", "title", "upper", "none"], var.context["label_value_case"])
-    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
-  }
 }
 
 variable "enabled" {
@@ -159,44 +158,11 @@ variable "id_length_limit" {
   type        = number
   default     = null
   description = <<-EOT
-    Limit `id` to this many characters (minimum 6).
+    Limit `id` to this many characters.
     Set to `0` for unlimited length.
     Set to `null` for default, which is `0`.
     Does not affect `id_full`.
   EOT
-  validation {
-    condition     = var.id_length_limit == null ? true : var.id_length_limit >= 6 || var.id_length_limit == 0
-    error_message = "The id_length_limit must be >= 6 if supplied (not null), or 0 for unlimited length."
-  }
 }
 
-variable "label_key_case" {
-  type        = string
-  default     = null
-  description = <<-EOT
-    The letter case of label keys (`tag` names) (i.e. `name`, `namespace`, `environment`, `stage`, `attributes`) to use in `tags`.
-    Possible values: `lower`, `title`, `upper`.
-    Default value: `title`.
-  EOT
-
-  validation {
-    condition     = var.label_key_case == null ? true : contains(["lower", "title", "upper"], var.label_key_case)
-    error_message = "Allowed values: `lower`, `title`, `upper`."
-  }
-}
-
-variable "label_value_case" {
-  type        = string
-  default     = null
-  description = <<-EOT
-    The letter case of output label values (also used in `tags` and `id`).
-    Possible values: `lower`, `title`, `upper` and `none` (no transformation).
-    Default value: `lower`.
-  EOT
-
-  validation {
-    condition     = var.label_value_case == null ? true : contains(["lower", "title", "upper", "none"], var.label_value_case)
-    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
-  }
-}
 #### End of copy of cloudposse/terraform-null-label/variables.tf

--- a/modules/eks/modules/node_group_by_az/main.tf
+++ b/modules/eks/modules/node_group_by_az/main.tf
@@ -4,7 +4,7 @@ data "aws_subnet_ids" "private" {
   vpc_id = var.cluster_context.vpc_id
 
   tags = {
-    "${var.cluster_context.subnet_type_tag_key}" = "private"
+    (var.cluster_context.subnet_type_tag_key) = "private"
   }
 
   filter {
@@ -22,7 +22,8 @@ locals {
 }
 
 module "eks_node_group" {
-  source  = "git::https://github.com/cloudposse/terraform-aws-eks-node-group.git?ref=tags/0.13.0"
+  source  = "cloudposse/eks-node-group/aws"
+  version = "0.17.2"
   enabled = local.enabled
 
   attributes = length(var.availability_zone) > 0 ? flatten([module.this.attributes, local.az_attribute]) : module.this.attributes
@@ -31,18 +32,18 @@ module "eks_node_group" {
   min_size     = local.enabled ? var.node_group_size.min_size : null
   max_size     = local.enabled ? var.node_group_size.max_size : null
 
-  cluster_name              = local.enabled ? var.cluster_context.cluster_name : null
-  create_before_destroy     = local.enabled ? var.cluster_context.create_before_destroy : null
-  disk_size                 = local.enabled ? var.cluster_context.disk_size : null
-  enable_cluster_autoscaler = local.enabled ? var.cluster_context.enable_cluster_autoscaler : null
-  instance_types            = local.enabled ? var.cluster_context.instance_types : null
-  ami_type                  = local.enabled ? var.cluster_context.ami_type : null
-  ami_release_version       = local.enabled ? var.cluster_context.ami_release_version : null
-  kubernetes_labels         = local.enabled ? var.cluster_context.kubernetes_labels : null
-  kubernetes_taints         = local.enabled ? var.cluster_context.kubernetes_taints : null
-  kubernetes_version        = local.enabled ? var.cluster_context.kubernetes_version : null
-  resources_to_tag          = local.enabled ? var.cluster_context.resources_to_tag : null
-  subnet_ids                = local.enabled ? local.subnet_ids : null
+  cluster_name               = local.enabled ? var.cluster_context.cluster_name : null
+  create_before_destroy      = local.enabled ? var.cluster_context.create_before_destroy : null
+  disk_size                  = local.enabled ? var.cluster_context.disk_size : null
+  cluster_autoscaler_enabled = local.enabled ? var.cluster_context.cluster_autoscaler_enabled : null
+  instance_types             = local.enabled ? var.cluster_context.instance_types : null
+  ami_type                   = local.enabled ? var.cluster_context.ami_type : null
+  ami_release_version        = local.enabled ? var.cluster_context.ami_release_version : null
+  kubernetes_labels          = local.enabled ? var.cluster_context.kubernetes_labels : null
+  kubernetes_taints          = local.enabled ? var.cluster_context.kubernetes_taints : null
+  kubernetes_version         = local.enabled ? var.cluster_context.kubernetes_version : null
+  resources_to_tag           = local.enabled ? var.cluster_context.resources_to_tag : null
+  subnet_ids                 = local.enabled ? local.subnet_ids : null
   # Prevent the node groups from being created before the Kubernetes aws-auth configMap
   module_depends_on = var.cluster_context.module_depends_on
 

--- a/modules/eks/modules/node_group_by_az/main.tf
+++ b/modules/eks/modules/node_group_by_az/main.tf
@@ -13,17 +13,24 @@ data "aws_subnet_ids" "private" {
   }
 }
 
+module "az_abbreviation" {
+  source  = "cloudposse/utils/aws"
+  version = "0.3.0"
+}
+
 locals {
   enabled         = module.this.enabled && length(var.availability_zone) > 0
   sentinel        = "~~"
   subnet_ids_test = coalescelist(flatten(data.aws_subnet_ids.private[*].ids), [local.sentinel])
   subnet_ids      = local.subnet_ids_test[0] == local.sentinel ? null : local.subnet_ids_test
-  az_attribute    = replace(var.availability_zone, "/^((.)[^-]*-(.)[^-]*-)/", "$2$3")
+  az_map          = var.cluster_context.az_abbreviation_type == "short" ? module.az_abbreviation.region_az_alt_code_maps.to_short : module.az_abbreviation.region_az_alt_code_maps.to_fixed
+  az_attribute    = local.az_map[var.availability_zone]
 }
 
 module "eks_node_group" {
   source  = "cloudposse/eks-node-group/aws"
-  version = "0.17.2"
+  version = "0.19.0"
+
   enabled = local.enabled
 
   attributes = length(var.availability_zone) > 0 ? flatten([module.this.attributes, local.az_attribute]) : module.this.attributes
@@ -32,18 +39,19 @@ module "eks_node_group" {
   min_size     = local.enabled ? var.node_group_size.min_size : null
   max_size     = local.enabled ? var.node_group_size.max_size : null
 
-  cluster_name               = local.enabled ? var.cluster_context.cluster_name : null
-  create_before_destroy      = local.enabled ? var.cluster_context.create_before_destroy : null
-  disk_size                  = local.enabled ? var.cluster_context.disk_size : null
-  cluster_autoscaler_enabled = local.enabled ? var.cluster_context.cluster_autoscaler_enabled : null
-  instance_types             = local.enabled ? var.cluster_context.instance_types : null
-  ami_type                   = local.enabled ? var.cluster_context.ami_type : null
-  ami_release_version        = local.enabled ? var.cluster_context.ami_release_version : null
-  kubernetes_labels          = local.enabled ? var.cluster_context.kubernetes_labels : null
-  kubernetes_taints          = local.enabled ? var.cluster_context.kubernetes_taints : null
-  kubernetes_version         = local.enabled ? var.cluster_context.kubernetes_version : null
-  resources_to_tag           = local.enabled ? var.cluster_context.resources_to_tag : null
-  subnet_ids                 = local.enabled ? local.subnet_ids : null
+  cluster_name                            = local.enabled ? var.cluster_context.cluster_name : null
+  create_before_destroy                   = local.enabled ? var.cluster_context.create_before_destroy : null
+  disk_size                               = local.enabled ? var.cluster_context.disk_size : null
+  cluster_autoscaler_enabled              = local.enabled ? var.cluster_context.cluster_autoscaler_enabled : null
+  instance_types                          = local.enabled ? var.cluster_context.instance_types : null
+  ami_type                                = local.enabled ? var.cluster_context.ami_type : null
+  ami_release_version                     = local.enabled ? var.cluster_context.ami_release_version : null
+  kubernetes_labels                       = local.enabled ? var.cluster_context.kubernetes_labels : null
+  kubernetes_taints                       = local.enabled ? var.cluster_context.kubernetes_taints : null
+  kubernetes_version                      = local.enabled ? var.cluster_context.kubernetes_version : null
+  launch_template_disk_encryption_enabled = local.enabled ? var.cluster_context.disk_encryption_enabled : null
+  resources_to_tag                        = local.enabled ? var.cluster_context.resources_to_tag : null
+  subnet_ids                              = local.enabled ? local.subnet_ids : null
   # Prevent the node groups from being created before the Kubernetes aws-auth configMap
   module_depends_on = var.cluster_context.module_depends_on
 

--- a/modules/eks/modules/node_group_by_az/variables.tf
+++ b/modules/eks/modules/node_group_by_az/variables.tf
@@ -12,19 +12,19 @@ variable "node_group_size" {
 
 variable "cluster_context" {
   type = object({
-    cluster_name              = string
-    create_before_destroy     = bool
-    disk_size                 = number
-    enable_cluster_autoscaler = bool
-    instance_types            = list(string)
-    ami_type                  = string
-    ami_release_version       = string
-    kubernetes_version        = string
-    kubernetes_labels         = map(string)
-    kubernetes_taints         = map(string)
-    subnet_type_tag_key       = string
-    vpc_id                    = string
-    resources_to_tag          = list(string)
-    module_depends_on         = any
+    cluster_name               = string
+    create_before_destroy      = bool
+    disk_size                  = number
+    cluster_autoscaler_enabled = bool
+    instance_types             = list(string)
+    ami_type                   = string
+    ami_release_version        = string
+    kubernetes_version         = string
+    kubernetes_labels          = map(string)
+    kubernetes_taints          = map(string)
+    subnet_type_tag_key        = string
+    vpc_id                     = string
+    resources_to_tag           = list(string)
+    module_depends_on          = any
   })
 }

--- a/modules/eks/modules/node_group_by_az/variables.tf
+++ b/modules/eks/modules/node_group_by_az/variables.tf
@@ -12,19 +12,21 @@ variable "node_group_size" {
 
 variable "cluster_context" {
   type = object({
+    ami_release_version        = string
+    ami_type                   = string
+    az_abbreviation_type       = string
+    cluster_autoscaler_enabled = bool
     cluster_name               = string
     create_before_destroy      = bool
+    disk_encryption_enabled    = bool
     disk_size                  = number
-    cluster_autoscaler_enabled = bool
     instance_types             = list(string)
-    ami_type                   = string
-    ami_release_version        = string
-    kubernetes_version         = string
     kubernetes_labels          = map(string)
     kubernetes_taints          = map(string)
+    kubernetes_version         = string
+    module_depends_on          = any
+    resources_to_tag           = list(string)
     subnet_type_tag_key        = string
     vpc_id                     = string
-    resources_to_tag           = list(string)
-    module_depends_on          = any
   })
 }

--- a/modules/eks/modules/node_group_by_region/context.tf
+++ b/modules/eks/modules/node_group_by_region/context.tf
@@ -34,8 +34,6 @@ module "this" {
   label_order         = var.label_order
   regex_replace_chars = var.regex_replace_chars
   id_length_limit     = var.id_length_limit
-  label_key_case      = var.label_key_case
-  label_value_case    = var.label_value_case
 
   context = var.context
 }
@@ -43,7 +41,20 @@ module "this" {
 # Copy contents of cloudposse/terraform-null-label/variables.tf here
 
 variable "context" {
-  type = any
+  type = object({
+    enabled             = bool
+    namespace           = string
+    environment         = string
+    stage               = string
+    name                = string
+    delimiter           = string
+    attributes          = list(string)
+    tags                = map(string)
+    additional_tag_map  = map(string)
+    regex_replace_chars = string
+    label_order         = list(string)
+    id_length_limit     = number
+  })
   default = {
     enabled             = true
     namespace           = null
@@ -57,8 +68,6 @@ variable "context" {
     regex_replace_chars = null
     label_order         = []
     id_length_limit     = null
-    label_key_case      = null
-    label_value_case    = null
   }
   description = <<-EOT
     Single object for setting entire context at once.
@@ -67,16 +76,6 @@ variable "context" {
     Individual variable settings (non-null) override settings in context object,
     except for attributes, tags, and additional_tag_map, which are merged.
   EOT
-
-  validation {
-    condition     = lookup(var.context, "label_key_case", null) == null ? true : contains(["lower", "title", "upper"], var.context["label_key_case"])
-    error_message = "Allowed values: `lower`, `title`, `upper`."
-  }
-
-  validation {
-    condition     = lookup(var.context, "label_value_case", null) == null ? true : contains(["lower", "title", "upper", "none"], var.context["label_value_case"])
-    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
-  }
 }
 
 variable "enabled" {
@@ -159,44 +158,11 @@ variable "id_length_limit" {
   type        = number
   default     = null
   description = <<-EOT
-    Limit `id` to this many characters (minimum 6).
+    Limit `id` to this many characters.
     Set to `0` for unlimited length.
     Set to `null` for default, which is `0`.
     Does not affect `id_full`.
   EOT
-  validation {
-    condition     = var.id_length_limit == null ? true : var.id_length_limit >= 6 || var.id_length_limit == 0
-    error_message = "The id_length_limit must be >= 6 if supplied (not null), or 0 for unlimited length."
-  }
 }
 
-variable "label_key_case" {
-  type        = string
-  default     = null
-  description = <<-EOT
-    The letter case of label keys (`tag` names) (i.e. `name`, `namespace`, `environment`, `stage`, `attributes`) to use in `tags`.
-    Possible values: `lower`, `title`, `upper`.
-    Default value: `title`.
-  EOT
-
-  validation {
-    condition     = var.label_key_case == null ? true : contains(["lower", "title", "upper"], var.label_key_case)
-    error_message = "Allowed values: `lower`, `title`, `upper`."
-  }
-}
-
-variable "label_value_case" {
-  type        = string
-  default     = null
-  description = <<-EOT
-    The letter case of output label values (also used in `tags` and `id`).
-    Possible values: `lower`, `title`, `upper` and `none` (no transformation).
-    Default value: `lower`.
-  EOT
-
-  validation {
-    condition     = var.label_value_case == null ? true : contains(["lower", "title", "upper", "none"], var.label_value_case)
-    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
-  }
-}
 #### End of copy of cloudposse/terraform-null-label/variables.tf

--- a/modules/eks/modules/node_group_by_region/variables.tf
+++ b/modules/eks/modules/node_group_by_region/variables.tf
@@ -12,19 +12,19 @@ variable "node_group_size" {
 
 variable "cluster_context" {
   type = object({
-    cluster_name              = string
-    create_before_destroy     = bool
-    disk_size                 = number
-    enable_cluster_autoscaler = bool
-    instance_types            = list(string)
-    ami_type                  = string
-    ami_release_version       = string
-    kubernetes_version        = string
-    kubernetes_labels         = map(string)
-    kubernetes_taints         = map(string)
-    subnet_type_tag_key       = string
-    vpc_id                    = string
-    resources_to_tag          = list(string)
-    module_depends_on         = any
+    cluster_name               = string
+    create_before_destroy      = bool
+    disk_size                  = number
+    cluster_autoscaler_enabled = bool
+    instance_types             = list(string)
+    ami_type                   = string
+    ami_release_version        = string
+    kubernetes_version         = string
+    kubernetes_labels          = map(string)
+    kubernetes_taints          = map(string)
+    subnet_type_tag_key        = string
+    vpc_id                     = string
+    resources_to_tag           = list(string)
+    module_depends_on          = any
   })
 }

--- a/modules/eks/modules/node_group_by_region/variables.tf
+++ b/modules/eks/modules/node_group_by_region/variables.tf
@@ -12,19 +12,21 @@ variable "node_group_size" {
 
 variable "cluster_context" {
   type = object({
+    ami_release_version        = string
+    ami_type                   = string
+    az_abbreviation_type       = string
+    cluster_autoscaler_enabled = bool
     cluster_name               = string
     create_before_destroy      = bool
+    disk_encryption_enabled    = bool
     disk_size                  = number
-    cluster_autoscaler_enabled = bool
     instance_types             = list(string)
-    ami_type                   = string
-    ami_release_version        = string
-    kubernetes_version         = string
     kubernetes_labels          = map(string)
     kubernetes_taints          = map(string)
+    kubernetes_version         = string
+    module_depends_on          = any
+    resources_to_tag           = list(string)
     subnet_type_tag_key        = string
     vpc_id                     = string
-    resources_to_tag           = list(string)
-    module_depends_on          = any
   })
 }

--- a/modules/eks/outputs.tf
+++ b/modules/eks/outputs.tf
@@ -53,7 +53,13 @@ output "eks_node_group_role_names" {
   value       = compact(flatten([for group in local.node_groups : group.eks_node_group_role_name]))
 }
 
+output "eks_auth_worker_roles" {
+  description = "List of worker IAM roles that were included in the `auth-map` ConfigMap."
+  value       = local.worker_role_arns
+}
+
 //output "eks_node_group_statuses" {
 //  description = "Status of the EKS Node Group"
 //  value       = compact([for group in local.node_groups : group.eks_node_group_status])
 //}
+

--- a/modules/eks/outputs.tf
+++ b/modules/eks/outputs.tf
@@ -58,8 +58,7 @@ output "eks_auth_worker_roles" {
   value       = local.worker_role_arns
 }
 
-//output "eks_node_group_statuses" {
-//  description = "Status of the EKS Node Group"
-//  value       = compact([for group in local.node_groups : group.eks_node_group_status])
-//}
-
+output "eks_node_group_statuses" {
+  description = "Status of the EKS Node Group"
+  value       = compact([for group in local.node_groups : group.eks_node_group_status])
+}

--- a/modules/eks/providers.tf
+++ b/modules/eks/providers.tf
@@ -8,14 +8,29 @@ provider "aws" {
   }
 }
 
+provider "aws" {
+  region = var.spotinst_secrets_region
+  alias  = "spotinst_secrets"
+
+  assume_role {
+    # `terraform import` will not use data from a data source,
+    # so on import we have to explicitly specify the role
+    role_arn = coalesce(var.import_role_arn, module.iam_roles.terraform_role_arn)
+  }
+}
+
 module "iam_roles" {
-  source = "../account-map/modules/iam-roles"
-  stage  = var.stage
-  region = var.region
+  source  = "../account-map/modules/iam-roles"
+  context = module.this.context
 }
 
 variable "import_role_arn" {
   type        = string
   default     = null
   description = "IAM Role ARN to use when importing a resource"
+}
+
+provider "spotinst" {
+  token   = local.spotinst_token
+  account = local.spotinst_account
 }

--- a/modules/eks/providers.tf
+++ b/modules/eks/providers.tf
@@ -4,17 +4,12 @@ provider "aws" {
   assume_role {
     # `terraform import` will not use data from a data source,
     # so on import we have to explicitly specify the role
-    role_arn = coalesce(var.import_role_arn, module.iam_roles.terraform_role_arn)
-  }
-}
-
-provider "aws" {
-  region = var.spotinst_secrets_region
-  alias  = "spotinst_secrets"
-
-  assume_role {
-    # `terraform import` will not use data from a data source,
-    # so on import we have to explicitly specify the role
+    # WARNING:
+    #   The EKS cluster is owned by the role that created it, and that
+    #   role is the only role that can access the cluster without an
+    #   entry in the auth-map ConfigMap, so it is crucial it is created
+    #   with the provisioned Terraform role and not an SSO role that could
+    #   be removed without notice.
     role_arn = coalesce(var.import_role_arn, module.iam_roles.terraform_role_arn)
   }
 }
@@ -28,9 +23,4 @@ variable "import_role_arn" {
   type        = string
   default     = null
   description = "IAM Role ARN to use when importing a resource"
-}
-
-provider "spotinst" {
-  token   = local.spotinst_token
-  account = local.spotinst_account
 }

--- a/modules/eks/remote-state.tf
+++ b/modules/eks/remote-state.tf
@@ -1,0 +1,62 @@
+module "vpc" {
+  source  = "cloudposse/stack-config/yaml//modules/remote-state"
+  version = "0.10.0"
+
+  stack_config_local_path = "../../../stacks"
+  component               = "vpc"
+
+  context = module.this.context
+}
+
+module "primary_roles" {
+  source  = "cloudposse/stack-config/yaml//modules/remote-state"
+  version = "0.10.0"
+
+  stack_config_local_path = "../../../stacks"
+  component               = "iam-primary-roles"
+  environment             = var.iam_roles_environment_name
+  stage                   = var.iam_primary_roles_stage_name
+
+  context = module.this.context
+}
+
+module "delegated_roles" {
+  source  = "cloudposse/stack-config/yaml//modules/remote-state"
+  version = "0.10.0"
+
+  stack_config_local_path = "../../../stacks"
+  component               = "iam-delegated-roles"
+  environment             = var.iam_roles_environment_name
+
+  context = module.this.context
+}
+
+module "spotinst_role" {
+  source  = "cloudposse/stack-config/yaml//modules/remote-state"
+  version = "0.10.0"
+
+  stack_config_local_path = "../../../stacks"
+  component               = "spotinst-integration"
+  environment             = var.iam_roles_environment_name
+  defaults = {
+    workers_role_arn = null
+  }
+
+  context = module.this.context
+}
+
+# Yes, this is self-referential.
+# It obtains the previous state of the cluster so that we can add
+# to it rather than overwrite it (specifically the aws-auth configMap)
+module "eks" {
+  source  = "cloudposse/stack-config/yaml//modules/remote-state"
+  version = "0.10.0"
+
+  stack_config_local_path = "../../../stacks"
+  component               = "eks"
+  defaults = {
+    eks_managed_node_workers_role_arns = []
+  }
+
+  context = module.this.context
+}

--- a/modules/eks/remote-state.tf
+++ b/modules/eks/remote-state.tf
@@ -1,20 +1,20 @@
 module "vpc" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "0.10.0"
+  version = "0.13.0"
 
-  stack_config_local_path = "../../../stacks"
   component               = "vpc"
+  stack_config_local_path = "../../../stacks"
 
   context = module.this.context
 }
 
 module "primary_roles" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "0.10.0"
+  version = "0.13.0"
 
-  stack_config_local_path = "../../../stacks"
   component               = "iam-primary-roles"
   environment             = var.iam_roles_environment_name
+  stack_config_local_path = "../../../stacks"
   stage                   = var.iam_primary_roles_stage_name
 
   context = module.this.context
@@ -22,25 +22,24 @@ module "primary_roles" {
 
 module "delegated_roles" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "0.10.0"
+  version = "0.13.0"
 
-  stack_config_local_path = "../../../stacks"
   component               = "iam-delegated-roles"
   environment             = var.iam_roles_environment_name
+  stack_config_local_path = "../../../stacks"
 
   context = module.this.context
 }
 
-module "spotinst_role" {
+module "workers_role" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "0.10.0"
+  version = "0.13.0"
 
-  stack_config_local_path = "../../../stacks"
-  component               = "spotinst-integration"
-  environment             = var.iam_roles_environment_name
+  component = "eks-workers"
   defaults = {
     workers_role_arn = null
   }
+  stack_config_local_path = "../../../stacks"
 
   context = module.this.context
 }
@@ -50,13 +49,13 @@ module "spotinst_role" {
 # to it rather than overwrite it (specifically the aws-auth configMap)
 module "eks" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "0.10.0"
+  version = "0.13.0"
 
-  stack_config_local_path = "../../../stacks"
-  component               = "eks"
+  component = "eks"
   defaults = {
     eks_managed_node_workers_role_arns = []
   }
+  stack_config_local_path = "../../../stacks"
 
   context = module.this.context
 }

--- a/modules/eks/scripts/list-sso-roles
+++ b/modules/eks/scripts/list-sso-roles
@@ -1,0 +1,38 @@
+#!/usr/bin/env sh
+# Use plain sh for compatibility with Terraform cloud
+# Unfortunately it does not have -o pipefail
+set -e
+
+# Validate required commands
+if ! [ -x "$(command -v aws)" ]; then
+	echo 'Error: aws is not installed.' >&2
+	exit 1
+fi
+if ! [ -x "$(command -v jq)" ]; then
+	echo 'Error: jq is not installed.' >&2
+	exit 1
+fi
+
+# Get the query
+TERRAFORM_QUERY=$(jq -Mc .)
+
+# Extract the query attributes
+ASSUME_ROLE_ARN=$(echo "${TERRAFORM_QUERY}" | jq -r '.assume_role_arn')
+if [ -n "$ASSUME_ROLE_ARN" ]; then
+	ASSUME_ROLE_ARN=$(printf "%s" "$ASSUME_ROLE_ARN" | sed 's%:sts:%:iam:%' | sed -E 's%:assumed-role/([^/]+)/.*%:role/\1%')
+fi
+
+# Do we need to assume a role?
+if [ -n "${ASSUME_ROLE_ARN}" ]; then
+	TEMP_ROLE=$(aws sts assume-role --role-arn "${ASSUME_ROLE_ARN}" --role-session-name "${ROLE_SESSION_NAME:-Terraform}")
+	export AWS_ACCESS_KEY_ID=$(echo "${TEMP_ROLE}" | jq -r '.Credentials.AccessKeyId')
+	export AWS_SECRET_ACCESS_KEY=$(echo "${TEMP_ROLE}" | jq -r '.Credentials.SecretAccessKey')
+	export AWS_SESSION_TOKEN=$(echo "${TEMP_ROLE}" | jq -r '.Credentials.SessionToken')
+fi
+
+# Disable any assigned pager
+export AWS_PAGER=""
+
+json=$(aws iam list-roles --path-prefix /aws-reserved/sso.amazonaws.com/ --query 'Roles[].RoleName' --output json)
+
+printf "%s" "$json" | jq '{ output: @json }'

--- a/modules/eks/spotinst-oceans.tf
+++ b/modules/eks/spotinst-oceans.tf
@@ -1,0 +1,63 @@
+
+locals {
+  ocean_names      = [for k, v in var.spotinst_oceans : k]
+  spotinst_enabled = length(local.ocean_names) > 0
+  spotinst_instance_profile = (
+    var.spotinst_instance_profile_pattern == null || var.spotinst_instance_profile_pattern == "" ?
+    null : format(var.spotinst_instance_profile_pattern, var.namespace, var.environment, var.stage)
+  )
+}
+
+data "aws_ssm_parameter" "spotinst_token" {
+  name     = var.spotinst_token_ssm_key
+  provider = aws.spotinst_secrets
+}
+data "aws_ssm_parameter" "spotinst_account" {
+  name     = var.spotinst_account_ssm_key
+  provider = aws.spotinst_secrets
+}
+data "aws_iam_instance_profile" "spotinst_worker" {
+  count = local.spotinst_enabled ? 1 : 0
+  name  = local.spotinst_instance_profile
+}
+
+locals {
+  //  spotinst_account = local.spotinst_enabled ? data.aws_ssm_parameter.spotinst_account[0].value : null
+  //  spotinst_token = local.spotinst_enabled ? data.aws_ssm_parameter.spotinst_token[0].value : null
+  spotinst_account = data.aws_ssm_parameter.spotinst_account.value
+  spotinst_token   = data.aws_ssm_parameter.spotinst_token.value
+  so_def           = var.spotinst_ocean_defaults
+}
+
+module "spotinst_oceans" {
+  for_each = var.spotinst_oceans
+  enabled  = local.spotinst_enabled
+  source   = "cloudposse/eks-spotinst-ocean-nodepool/aws"
+  version  = "0.1.1"
+
+  attributes          = compact(concat(["spotinst", each.key], each.value.attributes == null ? local.so_def.attributes : each.value.attributes))
+  desired_capacity    = each.value.desired_group_size == null ? local.so_def.desired_group_size : each.value.desired_group_size
+  disk_size           = each.value.disk_size == null ? local.so_def.disk_size : each.value.disk_size
+  instance_types      = each.value.instance_types == null ? local.so_def.instance_types : each.value.instance_types
+  instance_profile    = local.spotinst_instance_profile
+  ami_type            = each.value.ami_type == null ? local.so_def.ami_type : each.value.ami_type
+  ami_release_version = each.value.ami_release_version == null ? local.so_def.ami_release_version : each.value.ami_release_version
+  # If ocean kubernetes version is null, use cluster_kubernetes_version
+  kubernetes_version = coalesce(each.value.kubernetes_version, local.so_def.kubernetes_version, var.cluster_kubernetes_version, module.eks_cluster.eks_cluster_version)
+  max_size           = each.value.max_group_size == null ? local.so_def.max_group_size : each.value.max_group_size
+  min_size           = each.value.min_group_size == null ? local.so_def.min_group_size : each.value.min_group_size
+  tags               = each.value.tags == null ? local.so_def.tags : each.value.tags
+
+  eks_cluster_id      = module.eks_cluster.eks_cluster_id
+  ocean_controller_id = module.eks_cluster.eks_cluster_id
+  region              = var.region
+  subnet_ids          = local.private_subnet_ids
+  security_group_ids  = [module.eks_cluster.eks_cluster_managed_security_group_id]
+
+  before_cluster_joining_userdata = var.aws_ssm_enabled ? var.ssm_installer : null
+
+  update_policy_should_roll           = var.update_policy_should_roll
+  update_policy_batch_size_percentage = var.update_policy_batch_size_percentage
+
+  context = module.this.context
+}

--- a/modules/eks/spotinst-oceans.tf
+++ b/modules/eks/spotinst-oceans.tf
@@ -1,63 +1,54 @@
+# locals {
+#   ocean_names               = [for k, v in var.spotinst_oceans : k]
+#   spotinst_enabled          = module.this.enabled && var.spotinst_enabled && length(local.ocean_names) > 0
+#   spotinst_instance_profile = try(format(var.spotinst_instance_profile_pattern, module.this.namespace, module.this.environment, module.this.stage), "")
+# }
 
-locals {
-  ocean_names      = [for k, v in var.spotinst_oceans : k]
-  spotinst_enabled = length(local.ocean_names) > 0
-  spotinst_instance_profile = (
-    var.spotinst_instance_profile_pattern == null || var.spotinst_instance_profile_pattern == "" ?
-    null : format(var.spotinst_instance_profile_pattern, var.namespace, var.environment, var.stage)
-  )
-}
+# data "aws_ssm_parameter" "spotinst_token" {
+#   count = local.spotinst_enabled ? 1 : 0
+#   name  = var.spotinst_token_ssm_key
+# }
+# data "aws_ssm_parameter" "spotinst_account" {
+#   count = local.spotinst_enabled ? 1 : 0
+#   name  = var.spotinst_account_ssm_key
+# }
+# data "aws_iam_instance_profile" "spotinst_worker" {
+#   count = local.spotinst_enabled ? 1 : 0
+#   name  = local.spotinst_instance_profile
+# }
 
-data "aws_ssm_parameter" "spotinst_token" {
-  name     = var.spotinst_token_ssm_key
-  provider = aws.spotinst_secrets
-}
-data "aws_ssm_parameter" "spotinst_account" {
-  name     = var.spotinst_account_ssm_key
-  provider = aws.spotinst_secrets
-}
-data "aws_iam_instance_profile" "spotinst_worker" {
-  count = local.spotinst_enabled ? 1 : 0
-  name  = local.spotinst_instance_profile
-}
+# locals {
+#   spotinst_account = local.spotinst_enabled ? data.aws_ssm_parameter.spotinst_account[0].value : null
+#   spotinst_token   = local.spotinst_enabled ? data.aws_ssm_parameter.spotinst_token[0].value : null
+#   # spotinst_account = data.aws_ssm_parameter.spotinst_account.value
+#   # spotinst_token   = data.aws_ssm_parameter.spotinst_token.value
+#   so_def = var.spotinst_ocean_defaults
+# }
 
-locals {
-  //  spotinst_account = local.spotinst_enabled ? data.aws_ssm_parameter.spotinst_account[0].value : null
-  //  spotinst_token = local.spotinst_enabled ? data.aws_ssm_parameter.spotinst_token[0].value : null
-  spotinst_account = data.aws_ssm_parameter.spotinst_account.value
-  spotinst_token   = data.aws_ssm_parameter.spotinst_token.value
-  so_def           = var.spotinst_ocean_defaults
-}
+# module "spotinst_oceans" {
+#   for_each = var.spotinst_oceans
+#   enabled  = local.spotinst_enabled
+#   source   = "cloudposse/eks-spotinst-ocean-nodepool/aws"
+#   version  = "0.0.4"
 
-module "spotinst_oceans" {
-  for_each = var.spotinst_oceans
-  enabled  = local.spotinst_enabled
-  source   = "cloudposse/eks-spotinst-ocean-nodepool/aws"
-  version  = "0.1.1"
+#   attributes          = compact(concat(["spotinst", each.key], each.value.attributes == null ? local.so_def.attributes : each.value.attributes))
+#   desired_capacity    = each.value.desired_group_size == null ? local.so_def.desired_group_size : each.value.desired_group_size
+#   disk_size           = each.value.disk_size == null ? local.so_def.disk_size : each.value.disk_size
+#   instance_types      = each.value.instance_types == null ? local.so_def.instance_types : each.value.instance_types
+#   instance_profile    = local.spotinst_instance_profile
+#   ami_type            = each.value.ami_type == null ? local.so_def.ami_type : each.value.ami_type
+#   ami_release_version = each.value.ami_release_version == null ? local.so_def.ami_release_version : each.value.ami_release_version
+#   # If ocean kubernetes version is null, use cluster_kubernetes_version
+#   kubernetes_version = coalesce(each.value.kubernetes_version, local.so_def.kubernetes_version, var.cluster_kubernetes_version, module.eks_cluster.eks_cluster_version)
+#   max_size           = each.value.max_group_size == null ? local.so_def.max_group_size : each.value.max_group_size
+#   min_size           = each.value.min_group_size == null ? local.so_def.min_group_size : each.value.min_group_size
+#   tags               = each.value.tags == null ? local.so_def.tags : each.value.tags
 
-  attributes          = compact(concat(["spotinst", each.key], each.value.attributes == null ? local.so_def.attributes : each.value.attributes))
-  desired_capacity    = each.value.desired_group_size == null ? local.so_def.desired_group_size : each.value.desired_group_size
-  disk_size           = each.value.disk_size == null ? local.so_def.disk_size : each.value.disk_size
-  instance_types      = each.value.instance_types == null ? local.so_def.instance_types : each.value.instance_types
-  instance_profile    = local.spotinst_instance_profile
-  ami_type            = each.value.ami_type == null ? local.so_def.ami_type : each.value.ami_type
-  ami_release_version = each.value.ami_release_version == null ? local.so_def.ami_release_version : each.value.ami_release_version
-  # If ocean kubernetes version is null, use cluster_kubernetes_version
-  kubernetes_version = coalesce(each.value.kubernetes_version, local.so_def.kubernetes_version, var.cluster_kubernetes_version, module.eks_cluster.eks_cluster_version)
-  max_size           = each.value.max_group_size == null ? local.so_def.max_group_size : each.value.max_group_size
-  min_size           = each.value.min_group_size == null ? local.so_def.min_group_size : each.value.min_group_size
-  tags               = each.value.tags == null ? local.so_def.tags : each.value.tags
+#   eks_cluster_id      = module.eks_cluster.eks_cluster_id
+#   ocean_controller_id = module.eks_cluster.eks_cluster_id
+#   region              = var.region
+#   subnet_ids          = local.private_subnet_ids
+#   security_group_ids  = [module.eks_cluster.eks_cluster_managed_security_group_id]
 
-  eks_cluster_id      = module.eks_cluster.eks_cluster_id
-  ocean_controller_id = module.eks_cluster.eks_cluster_id
-  region              = var.region
-  subnet_ids          = local.private_subnet_ids
-  security_group_ids  = [module.eks_cluster.eks_cluster_managed_security_group_id]
-
-  before_cluster_joining_userdata = var.aws_ssm_enabled ? var.ssm_installer : null
-
-  update_policy_should_roll           = var.update_policy_should_roll
-  update_policy_batch_size_percentage = var.update_policy_batch_size_percentage
-
-  context = module.this.context
-}
+#   context = module.this.context
+# }

--- a/modules/eks/spotinst-variables.tf
+++ b/modules/eks/spotinst-variables.tf
@@ -1,0 +1,81 @@
+
+// Spotinst configuration
+variable "spotinst_token_ssm_key" {
+  type        = string
+  description = "SSM key for Spot Personal Access token"
+  default     = "/spotinst/spotinst_token"
+}
+
+variable "spotinst_account_ssm_key" {
+  type        = string
+  description = "SSM key for Spot account ID"
+  default     = "/spotinst/spotinst_account"
+}
+
+variable "spotinst_instance_profile_pattern" {
+  type        = string
+  description = <<-EOT
+    Pattern for the name of the AWS Instance Profile to use for Spotinst Worker instances:
+    `format(spotinst_instance_profile_pattern, var.namespace, var.environment, var.stage)`
+    If empty or null, a new instance profile will be created.
+    EOT
+  default     = "%v-gbl-%[3]v-spotinst-worker"
+}
+
+variable "spotinst_oceans" {
+  type = map(object({
+    # Additional attributes (e.g. `1`) for the ocean
+    attributes         = list(string)
+    desired_group_size = number
+    # Disk size in GiB for worker nodes. Terraform will only perform drift detection if a configuration value is provided.
+    disk_size = number
+    # List of allowed instance types. Leave null to allow Spot to choose any type.
+    instance_types = list(string)
+    # Type of Amazon Machine Image (AMI) associated with the EKS Node Group
+    ami_type = string
+    # EKS AMI version to use, e.g. "1.16.13-20200821" (no "v").
+    ami_release_version = string
+    # Desired Kubernetes master version. If you do not specify a value, the cluster version is used
+    kubernetes_version = string # set to null to use cluster_kubernetes_version
+    max_group_size     = number
+    min_group_size     = number
+    tags               = map(string)
+  }))
+  description = "List of objects defining a Spotinst Ocean for the cluster"
+  default     = {}
+}
+
+variable "spotinst_ocean_defaults" {
+  # Any value in the node group that is null will be replaced
+  # by the value in this object, which can also be null
+  type = object({
+    attributes          = list(string)
+    desired_group_size  = number
+    disk_size           = number
+    instance_types      = list(string)
+    ami_type            = string
+    ami_release_version = string
+    kubernetes_version  = string # set to null to use cluster_kubernetes_version
+    max_group_size      = number
+    min_group_size      = number
+    tags                = map(string)
+  })
+  description = "Defaults for node groups in the cluster"
+  default = {
+    attributes          = []
+    desired_group_size  = 1
+    disk_size           = 20
+    instance_types      = null
+    ami_type            = "AL2_x86_64"
+    ami_release_version = null
+    kubernetes_version  = null # set to null to use cluster_kubernetes_version
+    max_group_size      = 100
+    min_group_size      = null
+    tags                = {}
+  }
+}
+
+output "eks_spotinst_ocean_controller_ids" {
+  description = "The ID of the Ocean controller"
+  value       = toset(values(module.spotinst_oceans)[*].ocean_controller_id)
+}

--- a/modules/eks/spotinst-variables.tf
+++ b/modules/eks/spotinst-variables.tf
@@ -1,81 +1,87 @@
 
-// Spotinst configuration
-variable "spotinst_token_ssm_key" {
-  type        = string
-  description = "SSM key for Spot Personal Access token"
-  default     = "/spotinst/spotinst_token"
-}
+# // Spotinst configuration
+# variable "spotinst_token_ssm_key" {
+#   type        = string
+#   description = "SSM key for Spot Personal Access token"
+#   default     = "/spotinst/spotinst_token"
+# }
 
-variable "spotinst_account_ssm_key" {
-  type        = string
-  description = "SSM key for Spot account ID"
-  default     = "/spotinst/spotinst_account"
-}
+# variable "spotinst_account_ssm_key" {
+#   type        = string
+#   description = "SSM key for Spot account ID"
+#   default     = "/spotinst/spotinst_account"
+# }
 
-variable "spotinst_instance_profile_pattern" {
-  type        = string
-  description = <<-EOT
-    Pattern for the name of the AWS Instance Profile to use for Spotinst Worker instances:
-    `format(spotinst_instance_profile_pattern, var.namespace, var.environment, var.stage)`
-    If empty or null, a new instance profile will be created.
-    EOT
-  default     = "%v-gbl-%[3]v-spotinst-worker"
-}
+# variable "spotinst_instance_profile_pattern" {
+#   type        = string
+#   description = <<-EOT
+#     The `format` pattern for the AWS Instance Profile to use for Spotinst Worker instances.
+#     Arguments to `format` are `namespace`, `environment`, `stage`.
+#     If not set, an instance profile will be created.
+#     EOT
+#   default     = null
+# }
 
-variable "spotinst_oceans" {
-  type = map(object({
-    # Additional attributes (e.g. `1`) for the ocean
-    attributes         = list(string)
-    desired_group_size = number
-    # Disk size in GiB for worker nodes. Terraform will only perform drift detection if a configuration value is provided.
-    disk_size = number
-    # List of allowed instance types. Leave null to allow Spot to choose any type.
-    instance_types = list(string)
-    # Type of Amazon Machine Image (AMI) associated with the EKS Node Group
-    ami_type = string
-    # EKS AMI version to use, e.g. "1.16.13-20200821" (no "v").
-    ami_release_version = string
-    # Desired Kubernetes master version. If you do not specify a value, the cluster version is used
-    kubernetes_version = string # set to null to use cluster_kubernetes_version
-    max_group_size     = number
-    min_group_size     = number
-    tags               = map(string)
-  }))
-  description = "List of objects defining a Spotinst Ocean for the cluster"
-  default     = {}
-}
+# variable "spotinst_enabled" {
+#   type        = bool
+#   description = "Set false to prevent the creation of Spotinst resources. Unfortunately, you will still be required to provide Spotinst credentials."
+#   default     = true
+# }
 
-variable "spotinst_ocean_defaults" {
-  # Any value in the node group that is null will be replaced
-  # by the value in this object, which can also be null
-  type = object({
-    attributes          = list(string)
-    desired_group_size  = number
-    disk_size           = number
-    instance_types      = list(string)
-    ami_type            = string
-    ami_release_version = string
-    kubernetes_version  = string # set to null to use cluster_kubernetes_version
-    max_group_size      = number
-    min_group_size      = number
-    tags                = map(string)
-  })
-  description = "Defaults for node groups in the cluster"
-  default = {
-    attributes          = []
-    desired_group_size  = 1
-    disk_size           = 20
-    instance_types      = null
-    ami_type            = "AL2_x86_64"
-    ami_release_version = null
-    kubernetes_version  = null # set to null to use cluster_kubernetes_version
-    max_group_size      = 100
-    min_group_size      = null
-    tags                = {}
-  }
-}
+# variable "spotinst_oceans" {
+#   type = map(object({
+#     # Additional attributes (e.g. `1`) for the ocean
+#     attributes         = list(string)
+#     desired_group_size = number
+#     # Disk size in GiB for worker nodes. Terraform will only perform drift detection if a configuration value is provided.
+#     disk_size = number
+#     # List of allowed instance types. Leave null to allow Spot to choose any type.
+#     instance_types = list(string)
+#     # Type of Amazon Machine Image (AMI) associated with the EKS Node Group
+#     ami_type = string
+#     # EKS AMI version to use, e.g. "1.16.13-20200821" (no "v").
+#     ami_release_version = string
+#     # Desired Kubernetes master version. If you do not specify a value, the cluster version is used
+#     kubernetes_version = string # set to null to use cluster_kubernetes_version
+#     max_group_size     = number
+#     min_group_size     = number
+#     tags               = map(string)
+#   }))
+#   description = "List of objects defining a Spotinst Ocean for the cluster"
+#   default     = {}
+# }
 
-output "eks_spotinst_ocean_controller_ids" {
-  description = "The ID of the Ocean controller"
-  value       = toset(values(module.spotinst_oceans)[*].ocean_controller_id)
-}
+# variable "spotinst_ocean_defaults" {
+#   # Any value in the node group that is null will be replaced
+#   # by the value in this object, which can also be null
+#   type = object({
+#     attributes          = list(string)
+#     desired_group_size  = number
+#     disk_size           = number
+#     instance_types      = list(string)
+#     ami_type            = string
+#     ami_release_version = string
+#     kubernetes_version  = string # set to null to use cluster_kubernetes_version
+#     max_group_size      = number
+#     min_group_size      = number
+#     tags                = map(string)
+#   })
+#   description = "Defaults for node groups in the cluster"
+#   default = {
+#     attributes          = []
+#     desired_group_size  = 1
+#     disk_size           = 20
+#     instance_types      = null
+#     ami_type            = "AL2_x86_64"
+#     ami_release_version = null
+#     kubernetes_version  = null # set to null to use cluster_kubernetes_version
+#     max_group_size      = 100
+#     min_group_size      = null
+#     tags                = {}
+#   }
+# }
+
+# output "eks_spotinst_ocean_controller_ids" {
+#   description = "The ID of the Ocean controller"
+#   value       = toset(values(module.spotinst_oceans)[*].ocean_controller_id)
+# }

--- a/modules/eks/systems-manager.tf
+++ b/modules/eks/systems-manager.tf
@@ -1,0 +1,30 @@
+
+locals {
+  ssm_enabled = module.this.enabled && var.aws_ssm_enabled
+  # worker_role_arns does not include managed node group role ARNs created in this invocation
+  all_worker_role_arns = local.ssm_enabled ? toset(
+    distinct(compact(concat(local.worker_role_arns, local.node_group_role_arns)))
+  ) : []
+  worker_role_names = local.ssm_enabled ? toset([
+    for arn in local.all_worker_role_arns : split("/", data.aws_arn.roles[arn].resource)[1]]
+  ) : []
+}
+
+data "aws_arn" "roles" {
+  for_each = local.ssm_enabled ? local.all_worker_role_arns : []
+  arn      = each.key
+}
+
+# Attach Amazon's managed policy for SSM managed instance
+resource "aws_iam_role_policy_attachment" "ssm_core" {
+  for_each   = local.ssm_enabled ? local.worker_role_names : []
+  role       = each.key
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+# Attach Amazon's managed policy for EventBridge and CloudWatch access
+resource "aws_iam_role_policy_attachment" "cloudwatch" {
+  for_each   = local.ssm_enabled ? local.worker_role_names : []
+  role       = each.key
+  policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
+}

--- a/modules/eks/versions.tf
+++ b/modules/eks/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.13.0"
 
   required_providers {
     aws = {
@@ -13,6 +13,14 @@ terraform {
     local = {
       source  = "hashicorp/local"
       version = ">= 1.3"
+    }
+    spotinst = {
+      source  = "spotinst/spotinst"
+      version = ">= 1.30"
+    }
+    utils = {
+      source  = "cloudposse/utils"
+      version = ">= 0.3.0"
     }
   }
 }

--- a/modules/eks/versions.tf
+++ b/modules/eks/versions.tf
@@ -1,26 +1,38 @@
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = "~> 0.14"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = "~> 3.32"
     }
-    template = {
-      source  = "hashicorp/template"
-      version = ">= 2.0"
+    external = {
+      source  = "hashicorp/external"
+      version = "~> 2.1"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 1.13"
     }
     local = {
       source  = "hashicorp/local"
-      version = ">= 1.3"
+      version = "~> 2.1"
     }
-    spotinst = {
-      source  = "spotinst/spotinst"
-      version = ">= 1.30"
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.1"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.1"
+    }
+    template = {
+      source  = "hashicorp/template"
+      version = "~> 2.2"
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 0.3.0"
+      version = "~> 0.3"
     }
   }
 }


### PR DESCRIPTION
## what
* Updates the EKS component to the latest from downstream
* Updates pre-commit-terraform version to utilize latest terraform-docs version / README updates

## why
* We're going to be utilizing the EKS component in our upcoming tutorial so we wanted to be sure to be using the latest
* Bunch of terraform-docs updates recently, so utilizing the latest ensures we're keeping up-to-date with the improved README format. 

## references
* This broke the pre-commit GHA workflow, so I've separated the tf-docs version upgrade out into #301 which should be merged prior to this. 
