### PR TITLE
Pass `capacity_type` to the `terraform-aws-eks-node-group` module

### DIFF
--- a/modules/eks/default.auto.tfvars
+++ b/modules/eks/default.auto.tfvars
@@ -99,6 +99,7 @@ node_group_defaults = {
   disk_size                  = 100 # root EBS volume size in GB
   cluster_autoscaler_enabled = true
   instance_types             = ["t3.medium"]
+  capacity_type              = null
   ami_type                   = "AL2_x86_64"
   kubernetes_labels          = {}
   kubernetes_taints          = {}

--- a/modules/eks/eks-node-groups.tf
+++ b/modules/eks/eks-node-groups.tf
@@ -44,6 +44,7 @@ module "region_node_group" {
     disk_encryption_enabled    = each.value.disk_encryption_enabled == null ? var.node_group_defaults.disk_encryption_enabled : each.value.disk_encryption_enabled
     disk_size                  = each.value.disk_size == null ? var.node_group_defaults.disk_size : each.value.disk_size
     instance_types             = each.value.instance_types == null ? var.node_group_defaults.instance_types : each.value.instance_types
+    capacity_type              = each.value.capacity_type == null ? var.node_group_defaults.capacity_type : each.value.capacity_type
     kubernetes_labels          = each.value.kubernetes_labels == null ? var.node_group_defaults.kubernetes_labels : each.value.kubernetes_labels
     kubernetes_taints          = each.value.kubernetes_taints == null ? var.node_group_defaults.kubernetes_taints : each.value.kubernetes_taints
     kubernetes_version         = each.value.kubernetes_version == null ? local.node_group_default_kubernetes_version : each.value.kubernetes_version

--- a/modules/eks/modules/node_group_by_az/main.tf
+++ b/modules/eks/modules/node_group_by_az/main.tf
@@ -46,6 +46,7 @@ module "eks_node_group" {
   instance_types                          = local.enabled ? var.cluster_context.instance_types : null
   ami_type                                = local.enabled ? var.cluster_context.ami_type : null
   ami_release_version                     = local.enabled ? var.cluster_context.ami_release_version : null
+  capacity_type                           = local.enabled ? var.cluster_context.capacity_type : null
   kubernetes_labels                       = local.enabled ? var.cluster_context.kubernetes_labels : null
   kubernetes_taints                       = local.enabled ? var.cluster_context.kubernetes_taints : null
   kubernetes_version                      = local.enabled ? var.cluster_context.kubernetes_version : null

--- a/modules/eks/modules/node_group_by_az/variables.tf
+++ b/modules/eks/modules/node_group_by_az/variables.tf
@@ -21,6 +21,7 @@ variable "cluster_context" {
     disk_encryption_enabled    = bool
     disk_size                  = number
     instance_types             = list(string)
+    capacity_type              = string
     kubernetes_labels          = map(string)
     kubernetes_taints          = map(string)
     kubernetes_version         = string

--- a/modules/eks/modules/node_group_by_region/variables.tf
+++ b/modules/eks/modules/node_group_by_region/variables.tf
@@ -21,6 +21,7 @@ variable "cluster_context" {
     disk_encryption_enabled    = bool
     disk_size                  = number
     instance_types             = list(string)
+    capacity_type              = string
     kubernetes_labels          = map(string)
     kubernetes_taints          = map(string)
     kubernetes_version         = string

--- a/modules/eks/variables.tf
+++ b/modules/eks/variables.tf
@@ -170,6 +170,8 @@ variable "node_groups" {
     disk_size = number
     # Set of instance types associated with the EKS Node Group. Terraform will only perform drift detection if a configuration value is provided.
     instance_types = list(string)
+    # Type of EKS Node (can be either SPOT or ON_DEMAND)
+    capacity_type = string
     # Key-value mapping of Kubernetes labels. Only labels that are applied with the EKS API are managed by this argument. Other Kubernetes labels applied to the EKS Node Group will not be managed
     kubernetes_labels = map(string)
     # Key-value mapping of Kubernetes taints.
@@ -202,6 +204,7 @@ variable "node_group_defaults" {
     disk_encryption_enabled    = bool
     disk_size                  = number
     instance_types             = list(string)
+    capacity_type              = string
     kubernetes_labels          = map(string)
     kubernetes_taints          = map(string)
     kubernetes_version         = string # set to null to use cluster_kubernetes_version
@@ -222,6 +225,7 @@ variable "node_group_defaults" {
     disk_encryption_enabled    = true
     disk_size                  = 20
     instance_types             = ["t3.medium"]
+    capacity_type              = null
     kubernetes_labels          = null
     kubernetes_taints          = null
     kubernetes_version         = null # set to null to use cluster_kubernetes_version


### PR DESCRIPTION
## what

- Pass the `caacity_type` variable to the underlying `terraform-aws-eks-node-group` module

## why

- To enable the creation of spot-instance based node groups

