### PR TITLE
feat: Upgrade `cloudwatch-logs` to `0.4.3`

### DIFF
--- a/modules/cloudwatch-logs/README.md
+++ b/modules/cloudwatch-logs/README.md
@@ -40,7 +40,7 @@ components:
 |------|--------|---------|
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
 | <a name="module_kms_key_logs"></a> [kms\_key\_logs](#module\_kms\_key\_logs) | cloudposse/kms-key/aws | 0.10.0 |
-| <a name="module_logs"></a> [logs](#module\_logs) | cloudposse/cloudwatch-logs/aws | 0.4.2 |
+| <a name="module_logs"></a> [logs](#module\_logs) | cloudposse/cloudwatch-logs/aws | 0.4.3 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.24.1 |
 
 ## Resources

--- a/modules/cloudwatch-logs/main.tf
+++ b/modules/cloudwatch-logs/main.tf
@@ -6,7 +6,7 @@ data "aws_caller_identity" "current" {}
 
 module "logs" {
   source  = "cloudposse/cloudwatch-logs/aws"
-  version = "0.4.2"
+  version = "0.4.3"
 
   stream_names           = var.stream_names
   retention_in_days      = var.retention_in_days

--- a/modules/cloudwatch-logs/providers.tf
+++ b/modules/cloudwatch-logs/providers.tf
@@ -4,9 +4,10 @@ provider "aws" {
   # `terraform import` will not use data from a data source, so on import we have to explicitly specify the profile
   profile = coalesce(var.import_profile_name, module.iam_roles.terraform_profile_name)
 
-  default_tags {
-    tags = module.this.tags
-  }
+  # See issue: https://github.com/hashicorp/terraform-provider-aws/issues/18311
+  # default_tags {
+  #   tags = module.this.tags
+  # }
 }
 
 module "iam_roles" {


### PR DESCRIPTION
## what
* Upgrade `cloudwatch-logs` to `0.4.3`

## why
* This no longer has the dependency https://github.com/cloudposse/terraform-aws-iam-policy-document-aggregator/tree/master
* This issue was causing spacelift to show differences for each cloudwatch-logs stack

## references
* Previous PR https://github.com/cloudposse/terraform-aws-components/pull/344
* Upstream module PR https://github.com/cloudposse/terraform-aws-cloudwatch-logs/pull/16

