### PR TITLE
feat: Upstream `elasticsearch` component

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 <!-- markdownlint-disable -->
 # terraform-aws-components [![Latest Release](https://img.shields.io/github/release/cloudposse/terraform-aws-components.svg)](https://github.com/cloudposse/terraform-aws-components/releases/latest) [![Slack Community](https://slack.cloudposse.com/badge.svg)](https://slack.cloudposse.com)
 <!-- markdownlint-restore -->
@@ -28,7 +29,6 @@
 -->
 
 This is a collection of reusable Terraform components and blueprints for provisioning reference architectures.
-
 
 ---
 
@@ -94,6 +94,7 @@ make rebuild-docs
 
 
 
+
 ## Usage
 
 
@@ -136,6 +137,7 @@ Available targets:
   help/all                            Display help for all targets
   help/short                          This help short screen
   rebuild-docs                        Rebuild README for all Terraform components
+  upstream-component                  Upstream a given component
 
 ```
 <!-- markdownlint-restore -->
@@ -174,6 +176,7 @@ Like this project? Please give it a ★ on [our GitHub](https://github.com/cloud
 Are you using this project or any of our other projects? Consider [leaving a testimonial][testimonial]. =)
 
 
+
 ## Related Projects
 
 Check out these related projects.
@@ -183,8 +186,6 @@ Check out these related projects.
 - [prod.cloudposse.co](https://github.com/cloudposse/prod.cloudposse.co) - Example Terraform Reference Architecture of a Geodesic Module for a Production Organization in AWS.
 - [staging.cloudposse.co](https://github.com/cloudposse/staging.cloudposse.co) - Example Terraform Reference Architecture of a Geodesic Module for a Staging Organization in AWS.
 - [dev.cloudposse.co](https://github.com/cloudposse/dev.cloudposse.co) - Example Terraform Reference Architecture of a Geodesic Module for a Development Sandbox Organization in AWS.
-
-
 
 
 ## References

--- a/docs/targets.md
+++ b/docs/targets.md
@@ -7,6 +7,7 @@ Available targets:
   help/all                            Display help for all targets
   help/short                          This help short screen
   rebuild-docs                        Rebuild README for all Terraform components
+  upstream-component                  Upstream a given component
 
 ```
 <!-- markdownlint-restore -->

