### PR TITLE
feat: adds a new abstract providers.tf proposal

### DIFF
--- a/modules/vpc/README.md
+++ b/modules/vpc/README.md
@@ -45,7 +45,7 @@ components:
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles |  |
+| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | cloudposse/components/aws//modules/account-map/modules/iam-roles | 0.146.0 |
 | <a name="module_subnets"></a> [subnets](#module\_subnets) | cloudposse/dynamic-subnets/aws | 0.37.6 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.24.1 |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | cloudposse/vpc/aws | 0.21.0 |
@@ -64,13 +64,16 @@ components:
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
 | <a name="input_attributes"></a> [attributes](#input\_attributes) | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
 | <a name="input_availability_zones"></a> [availability\_zones](#input\_availability\_zones) | List of availability zones in which to provision VPC subnets | `list(string)` | `[]` | no |
+| <a name="input_aws_profile_name"></a> [aws\_profile\_name](#input\_aws\_profile\_name) | Profile to use with the AWS Provider<br>This can be used for importing locally which does not allow data sources | `string` | `null` | no |
+| <a name="input_aws_role_arn"></a> [aws\_role\_arn](#input\_aws\_role\_arn) | Role ARN to assume with the AWS Provider<br>This can be used for importing locally which does not allow data sources | `string` | `null` | no |
 | <a name="input_cidr_block"></a> [cidr\_block](#input\_cidr\_block) | VPC CIDR block | `string` | n/a | yes |
 | <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | <pre>object({<br>    enabled             = bool<br>    namespace           = string<br>    environment         = string<br>    stage               = string<br>    name                = string<br>    delimiter           = string<br>    attributes          = list(string)<br>    tags                = map(string)<br>    additional_tag_map  = map(string)<br>    regex_replace_chars = string<br>    label_order         = list(string)<br>    id_length_limit     = number<br>  })</pre> | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_order": [],<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
 | <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
+| <a name="input_iam_roles_profile_enabled"></a> [iam\_roles\_profile\_enabled](#input\_iam\_roles\_profile\_enabled) | Whether or not to use the account-map's iam-roles module to pull the AWS Profile<br>Conflicts with `iam_roles_role_arn_enabled` | `bool` | `true` | no |
+| <a name="input_iam_roles_role_arn_enabled"></a> [iam\_roles\_role\_arn\_enabled](#input\_iam\_roles\_role\_arn\_enabled) | Whether or not to use the account-map's iam-roles module to pull the AWS Role ARN<br>Conflicts with `iam_roles_profile_enabled` | `bool` | `false` | no |
 | <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters.<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
-| <a name="input_import_profile_name"></a> [import\_profile\_name](#input\_import\_profile\_name) | AWS Profile to use when importing a resource | `string` | `null` | no |
 | <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
 | <a name="input_map_public_ip_on_launch"></a> [map\_public\_ip\_on\_launch](#input\_map\_public\_ip\_on\_launch) | Instances launched into a public subnet should be assigned a public IP address | `bool` | `true` | no |
 | <a name="input_max_subnet_count"></a> [max\_subnet\_count](#input\_max\_subnet\_count) | Sets the maximum amount of subnets to deploy. 0 will deploy a subnet for every provided availability zone (in `region_availability_zones` variable) within the region | `number` | `0` | no |

--- a/modules/vpc/providers.tf
+++ b/modules/vpc/providers.tf
@@ -1,17 +1,66 @@
-provider "aws" {
-  region = var.region
+variable "aws_profile_name" {
+  type        = string
+  default     = null
+  description = <<-EOT
+  Profile to use with the AWS Provider
+  This can be used for importing locally which does not allow data sources
+  EOT
+}
 
-  # `terraform import` will not use data from a data source, so on import we have to explicitly specify the profile
-  profile = coalesce(var.import_profile_name, module.iam_roles.terraform_profile_name)
+variable "aws_role_arn" {
+  type        = string
+  default     = null
+  description = <<-EOT
+  Role ARN to assume with the AWS Provider
+  This can be used for importing locally which does not allow data sources
+  EOT
+}
+
+variable "iam_roles_profile_enabled" {
+  type        = bool
+  default     = true
+  description = <<-EOT
+  Whether or not to use the account-map's iam-roles module to pull the AWS Profile
+  Conflicts with `iam_roles_role_arn_enabled`
+  EOT
+}
+
+variable "iam_roles_role_arn_enabled" {
+  type        = bool
+  default     = false
+  description = <<-EOT
+  Whether or not to use the account-map's iam-roles module to pull the AWS Role ARN
+  Conflicts with `iam_roles_profile_enabled`
+  EOT
 }
 
 module "iam_roles" {
-  source  = "../account-map/modules/iam-roles"
+  count   = var.iam_roles_profile_enabled || var.iam_roles_role_arn_enabled ? 1 : 0
+  source  = "cloudposse/components/aws//modules/account-map/modules/iam-roles"
+  version = "0.146.0"
   context = module.this.context
 }
 
-variable "import_profile_name" {
-  type        = string
-  default     = null
-  description = "AWS Profile to use when importing a resource"
+locals {
+  iam_roles_profile  = join("", module.iam_roles[*].terraform_profile_name)
+  iam_roles_role_arn = join("", module.iam_roles[*].terraform_role_arn)
+
+  profile = var.iam_roles_profile_enabled ? local.iam_roles_profile : var.aws_profile_name
+
+  wrapped_role_arn = var.aws_role_arn != null ? [var.aws_role_arn] : []
+  role_arn         = var.iam_roles_role_arn_enabled ? [local.iam_roles_role_arn] : local.wrapped_role_arn
+}
+
+provider "aws" {
+  region  = var.region
+  profile = local.profile
+
+  dynamic "assume_role" {
+    for_each = local.role_arn
+    content {
+      role_arn     = assume_role.value
+      session_name = basename(path.root)
+      external_id  = "terraform"
+    }
+  }
 }


### PR DESCRIPTION
## what

* Proposes a new pattern for abstractly defining the aws provider via a common `providers.tf`


## why

* This enables usage of the following types of AWS auth for components: 
	* Environment credentials (`AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY`) via `iam_roles_profile_enabled = false` and not touching the other vars
	* Profile from iam-roles
	* Role ARN from iam-roles
	* Manually passed Profile (Solves the import need)
	* Manually passed Role ARN (Solves the import need)


## Notes

* This does require the iam-roles which is sitting on PR now in the `upstream-account-comps` branch: #304 
	* Tried making it work with `0.146.0`, but that is older and requires `region` which is annoying. 
	* Locally I updated to use the github URL: `git::https://github.com/cloudposse/terraform-aws-components.git//modules/account-map/modules/iam-roles/?ref=upstream-account-comps`