### PR TITLE
Use latest pre-commit.yml to fix terraform-docs install

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -23,11 +23,18 @@ jobs:
           INSTALL_PATH: "${{ github.workspace }}/bin"
         run: |
           make init
+          mkdir -p "${INSTALL_PATH}"
           make packages/install/terraform-docs
           echo "$INSTALL_PATH" >> $GITHUB_PATH
 
       # pre-commit setup
       - uses: actions/setup-python@v2
-
-      # pre-commit checks
-      - uses: pre-commit/action@v2.0.0
+      # pre-commit checks: fmt + terraform-docs
+      # We skip tf_validate as it requires an init
+      # of all root modules, which is to be avoided.
+      - uses: pre-commit/action@v2.0.2
+        env:
+          SKIP: tf_validate
+        with:
+          token: ${{ secrets.CODE_OWNER_VALIDATION }}
+          extra_args: --all-files

--- a/modules/account-map/README.md
+++ b/modules/account-map/README.md
@@ -40,7 +40,7 @@ components:
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_this"></a> [this](#module\_this) | git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.21.0 |  |
+| <a name="module_this"></a> [this](#module\_this) | git::https://github.com/cloudposse/terraform-null-label.git | tags/0.21.0 |
 
 ## Resources
 

--- a/modules/account-settings/README.md
+++ b/modules/account-settings/README.md
@@ -37,8 +37,8 @@ components:
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles |  |
-| <a name="module_this"></a> [this](#module\_this) | git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.21.0 |  |
+| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
+| <a name="module_this"></a> [this](#module\_this) | git::https://github.com/cloudposse/terraform-null-label.git | tags/0.21.0 |
 
 ## Resources
 

--- a/modules/account/README.md
+++ b/modules/account/README.md
@@ -106,11 +106,11 @@ components:
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_accounts_service_control_policies"></a> [accounts\_service\_control\_policies](#module\_accounts\_service\_control\_policies) | git::https://github.com/cloudposse/terraform-aws-service-control-policies.git?ref=tags/0.4.0 |  |
-| <a name="module_organization_service_control_policies"></a> [organization\_service\_control\_policies](#module\_organization\_service\_control\_policies) | git::https://github.com/cloudposse/terraform-aws-service-control-policies.git?ref=tags/0.4.0 |  |
-| <a name="module_organizational_units_service_control_policies"></a> [organizational\_units\_service\_control\_policies](#module\_organizational\_units\_service\_control\_policies) | git::https://github.com/cloudposse/terraform-aws-service-control-policies.git?ref=tags/0.4.0 |  |
-| <a name="module_service_control_policy_statements_yaml_config"></a> [service\_control\_policy\_statements\_yaml\_config](#module\_service\_control\_policy\_statements\_yaml\_config) | git::https://github.com/cloudposse/terraform-yaml-config.git?ref=tags/0.1.0 |  |
-| <a name="module_this"></a> [this](#module\_this) | git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.21.0 |  |
+| <a name="module_accounts_service_control_policies"></a> [accounts\_service\_control\_policies](#module\_accounts\_service\_control\_policies) | git::https://github.com/cloudposse/terraform-aws-service-control-policies.git | tags/0.4.0 |
+| <a name="module_organization_service_control_policies"></a> [organization\_service\_control\_policies](#module\_organization\_service\_control\_policies) | git::https://github.com/cloudposse/terraform-aws-service-control-policies.git | tags/0.4.0 |
+| <a name="module_organizational_units_service_control_policies"></a> [organizational\_units\_service\_control\_policies](#module\_organizational\_units\_service\_control\_policies) | git::https://github.com/cloudposse/terraform-aws-service-control-policies.git | tags/0.4.0 |
+| <a name="module_service_control_policy_statements_yaml_config"></a> [service\_control\_policy\_statements\_yaml\_config](#module\_service\_control\_policy\_statements\_yaml\_config) | git::https://github.com/cloudposse/terraform-yaml-config.git | tags/0.1.0 |
+| <a name="module_this"></a> [this](#module\_this) | git::https://github.com/cloudposse/terraform-null-label.git | tags/0.21.0 |
 
 ## Resources
 

--- a/modules/cloudtrail-bucket/README.md
+++ b/modules/cloudtrail-bucket/README.md
@@ -39,9 +39,9 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_cloudtrail_s3_bucket"></a> [cloudtrail\_s3\_bucket](#module\_cloudtrail\_s3\_bucket) | git::https://github.com/cloudposse/terraform-aws-cloudtrail-s3-bucket.git?ref=tags/0.12.0 |  |
-| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles |  |
-| <a name="module_this"></a> [this](#module\_this) | git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.21.0 |  |
+| <a name="module_cloudtrail_s3_bucket"></a> [cloudtrail\_s3\_bucket](#module\_cloudtrail\_s3\_bucket) | git::https://github.com/cloudposse/terraform-aws-cloudtrail-s3-bucket.git | tags/0.12.0 |
+| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
+| <a name="module_this"></a> [this](#module\_this) | git::https://github.com/cloudposse/terraform-null-label.git | tags/0.21.0 |
 
 ## Resources
 

--- a/modules/cloudtrail/README.md
+++ b/modules/cloudtrail/README.md
@@ -39,9 +39,9 @@ components:
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_cloudtrail"></a> [cloudtrail](#module\_cloudtrail) | git::https://github.com/cloudposse/terraform-aws-cloudtrail.git?ref=tags/0.14.0 |  |
-| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles |  |
-| <a name="module_this"></a> [this](#module\_this) | git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.21.0 |  |
+| <a name="module_cloudtrail"></a> [cloudtrail](#module\_cloudtrail) | git::https://github.com/cloudposse/terraform-aws-cloudtrail.git | tags/0.14.0 |
+| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
+| <a name="module_this"></a> [this](#module\_this) | git::https://github.com/cloudposse/terraform-null-label.git | tags/0.21.0 |
 
 ## Resources
 

--- a/modules/datadog-integration/README.md
+++ b/modules/datadog-integration/README.md
@@ -43,9 +43,9 @@ components:
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_datadog_integration"></a> [datadog\_integration](#module\_datadog\_integration) | git::https://github.com/cloudposse/terraform-aws-datadog-integration.git?ref=tags/0.6.1 |  |
-| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles |  |
-| <a name="module_this"></a> [this](#module\_this) | git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.21.0 |  |
+| <a name="module_datadog_integration"></a> [datadog\_integration](#module\_datadog\_integration) | git::https://github.com/cloudposse/terraform-aws-datadog-integration.git | tags/0.6.1 |
+| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
+| <a name="module_this"></a> [this](#module\_this) | git::https://github.com/cloudposse/terraform-null-label.git | tags/0.21.0 |
 
 ## Resources
 

--- a/modules/datadog-monitor/README.md
+++ b/modules/datadog-monitor/README.md
@@ -44,10 +44,10 @@ components:
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_datadog_monitors"></a> [datadog\_monitors](#module\_datadog\_monitors) | git::https://github.com/cloudposse/terraform-datadog-monitor.git?ref=tags/0.9.0 |  |
-| <a name="module_datadog_monitors_yaml_config"></a> [datadog\_monitors\_yaml\_config](#module\_datadog\_monitors\_yaml\_config) | git::https://github.com/cloudposse/terraform-yaml-config.git?ref=tags/0.1.0 |  |
-| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles |  |
-| <a name="module_this"></a> [this](#module\_this) | git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.21.0 |  |
+| <a name="module_datadog_monitors"></a> [datadog\_monitors](#module\_datadog\_monitors) | git::https://github.com/cloudposse/terraform-datadog-monitor.git | tags/0.9.0 |
+| <a name="module_datadog_monitors_yaml_config"></a> [datadog\_monitors\_yaml\_config](#module\_datadog\_monitors\_yaml\_config) | git::https://github.com/cloudposse/terraform-yaml-config.git | tags/0.1.0 |
+| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
+| <a name="module_this"></a> [this](#module\_this) | git::https://github.com/cloudposse/terraform-null-label.git | tags/0.21.0 |
 
 ## Resources
 

--- a/modules/dns-delegated/README.md
+++ b/modules/dns-delegated/README.md
@@ -41,8 +41,8 @@ components:
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles |  |
-| <a name="module_this"></a> [this](#module\_this) | git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.21.0 |  |
+| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
+| <a name="module_this"></a> [this](#module\_this) | git::https://github.com/cloudposse/terraform-null-label.git | tags/0.21.0 |
 
 ## Resources
 

--- a/modules/dns-primary/README.md
+++ b/modules/dns-primary/README.md
@@ -53,8 +53,8 @@ components:
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles |  |
-| <a name="module_this"></a> [this](#module\_this) | git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.21.0 |  |
+| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
+| <a name="module_this"></a> [this](#module\_this) | git::https://github.com/cloudposse/terraform-null-label.git | tags/0.21.0 |
 
 ## Resources
 

--- a/modules/ecr/README.md
+++ b/modules/ecr/README.md
@@ -62,11 +62,11 @@ components:
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_ecr"></a> [ecr](#module\_ecr) | git::https://github.com/cloudposse/terraform-aws-ecr.git?ref=tags/0.29.0 |  |
-| <a name="module_full_access"></a> [full\_access](#module\_full\_access) | ../account-map/modules/roles-to-principals |  |
-| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles |  |
-| <a name="module_readonly_access"></a> [readonly\_access](#module\_readonly\_access) | ../account-map/modules/roles-to-principals |  |
-| <a name="module_this"></a> [this](#module\_this) | git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.21.0 |  |
+| <a name="module_ecr"></a> [ecr](#module\_ecr) | git::https://github.com/cloudposse/terraform-aws-ecr.git | tags/0.29.0 |
+| <a name="module_full_access"></a> [full\_access](#module\_full\_access) | ../account-map/modules/roles-to-principals | n/a |
+| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
+| <a name="module_readonly_access"></a> [readonly\_access](#module\_readonly\_access) | ../account-map/modules/roles-to-principals | n/a |
+| <a name="module_this"></a> [this](#module\_this) | git::https://github.com/cloudposse/terraform-null-label.git | tags/0.21.0 |
 
 ## Resources
 

--- a/modules/efs/README.md
+++ b/modules/efs/README.md
@@ -39,10 +39,10 @@ components:
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_efs"></a> [efs](#module\_efs) | git::https://github.com/cloudposse/terraform-aws-efs.git?ref=tags/0.21.0 |  |
-| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles |  |
-| <a name="module_kms_key_efs"></a> [kms\_key\_efs](#module\_kms\_key\_efs) | git::https://github.com/cloudposse/terraform-aws-kms-key.git?ref=tags/0.7.0 |  |
-| <a name="module_this"></a> [this](#module\_this) | git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.21.0 |  |
+| <a name="module_efs"></a> [efs](#module\_efs) | git::https://github.com/cloudposse/terraform-aws-efs.git | tags/0.21.0 |
+| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
+| <a name="module_kms_key_efs"></a> [kms\_key\_efs](#module\_kms\_key\_efs) | git::https://github.com/cloudposse/terraform-aws-kms-key.git | tags/0.7.0 |
+| <a name="module_this"></a> [this](#module\_this) | git::https://github.com/cloudposse/terraform-null-label.git | tags/0.21.0 |
 
 ## Resources
 

--- a/modules/eks-iam/README.md
+++ b/modules/eks-iam/README.md
@@ -45,12 +45,12 @@ components:
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_alb-controller"></a> [alb-controller](#module\_alb-controller) | ./modules/service-account |  |
-| <a name="module_autoscaler"></a> [autoscaler](#module\_autoscaler) | ./modules/service-account |  |
-| <a name="module_cert-manager"></a> [cert-manager](#module\_cert-manager) | ./modules/service-account |  |
-| <a name="module_external-dns"></a> [external-dns](#module\_external-dns) | ./modules/service-account |  |
-| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles |  |
-| <a name="module_this"></a> [this](#module\_this) | git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.21.0 |  |
+| <a name="module_alb-controller"></a> [alb-controller](#module\_alb-controller) | ./modules/service-account | n/a |
+| <a name="module_autoscaler"></a> [autoscaler](#module\_autoscaler) | ./modules/service-account | n/a |
+| <a name="module_cert-manager"></a> [cert-manager](#module\_cert-manager) | ./modules/service-account | n/a |
+| <a name="module_external-dns"></a> [external-dns](#module\_external-dns) | ./modules/service-account | n/a |
+| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
+| <a name="module_this"></a> [this](#module\_this) | git::https://github.com/cloudposse/terraform-null-label.git | tags/0.21.0 |
 
 ## Resources
 

--- a/modules/eks/README.md
+++ b/modules/eks/README.md
@@ -56,10 +56,10 @@ components:
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_eks_cluster"></a> [eks\_cluster](#module\_eks\_cluster) | git::https://github.com/cloudposse/terraform-aws-eks-cluster.git?ref=tags/0.29.0 |  |
-| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles |  |
-| <a name="module_region_node_group"></a> [region\_node\_group](#module\_region\_node\_group) | ./modules/node_group_by_region |  |
-| <a name="module_this"></a> [this](#module\_this) | git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.21.0 |  |
+| <a name="module_eks_cluster"></a> [eks\_cluster](#module\_eks\_cluster) | git::https://github.com/cloudposse/terraform-aws-eks-cluster.git | tags/0.29.0 |
+| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
+| <a name="module_region_node_group"></a> [region\_node\_group](#module\_region\_node\_group) | ./modules/node_group_by_region | n/a |
+| <a name="module_this"></a> [this](#module\_this) | git::https://github.com/cloudposse/terraform-null-label.git | tags/0.21.0 |
 
 ## Resources
 

--- a/modules/elasticache-redis/README.md
+++ b/modules/elasticache-redis/README.md
@@ -81,8 +81,8 @@ No providers.
 |------|--------|---------|
 | <a name="module_dns_delegated"></a> [dns\_delegated](#module\_dns\_delegated) | cloudposse/stack-config/yaml//modules/remote-state | 0.13.0 |
 | <a name="module_eks"></a> [eks](#module\_eks) | cloudposse/stack-config/yaml//modules/remote-state | 0.13.0 |
-| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles |  |
-| <a name="module_redis_clusters"></a> [redis\_clusters](#module\_redis\_clusters) | ./modules/redis_cluster |  |
+| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
+| <a name="module_redis_clusters"></a> [redis\_clusters](#module\_redis\_clusters) | ./modules/redis_cluster | n/a |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.24.1 |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | cloudposse/stack-config/yaml//modules/remote-state | 0.13.0 |
 

--- a/modules/iam-delegated-roles/README.md
+++ b/modules/iam-delegated-roles/README.md
@@ -48,9 +48,9 @@ components:
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles |  |
-| <a name="module_label"></a> [label](#module\_label) | git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.21.0 |  |
-| <a name="module_this"></a> [this](#module\_this) | git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.21.0 |  |
+| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
+| <a name="module_label"></a> [label](#module\_label) | git::https://github.com/cloudposse/terraform-null-label.git | tags/0.21.0 |
+| <a name="module_this"></a> [this](#module\_this) | git::https://github.com/cloudposse/terraform-null-label.git | tags/0.21.0 |
 
 ## Resources
 

--- a/modules/iam-primary-roles/README.md
+++ b/modules/iam-primary-roles/README.md
@@ -122,8 +122,8 @@ components:
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles |  |
-| <a name="module_this"></a> [this](#module\_this) | git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.21.0 |  |
+| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
+| <a name="module_this"></a> [this](#module\_this) | git::https://github.com/cloudposse/terraform-null-label.git | tags/0.21.0 |
 
 ## Resources
 

--- a/modules/opsgenie/README.md
+++ b/modules/opsgenie/README.md
@@ -91,9 +91,9 @@ components:
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles |  |
-| <a name="module_opsgenie_config"></a> [opsgenie\_config](#module\_opsgenie\_config) | git::https://github.com/cloudposse/terraform-opsgenie-incident-management.git//modules/config?ref=0.9.0 |  |
-| <a name="module_this"></a> [this](#module\_this) | git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.21.0 |  |
+| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
+| <a name="module_opsgenie_config"></a> [opsgenie\_config](#module\_opsgenie\_config) | git::https://github.com/cloudposse/terraform-opsgenie-incident-management.git//modules/config | 0.9.0 |
+| <a name="module_this"></a> [this](#module\_this) | git::https://github.com/cloudposse/terraform-null-label.git | tags/0.21.0 |
 
 ## Resources
 

--- a/modules/spacelift-worker-pool/README.md
+++ b/modules/spacelift-worker-pool/README.md
@@ -68,7 +68,7 @@ _HINT_: The API key ID is displayed as an upper-case, 16-character alphanumeric 
 |------|--------|---------|
 | <a name="module_account_map"></a> [account\_map](#module\_account\_map) | cloudposse/stack-config/yaml//modules/remote-state | 0.13.0 |
 | <a name="module_ecr"></a> [ecr](#module\_ecr) | cloudposse/stack-config/yaml//modules/remote-state | 0.14.0 |
-| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles |  |
+| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
 | <a name="module_spacelift_ec2_workerpool"></a> [spacelift\_ec2\_workerpool](#module\_spacelift\_ec2\_workerpool) | spacelift.io/spacelift-io/spacelift-workerpool-on-ec2/aws | 1.0.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.24.1 |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | cloudposse/stack-config/yaml//modules/remote-state | 0.13.0 |

--- a/modules/sso/README.md
+++ b/modules/sso/README.md
@@ -40,8 +40,8 @@ components:
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles |  |
-| <a name="module_this"></a> [this](#module\_this) | git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.21.0 |  |
+| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
+| <a name="module_this"></a> [this](#module\_this) | git::https://github.com/cloudposse/terraform-null-label.git | tags/0.21.0 |
 
 ## Resources
 

--- a/modules/tfstate-backend/README.md
+++ b/modules/tfstate-backend/README.md
@@ -37,8 +37,8 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_tfstate_backend"></a> [tfstate\_backend](#module\_tfstate\_backend) | git::https://github.com/cloudposse/terraform-aws-tfstate-backend.git?ref=tags/0.28.0 |  |
-| <a name="module_this"></a> [this](#module\_this) | git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.21.0 |  |
+| <a name="module_tfstate_backend"></a> [tfstate\_backend](#module\_tfstate\_backend) | git::https://github.com/cloudposse/terraform-aws-tfstate-backend.git | tags/0.28.0 |
+| <a name="module_this"></a> [this](#module\_this) | git::https://github.com/cloudposse/terraform-null-label.git | tags/0.21.0 |
 
 ## Resources
 

--- a/modules/transit-gateway/README.md
+++ b/modules/transit-gateway/README.md
@@ -69,13 +69,13 @@ components:
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles |  |
-| <a name="module_iam_roles_tgw"></a> [iam\_roles\_tgw](#module\_iam\_roles\_tgw) | ../account-map/modules/iam-roles |  |
-| <a name="module_tgw_vpc_attachment_dev"></a> [tgw\_vpc\_attachment\_dev](#module\_tgw\_vpc\_attachment\_dev) | ./modules/standard_vpc_attachment |  |
-| <a name="module_tgw_vpc_attachment_prod"></a> [tgw\_vpc\_attachment\_prod](#module\_tgw\_vpc\_attachment\_prod) | ./modules/standard_vpc_attachment |  |
-| <a name="module_tgw_vpc_attachment_staging"></a> [tgw\_vpc\_attachment\_staging](#module\_tgw\_vpc\_attachment\_staging) | ./modules/standard_vpc_attachment |  |
-| <a name="module_this"></a> [this](#module\_this) | git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.21.0 |  |
-| <a name="module_transit_gateway"></a> [transit\_gateway](#module\_transit\_gateway) | git::https://github.com/cloudposse/terraform-aws-transit-gateway.git?ref=tags/0.2.1 |  |
+| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
+| <a name="module_iam_roles_tgw"></a> [iam\_roles\_tgw](#module\_iam\_roles\_tgw) | ../account-map/modules/iam-roles | n/a |
+| <a name="module_tgw_vpc_attachment_dev"></a> [tgw\_vpc\_attachment\_dev](#module\_tgw\_vpc\_attachment\_dev) | ./modules/standard_vpc_attachment | n/a |
+| <a name="module_tgw_vpc_attachment_prod"></a> [tgw\_vpc\_attachment\_prod](#module\_tgw\_vpc\_attachment\_prod) | ./modules/standard_vpc_attachment | n/a |
+| <a name="module_tgw_vpc_attachment_staging"></a> [tgw\_vpc\_attachment\_staging](#module\_tgw\_vpc\_attachment\_staging) | ./modules/standard_vpc_attachment | n/a |
+| <a name="module_this"></a> [this](#module\_this) | git::https://github.com/cloudposse/terraform-null-label.git | tags/0.21.0 |
+| <a name="module_transit_gateway"></a> [transit\_gateway](#module\_transit\_gateway) | git::https://github.com/cloudposse/terraform-aws-transit-gateway.git | tags/0.2.1 |
 
 ## Resources
 

--- a/modules/vpc/README.md
+++ b/modules/vpc/README.md
@@ -39,10 +39,10 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles |  |
-| <a name="module_subnets"></a> [subnets](#module\_subnets) | git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.31.0 |  |
-| <a name="module_this"></a> [this](#module\_this) | git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.21.0 |  |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.18.0 |  |
+| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
+| <a name="module_subnets"></a> [subnets](#module\_subnets) | git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git | tags/0.31.0 |
+| <a name="module_this"></a> [this](#module\_this) | git::https://github.com/cloudposse/terraform-null-label.git | tags/0.21.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | git::https://github.com/cloudposse/terraform-aws-vpc.git | tags/0.18.0 |
 
 ## Resources
 


### PR DESCRIPTION
## what
* Used latest pre-commit.yml to fix terraform-docs install
* Ran `pre-commit run --all-files` locally using the same version of `terraform-docs` to pass the tests.

## why
* The pre-commit install step seems broken in recent PRs and this should fix it by using the latest pre-commit workflow

## references
* Blocks PR https://github.com/cloudposse/terraform-aws-components/pull/326