--- a/modules/elasticsearch/README.md
+++ b/modules/elasticsearch/README.md
@@ -1,0 +1,117 @@
+# Component: `elasticsearch`
+
+This component is responsible for provisioning an Elasticsearch cluster with built-in integrations with Kibana and Logstash.
+
+## Usage
+
+**Stack Level**: Regional
+
+Here's an example snippet for how to use this component.
+
+```yaml
+components:
+  terraform:
+    elasticache-redis:
+      vars:
+        enabled: true
+        instance_type: "t3.medium.elasticsearch"
+        elasticsearch_version: "7.9"
+        encrypt_at_rest_enabled: false
+        dedicated_master_enabled: false
+        elasticsearch_subdomain_name: "es"
+        kibana_subdomain_name: "kibana"
+        ebs_volume_size: 40
+        create_iam_service_linked_role: true
+        kibana_hostname_enabled: true
+        domain_hostname_enabled: true
+```
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.8 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
+| <a name="requirement_template"></a> [template](#requirement\_template) | >= 2.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.8 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_dns_delegated"></a> [dns\_delegated](#module\_dns\_delegated) | cloudposse/stack-config/yaml//modules/remote-state | 0.17.0 |
+| <a name="module_elasticsearch"></a> [elasticsearch](#module\_elasticsearch) | cloudposse/elasticsearch/aws | 0.33.0 |
+| <a name="module_elasticsearch_log_cleanup"></a> [elasticsearch\_log\_cleanup](#module\_elasticsearch\_log\_cleanup) | cloudposse/lambda-elasticsearch-cleanup/aws | 0.12.3 |
+| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
+| <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.24.1 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | cloudposse/stack-config/yaml//modules/remote-state | 0.17.0 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_ssm_parameter.admin_password](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.elasticsearch_domain_endpoint](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.elasticsearch_kibana_endpoint](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
+| <a name="input_attributes"></a> [attributes](#input\_attributes) | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
+| <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
+| <a name="input_create_iam_service_linked_role"></a> [create\_iam\_service\_linked\_role](#input\_create\_iam\_service\_linked\_role) | Whether to create `AWSServiceRoleForAmazonElasticsearchService` service-linked role. Set it to `false` if you already have an ElasticSearch cluster created in the AWS account and AWSServiceRoleForAmazonElasticsearchService already exists. See https://github.com/terraform-providers/terraform-provider-aws/issues/5218 for more info | `bool` | n/a | yes |
+| <a name="input_dedicated_master_enabled"></a> [dedicated\_master\_enabled](#input\_dedicated\_master\_enabled) | Indicates whether dedicated master nodes are enabled for the cluster | `bool` | n/a | yes |
+| <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
+| <a name="input_domain_hostname_enabled"></a> [domain\_hostname\_enabled](#input\_domain\_hostname\_enabled) | Explicit flag to enable creating a DNS hostname for ES. If `true`, then `var.dns_zone_id` is required. | `bool` | n/a | yes |
+| <a name="input_ebs_volume_size"></a> [ebs\_volume\_size](#input\_ebs\_volume\_size) | EBS volumes for data storage in GB | `number` | n/a | yes |
+| <a name="input_elasticsearch_iam_actions"></a> [elasticsearch\_iam\_actions](#input\_elasticsearch\_iam\_actions) | List of actions to allow for the IAM roles, _e.g._ `es:ESHttpGet`, `es:ESHttpPut`, `es:ESHttpPost` | `list(string)` | <pre>[<br>  "es:ESHttpGet",<br>  "es:ESHttpPut",<br>  "es:ESHttpPost",<br>  "es:ESHttpHead",<br>  "es:Describe*",<br>  "es:List*"<br>]</pre> | no |
+| <a name="input_elasticsearch_iam_role_arns"></a> [elasticsearch\_iam\_role\_arns](#input\_elasticsearch\_iam\_role\_arns) | List of additional IAM role ARNs to permit access to the Elasticsearch domain | `list(string)` | `[]` | no |
+| <a name="input_elasticsearch_subdomain_name"></a> [elasticsearch\_subdomain\_name](#input\_elasticsearch\_subdomain\_name) | The name of the subdomain for Elasticsearch in the DNS zone (\_e.g.\_ `elasticsearch`, `ui`, `ui-es`, `search-ui`) | `string` | n/a | yes |
+| <a name="input_elasticsearch_version"></a> [elasticsearch\_version](#input\_elasticsearch\_version) | Version of Elasticsearch to deploy (\_e.g.\_ `7.1`, `6.8`, `6.7`, `6.5`, `6.4`, `6.3`, `6.2`, `6.0`, `5.6`, `5.5`, `5.3`, `5.1`, `2.3`, `1.5` | `string` | n/a | yes |
+| <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
+| <a name="input_encrypt_at_rest_enabled"></a> [encrypt\_at\_rest\_enabled](#input\_encrypt\_at\_rest\_enabled) | Whether to enable encryption at rest | `bool` | n/a | yes |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
+| <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
+| <a name="input_import_profile_name"></a> [import\_profile\_name](#input\_import\_profile\_name) | IAM Profile to use when importing a resource | `string` | `null` | no |
+| <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | The type of the instance | `string` | n/a | yes |
+| <a name="input_kibana_hostname_enabled"></a> [kibana\_hostname\_enabled](#input\_kibana\_hostname\_enabled) | Explicit flag to enable creating a DNS hostname for Kibana. If `true`, then `var.dns_zone_id` is required. | `bool` | n/a | yes |
+| <a name="input_kibana_subdomain_name"></a> [kibana\_subdomain\_name](#input\_kibana\_subdomain\_name) | The name of the subdomain for Kibana in the DNS zone (\_e.g.\_ `kibana`, `ui`, `ui-es`, `search-ui`, `kibana.elasticsearch`) | `string` | n/a | yes |
+| <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | The letter case of label keys (`tag` names) (i.e. `name`, `namespace`, `environment`, `stage`, `attributes`) to use in `tags`.<br>Possible values: `lower`, `title`, `upper`.<br>Default value: `title`. | `string` | `null` | no |
+| <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
+| <a name="input_label_value_case"></a> [label\_value\_case](#input\_label\_value\_case) | The letter case of output label values (also used in `tags` and `id`).<br>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br>Default value: `lower`. | `string` | `null` | no |
+| <a name="input_name"></a> [name](#input\_name) | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
+| <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
+| <a name="input_region"></a> [region](#input\_region) | AWS region | `string` | n/a | yes |
+| <a name="input_stage"></a> [stage](#input\_stage) | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_domain_arn"></a> [domain\_arn](#output\_domain\_arn) | ARN of the Elasticsearch domain |
+| <a name="output_domain_endpoint"></a> [domain\_endpoint](#output\_domain\_endpoint) | Domain-specific endpoint used to submit index, search, and data upload requests |
+| <a name="output_domain_hostname"></a> [domain\_hostname](#output\_domain\_hostname) | Elasticsearch domain hostname to submit index, search, and data upload requests |
+| <a name="output_domain_id"></a> [domain\_id](#output\_domain\_id) | Unique identifier for the Elasticsearch domain |
+| <a name="output_elasticsearch_user_iam_role_arn"></a> [elasticsearch\_user\_iam\_role\_arn](#output\_elasticsearch\_user\_iam\_role\_arn) | The ARN of the IAM role to allow access to Elasticsearch cluster |
+| <a name="output_elasticsearch_user_iam_role_name"></a> [elasticsearch\_user\_iam\_role\_name](#output\_elasticsearch\_user\_iam\_role\_name) | The name of the IAM role to allow access to Elasticsearch cluster |
+| <a name="output_kibana_endpoint"></a> [kibana\_endpoint](#output\_kibana\_endpoint) | Domain-specific endpoint for Kibana without https scheme |
+| <a name="output_kibana_hostname"></a> [kibana\_hostname](#output\_kibana\_hostname) | Kibana hostname |
+| <a name="output_master_password_ssm_key"></a> [master\_password\_ssm\_key](#output\_master\_password\_ssm\_key) | SSM key of Elasticsearch master password |
+| <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | Security Group ID to control access to the Elasticsearch domain |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+## References
+* [cloudposse/terraform-aws-components](https://github.com/cloudposse/terraform-aws-components/tree/master/modules/TODO) - Cloud Posse's upstream component
+
+[<img src="https://cloudposse.com/logo-300x69.svg" height="32" align="right"/>](https://cpco.io/component)

--- a/modules/elasticsearch/context.tf
+++ b/modules/elasticsearch/context.tf
@@ -1,0 +1,202 @@
+#
+# ONLY EDIT THIS FILE IN github.com/cloudposse/terraform-null-label
+# All other instances of this file should be a copy of that one
+#
+#
+# Copy this file from https://github.com/cloudposse/terraform-null-label/blob/master/exports/context.tf
+# and then place it in your Terraform module to automatically get
+# Cloud Posse's standard configuration inputs suitable for passing
+# to Cloud Posse modules.
+#
+# Modules should access the whole context as `module.this.context`
+# to get the input variables with nulls for defaults,
+# for example `context = module.this.context`,
+# and access individual variables as `module.this.<var>`,
+# with final values filled in.
+#
+# For example, when using defaults, `module.this.context.delimiter`
+# will be null, and `module.this.delimiter` will be `-` (hyphen).
+#
+
+module "this" {
+  source  = "cloudposse/label/null"
+  version = "0.24.1" # requires Terraform >= 0.13.0
+
+  enabled             = var.enabled
+  namespace           = var.namespace
+  environment         = var.environment
+  stage               = var.stage
+  name                = var.name
+  delimiter           = var.delimiter
+  attributes          = var.attributes
+  tags                = var.tags
+  additional_tag_map  = var.additional_tag_map
+  label_order         = var.label_order
+  regex_replace_chars = var.regex_replace_chars
+  id_length_limit     = var.id_length_limit
+  label_key_case      = var.label_key_case
+  label_value_case    = var.label_value_case
+
+  context = var.context
+}
+
+# Copy contents of cloudposse/terraform-null-label/variables.tf here
+
+variable "context" {
+  type = any
+  default = {
+    enabled             = true
+    namespace           = null
+    environment         = null
+    stage               = null
+    name                = null
+    delimiter           = null
+    attributes          = []
+    tags                = {}
+    additional_tag_map  = {}
+    regex_replace_chars = null
+    label_order         = []
+    id_length_limit     = null
+    label_key_case      = null
+    label_value_case    = null
+  }
+  description = <<-EOT
+    Single object for setting entire context at once.
+    See description of individual variables for details.
+    Leave string and numeric variables as `null` to use default value.
+    Individual variable settings (non-null) override settings in context object,
+    except for attributes, tags, and additional_tag_map, which are merged.
+  EOT
+
+  validation {
+    condition     = lookup(var.context, "label_key_case", null) == null ? true : contains(["lower", "title", "upper"], var.context["label_key_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+
+  validation {
+    condition     = lookup(var.context, "label_value_case", null) == null ? true : contains(["lower", "title", "upper", "none"], var.context["label_value_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+variable "enabled" {
+  type        = bool
+  default     = null
+  description = "Set to false to prevent the module from creating any resources"
+}
+
+variable "namespace" {
+  type        = string
+  default     = null
+  description = "Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp'"
+}
+
+variable "environment" {
+  type        = string
+  default     = null
+  description = "Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT'"
+}
+
+variable "stage" {
+  type        = string
+  default     = null
+  description = "Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release'"
+}
+
+variable "name" {
+  type        = string
+  default     = null
+  description = "Solution name, e.g. 'app' or 'jenkins'"
+}
+
+variable "delimiter" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.
+    Defaults to `-` (hyphen). Set to `""` to use no delimiter at all.
+  EOT
+}
+
+variable "attributes" {
+  type        = list(string)
+  default     = []
+  description = "Additional attributes (e.g. `1`)"
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = "Additional tags (e.g. `map('BusinessUnit','XYZ')`"
+}
+
+variable "additional_tag_map" {
+  type        = map(string)
+  default     = {}
+  description = "Additional tags for appending to tags_as_list_of_maps. Not added to `tags`."
+}
+
+variable "label_order" {
+  type        = list(string)
+  default     = null
+  description = <<-EOT
+    The naming order of the id output and Name tag.
+    Defaults to ["namespace", "environment", "stage", "name", "attributes"].
+    You can omit any of the 5 elements, but at least one must be present.
+  EOT
+}
+
+variable "regex_replace_chars" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.
+    If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits.
+  EOT
+}
+
+variable "id_length_limit" {
+  type        = number
+  default     = null
+  description = <<-EOT
+    Limit `id` to this many characters (minimum 6).
+    Set to `0` for unlimited length.
+    Set to `null` for default, which is `0`.
+    Does not affect `id_full`.
+  EOT
+  validation {
+    condition     = var.id_length_limit == null ? true : var.id_length_limit >= 6 || var.id_length_limit == 0
+    error_message = "The id_length_limit must be >= 6 if supplied (not null), or 0 for unlimited length."
+  }
+}
+
+variable "label_key_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    The letter case of label keys (`tag` names) (i.e. `name`, `namespace`, `environment`, `stage`, `attributes`) to use in `tags`.
+    Possible values: `lower`, `title`, `upper`.
+    Default value: `title`.
+  EOT
+
+  validation {
+    condition     = var.label_key_case == null ? true : contains(["lower", "title", "upper"], var.label_key_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+}
+
+variable "label_value_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    The letter case of output label values (also used in `tags` and `id`).
+    Possible values: `lower`, `title`, `upper` and `none` (no transformation).
+    Default value: `lower`.
+  EOT
+
+  validation {
+    condition     = var.label_value_case == null ? true : contains(["lower", "title", "upper", "none"], var.label_value_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+#### End of copy of cloudposse/terraform-null-label/variables.tf

--- a/modules/elasticsearch/default.auto.tfvars
+++ b/modules/elasticsearch/default.auto.tfvars
@@ -1,0 +1,41 @@
+enabled = false
+
+name = "es"
+
+instance_type = "t3.medium.elasticsearch"
+
+elasticsearch_version = "7.9"
+
+# calculated: length(local.vpc_private_subnet_ids)
+# instance_count = 2
+
+# calculated: length(local.vpc_private_subnet_ids) > 1 ? true : false
+# zone_awareness_enabled = true
+
+encrypt_at_rest_enabled = false
+
+dedicated_master_enabled = false
+
+elasticsearch_subdomain_name = "es"
+
+kibana_subdomain_name = "kibana"
+
+ebs_volume_size = 40
+
+create_iam_service_linked_role = true
+
+kibana_hostname_enabled = true
+
+domain_hostname_enabled = true
+
+# Allow anonymous access without request signing, relying on network access controls
+# https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-ac.html#es-ac-types-ip
+# https://aws.amazon.com/premiumsupport/knowledge-center/anonymous-not-authorized-elasticsearch/
+elasticsearch_iam_role_arns = [
+  "*",
+]
+elasticsearch_iam_actions = [
+  "es:ESHttpGet", "es:ESHttpPut", "es:ESHttpPost", "es:ESHttpHead", "es:Describe*", "es:List*",
+  // delete and patch are destructive and could be left out
+  "es:ESHttpDelete", "es:ESHttpPatch"
+]

--- a/modules/elasticsearch/main.tf
+++ b/modules/elasticsearch/main.tf
@@ -27,7 +27,7 @@ module "elasticsearch" {
   instance_type                  = var.instance_type
   instance_count                 = length(local.vpc_private_subnet_ids)
   availability_zone_count        = length(local.vpc_private_subnet_ids)
-  encrypt_at_rest_enabled        = true //var.encrypt_at_rest_enabled
+  encrypt_at_rest_enabled        = var.encrypt_at_rest_enabled
   dedicated_master_enabled       = var.dedicated_master_enabled
   create_iam_service_linked_role = var.create_iam_service_linked_role
   kibana_subdomain_name          = module.this.environment

--- a/modules/elasticsearch/main.tf
+++ b/modules/elasticsearch/main.tf
@@ -1,0 +1,110 @@
+locals {
+  enabled = module.this.enabled
+
+  dns_zone_id                   = module.dns_delegated.outputs.default_dns_zone_id
+  vpc_id                        = module.vpc.outputs.vpc_id
+  vpc_default_security_group    = module.vpc.outputs.vpc_default_security_group_id
+  vpc_private_subnet_ids        = module.vpc.outputs.private_subnet_ids
+  elasticsearch_domain_endpoint = format("/%s/%s/%s", "elasticsearch", module.this.name, "elasticsearch_domain_endpoint")
+  elasticsearch_kibana_endpoint = format("/%s/%s/%s", "elasticsearch", module.this.name, "elasticsearch_kibana_endpoint")
+  elasticsearch_admin_password  = format("/%s/%s/%s", "elasticsearch", module.this.name, "password")
+}
+
+locals {
+  create_password        = local.enabled && length(var.elasticsearch_password) == 0
+  elasticsearch_password = local.create_password ? join("", random_password.elasticsearch_password.*.result) : var.elasticsearch_password
+}
+
+module "elasticsearch" {
+  source  = "cloudposse/elasticsearch/aws"
+  version = "0.33.0"
+
+  security_groups                = [local.vpc_default_security_group]
+  vpc_id                         = local.vpc_id
+  subnet_ids                     = local.vpc_private_subnet_ids
+  zone_awareness_enabled         = length(local.vpc_private_subnet_ids) > 1 ? true : false
+  elasticsearch_version          = var.elasticsearch_version
+  instance_type                  = var.instance_type
+  instance_count                 = length(local.vpc_private_subnet_ids)
+  availability_zone_count        = length(local.vpc_private_subnet_ids)
+  encrypt_at_rest_enabled        = true //var.encrypt_at_rest_enabled
+  dedicated_master_enabled       = var.dedicated_master_enabled
+  create_iam_service_linked_role = var.create_iam_service_linked_role
+  kibana_subdomain_name          = module.this.environment
+  ebs_volume_size                = var.ebs_volume_size
+  dns_zone_id                    = local.dns_zone_id
+  kibana_hostname_enabled        = var.kibana_hostname_enabled
+  domain_hostname_enabled        = var.domain_hostname_enabled
+  iam_role_arns                  = var.elasticsearch_iam_role_arns
+  iam_actions                    = var.elasticsearch_iam_actions
+
+  node_to_node_encryption_enabled                          = true
+  advanced_security_options_enabled                        = true
+  advanced_security_options_internal_user_database_enabled = true
+  advanced_security_options_master_user_name               = "admin"
+  advanced_security_options_master_user_password           = local.elasticsearch_password
+
+  allowed_cidr_blocks = [module.vpc.outputs.vpc_cidr]
+
+  advanced_options = {
+    "rest.action.multi.allow_explicit_index" = "true"
+  }
+
+  context = module.this.context
+}
+
+resource "random_password" "elasticsearch_password" {
+  # character length
+  length = 33
+
+  special = true
+  upper   = true
+  lower   = true
+  number  = true
+
+  min_special = 1
+  min_upper   = 1
+  min_lower   = 1
+  min_numeric = 1
+}
+
+resource "aws_ssm_parameter" "admin_password" {
+  count       = local.enabled ? 1 : 0
+  name        = local.elasticsearch_admin_password
+  value       = local.elasticsearch_password
+  description = "Primary Aurora Postgres Password for the master DB user"
+  type        = "SecureString"
+  overwrite   = true
+}
+
+
+resource "aws_ssm_parameter" "elasticsearch_domain_endpoint" {
+  count       = local.enabled ? 1 : 0
+  name        = local.elasticsearch_domain_endpoint
+  value       = module.elasticsearch.domain_endpoint
+  description = "Domain-specific endpoint used to submit index, search, and data upload requests"
+  type        = "String"
+  overwrite   = true
+}
+
+resource "aws_ssm_parameter" "elasticsearch_kibana_endpoint" {
+  count       = local.enabled ? 1 : 0
+  name        = local.elasticsearch_kibana_endpoint
+  value       = module.elasticsearch.kibana_endpoint
+  description = "Domain-specific endpoint for Kibana without https scheme"
+  type        = "String"
+  overwrite   = true
+}
+
+module "elasticsearch_log_cleanup" {
+  source  = "cloudposse/lambda-elasticsearch-cleanup/aws"
+  version = "0.12.3"
+
+  es_endpoint          = module.elasticsearch.domain_endpoint
+  es_domain_arn        = module.elasticsearch.domain_arn
+  es_security_group_id = module.elasticsearch.security_group_id
+  vpc_id               = local.vpc_id
+  subnet_ids           = local.vpc_private_subnet_ids
+
+  context = module.this.context
+}

--- a/modules/elasticsearch/main.tf
+++ b/modules/elasticsearch/main.tf
@@ -5,9 +5,10 @@ locals {
   vpc_id                        = module.vpc.outputs.vpc_id
   vpc_default_security_group    = module.vpc.outputs.vpc_default_security_group_id
   vpc_private_subnet_ids        = module.vpc.outputs.private_subnet_ids
-  elasticsearch_domain_endpoint = format("/%s/%s/%s", "elasticsearch", module.this.name, "elasticsearch_domain_endpoint")
-  elasticsearch_kibana_endpoint = format("/%s/%s/%s", "elasticsearch", module.this.name, "elasticsearch_kibana_endpoint")
-  elasticsearch_admin_password  = format("/%s/%s/%s", "elasticsearch", module.this.name, "password")
+  elasticsearch_endpoint_format = "/elasticsearch/${module.this.name}/%s"
+  elasticsearch_domain_endpoint = format(local.elasticsearch_endpoint_format, "elasticsearch_domain_endpoint")
+  elasticsearch_kibana_endpoint = format(local.elasticsearch_endpoint_format, "elasticsearch_kibana_endpoint")
+  elasticsearch_admin_password  = format(local.elasticsearch_endpoint_format, "password")
 }
 
 locals {

--- a/modules/elasticsearch/outputs.tf
+++ b/modules/elasticsearch/outputs.tf
@@ -1,0 +1,49 @@
+output "security_group_id" {
+  value       = module.elasticsearch.security_group_id
+  description = "Security Group ID to control access to the Elasticsearch domain"
+}
+
+output "domain_arn" {
+  value       = module.elasticsearch.domain_arn
+  description = "ARN of the Elasticsearch domain"
+}
+
+output "domain_id" {
+  value       = module.elasticsearch.domain_id
+  description = "Unique identifier for the Elasticsearch domain"
+}
+
+output "domain_endpoint" {
+  value       = module.elasticsearch.domain_endpoint
+  description = "Domain-specific endpoint used to submit index, search, and data upload requests"
+}
+
+output "kibana_endpoint" {
+  value       = module.elasticsearch.kibana_endpoint
+  description = "Domain-specific endpoint for Kibana without https scheme"
+}
+
+output "domain_hostname" {
+  value       = module.elasticsearch.domain_hostname
+  description = "Elasticsearch domain hostname to submit index, search, and data upload requests"
+}
+
+output "kibana_hostname" {
+  value       = module.elasticsearch.kibana_hostname
+  description = "Kibana hostname"
+}
+
+output "elasticsearch_user_iam_role_name" {
+  value       = module.elasticsearch.elasticsearch_user_iam_role_name
+  description = "The name of the IAM role to allow access to Elasticsearch cluster"
+}
+
+output "elasticsearch_user_iam_role_arn" {
+  value       = module.elasticsearch.elasticsearch_user_iam_role_arn
+  description = "The ARN of the IAM role to allow access to Elasticsearch cluster"
+}
+
+output "master_password_ssm_key" {
+  value       = local.elasticsearch_admin_password
+  description = "SSM key of Elasticsearch master password"
+}

--- a/modules/elasticsearch/providers.tf
+++ b/modules/elasticsearch/providers.tf
@@ -1,0 +1,17 @@
+provider "aws" {
+  region = var.region
+
+  # `terraform import` will not use data from a data source, so on import we have to explicitly specify the profile
+  profile = coalesce(var.import_profile_name, module.iam_roles.terraform_profile_name)
+}
+
+module "iam_roles" {
+  source  = "../account-map/modules/iam-roles"
+  context = module.this.context
+}
+
+variable "import_profile_name" {
+  type        = string
+  default     = null
+  description = "IAM Profile to use when importing a resource"
+}

--- a/modules/elasticsearch/remote-state.tf
+++ b/modules/elasticsearch/remote-state.tf
@@ -1,0 +1,21 @@
+module "vpc" {
+  source  = "cloudposse/stack-config/yaml//modules/remote-state"
+  version = "0.17.0"
+
+  stack_config_local_path = "../../../stacks"
+  component               = "vpc"
+
+  context = module.this.context
+  enabled = true
+}
+
+module "dns_delegated" {
+  source  = "cloudposse/stack-config/yaml//modules/remote-state"
+  version = "0.17.0"
+
+  stack_config_local_path = "../../../stacks"
+  component               = "dns-delegated"
+
+  context = module.this.context
+  enabled = true
+}

--- a/modules/elasticsearch/variables.tf
+++ b/modules/elasticsearch/variables.tf
@@ -35,7 +35,11 @@ variable "kibana_subdomain_name" {
 
 variable "create_iam_service_linked_role" {
   type        = bool
-  description = "Whether to create `AWSServiceRoleForAmazonElasticsearchService` service-linked role. Set it to `false` if you already have an ElasticSearch cluster created in the AWS account and AWSServiceRoleForAmazonElasticsearchService already exists. See https://github.com/terraform-providers/terraform-provider-aws/issues/5218 for more info"
+  description = <<-EOT
+  Whether to create `AWSServiceRoleForAmazonElasticsearchService` service-linked role.
+  Set this to `false` if you already have an ElasticSearch cluster created in the AWS account and `AWSServiceRoleForAmazonElasticsearchService` already exists.
+  See https://github.com/terraform-providers/terraform-provider-aws/issues/5218 for more information.
+  EOT
 }
 
 variable "ebs_volume_size" {

--- a/modules/elasticsearch/variables.tf
+++ b/modules/elasticsearch/variables.tf
@@ -1,0 +1,85 @@
+variable "region" {
+  type        = string
+  description = "AWS region"
+}
+
+variable "instance_type" {
+  type        = string
+  description = "The type of the instance"
+}
+
+variable "elasticsearch_version" {
+  type        = string
+  description = "Version of Elasticsearch to deploy (_e.g._ `7.1`, `6.8`, `6.7`, `6.5`, `6.4`, `6.3`, `6.2`, `6.0`, `5.6`, `5.5`, `5.3`, `5.1`, `2.3`, `1.5`"
+}
+
+variable "encrypt_at_rest_enabled" {
+  type        = bool
+  description = "Whether to enable encryption at rest"
+}
+
+variable "dedicated_master_enabled" {
+  type        = bool
+  description = "Indicates whether dedicated master nodes are enabled for the cluster"
+}
+
+variable "elasticsearch_subdomain_name" {
+  type        = string
+  description = "The name of the subdomain for Elasticsearch in the DNS zone (_e.g._ `elasticsearch`, `ui`, `ui-es`, `search-ui`)"
+}
+
+variable "kibana_subdomain_name" {
+  type        = string
+  description = "The name of the subdomain for Kibana in the DNS zone (_e.g._ `kibana`, `ui`, `ui-es`, `search-ui`, `kibana.elasticsearch`)"
+}
+
+variable "create_iam_service_linked_role" {
+  type        = bool
+  description = "Whether to create `AWSServiceRoleForAmazonElasticsearchService` service-linked role. Set it to `false` if you already have an ElasticSearch cluster created in the AWS account and AWSServiceRoleForAmazonElasticsearchService already exists. See https://github.com/terraform-providers/terraform-provider-aws/issues/5218 for more info"
+}
+
+variable "ebs_volume_size" {
+  type        = number
+  description = "EBS volumes for data storage in GB"
+}
+
+variable "domain_hostname_enabled" {
+  type        = bool
+  description = "Explicit flag to enable creating a DNS hostname for ES. If `true`, then `var.dns_zone_id` is required."
+}
+
+variable "kibana_hostname_enabled" {
+  type        = bool
+  description = "Explicit flag to enable creating a DNS hostname for Kibana. If `true`, then `var.dns_zone_id` is required."
+}
+
+# https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-ac.html
+variable "elasticsearch_iam_actions" {
+  type        = list(string)
+  default     = ["es:ESHttpGet", "es:ESHttpPut", "es:ESHttpPost", "es:ESHttpHead", "es:Describe*", "es:List*"]
+  description = "List of actions to allow for the IAM roles, _e.g._ `es:ESHttpGet`, `es:ESHttpPut`, `es:ESHttpPost`"
+}
+
+variable "elasticsearch_iam_role_arns" {
+  type        = list(string)
+  default     = []
+  description = "List of additional IAM role ARNs to permit access to the Elasticsearch domain"
+}
+
+variable "elasticsearch_password" {
+  type        = string
+  description = "Password for the elasticsearch user"
+  default     = ""
+
+  # "sensitive" required Terraform 0.14 or later
+  #  sensitive   = true
+
+  validation {
+    condition = (
+      length(var.elasticsearch_password) == 0 ||
+      (length(var.elasticsearch_password) >= 8 &&
+      length(var.elasticsearch_password) <= 128)
+    )
+    error_message = "Password must be between 8 and 128 characters. If null is provided then a random password will be used."
+  }
+}

--- a/modules/elasticsearch/versions.tf
+++ b/modules/elasticsearch/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 0.13.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.8"
+    }
+    template = {
+      source  = "hashicorp/template"
+      version = ">= 2.0"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 2.0"
+    }
+  }
+}

--- a/modules/elasticsearch/versions.tf
+++ b/modules/elasticsearch/versions.tf
@@ -6,13 +6,5 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 3.8"
     }
-    template = {
-      source  = "hashicorp/template"
-      version = ">= 2.0"
-    }
-    null = {
-      source  = "hashicorp/null"
-      version = ">= 2.0"
-    }
   }
 }


### PR DESCRIPTION
## what
* Upstream `elasticsearch` component
* Bumped version from 0.30.0 to 0.33.0 (latest non pre-release)

## why
* Install kibana with a security group, iam role, and configured elasticsearch

## references
* https://github.com/cloudposse/terraform-aws-elasticsearch

## notes

To pass pre-commit hook

```shell
tfenv install 0.13.5
tfenv use 0.13.5
make readme
pre-commit run --show-diff-on-failure --color=always --all-files
git add modules/elasticsearch
```
