### PR TITLE
feat: adds upstream-component make target to make upstreaming easier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@ export DOCKER_BUILD_FLAGS =
 export README_DEPS ?= docs/targets.md docs/terraform.md
 -include $(shell curl -sSL -o .build-harness "https://git.io/build-harness"; echo .build-harness)
 
+UPSTREAM_PATH := "NONE"
+COMPONENT    := "NONE"
+
 all: init deps build install run
 
 deps:
@@ -23,3 +26,17 @@ run:
 ## Rebuild README for all Terraform components
 rebuild-docs:
 	@pre-commit run --all-files terraform_docs
+
+# Upstream a given component
+# Requires:
+# UPSTREAM_PATH -- The relative or absolute path to the upstream project directory
+# COMPONENT     -- The name of the component to upstream into this repository
+upstream-component:
+	@test "$(UPSTREAM_PATH)" != "NONE" || { echo "Please set UPSTREAM_PATH"; exit 1; }
+	@test "$(COMPONENT)" != "NONE" || { echo "Please set COMPONENT"; exit 1; }
+
+	@cp -r $(UPSTREAM_PATH)/components/terraform/$(COMPONENT) ./modules/; \
+		test -f "./modules/$(COMPONENT)/backend.tf.json" && rm ./modules/$(COMPONENT)/backend.tf.json; \
+		test -d "./modules/$(COMPONENT)/.terraform" && rm -r ./modules/$(COMPONENT)/.terraform; \
+		echo "Upstreamed ./modules/$(COMPONENT)";
+

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,6 @@ upstream-component:
 
 	@cp -r $(UPSTREAM_PATH)/components/terraform/$(COMPONENT) ./modules/; \
 		test -f "./modules/$(COMPONENT)/backend.tf.json" && rm ./modules/$(COMPONENT)/backend.tf.json; \
-		test -d "./modules/$(COMPONENT)/.terraform" && rm -r ./modules/$(COMPONENT)/.terraform; \
+		test -d "./modules/$(COMPONENT)/.terraform" && rm -rf ./modules/$(COMPONENT)/.terraform; \
 		echo "Upstreamed ./modules/$(COMPONENT)";
 

--- a/Makefile
+++ b/Makefile
@@ -26,12 +26,11 @@ run:
 ## Rebuild README for all Terraform components
 rebuild-docs:
 	@pre-commit run --all-files terraform_docs
-
-# Upstream a given component
-# Requires:
-# UPSTREAM_PATH -- The relative or absolute path to the upstream project directory
-# COMPONENT     -- The name of the component to upstream into this repository
+## Upstream a given component
 upstream-component:
+# Requires:
+#   UPSTREAM_PATH -- The relative or absolute path to the upstream project directory
+#   COMPONENT     -- The name of the component to upstream into this repository
 	@test "$(UPSTREAM_PATH)" != "NONE" || { echo "Please set UPSTREAM_PATH"; exit 1; }
 	@test "$(COMPONENT)" != "NONE" || { echo "Please set COMPONENT"; exit 1; }
 
@@ -39,4 +38,3 @@ upstream-component:
 		test -f "./modules/$(COMPONENT)/backend.tf.json" && rm ./modules/$(COMPONENT)/backend.tf.json; \
 		test -d "./modules/$(COMPONENT)/.terraform" && rm -rf ./modules/$(COMPONENT)/.terraform; \
 		echo "Upstreamed ./modules/$(COMPONENT)";
-


### PR DESCRIPTION
## what
* adds a `upstream-component` Makefile task

## why
* Simple helper to support upstreaming from a project directory... it's stupid, but figured we're going to be doing this from many project repositories as Cloud Posse invests more and more into the components system. 



