### PR TITLE
Feat: add `cert-manager` EKS component

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,7 @@ repos:
     rev: v2.3.0
     hooks:
       - id: check-yaml
+        exclude: modules/cert-manager/cert-manager-issuer/templates/.*.yaml
   - repo: git://github.com/antonbabenko/pre-commit-terraform
     rev: v1.48.0
     hooks:

--- a/modules/cert-manager/README.md
+++ b/modules/cert-manager/README.md
@@ -1,0 +1,122 @@
+# Component: `cert-manager`
+
+This component creates a Helm release for [cert-manager](https://github.com/jetstack/cert-manager) on a Kubernetes cluster. [cert-manager](https://github.com/jetstack/cert-manager) is a Kubernetes addon that provisions X.509 certificates.
+
+## Usage
+
+**Stack Level**: Regional
+
+Once the catalog file is created, the file can be imported as follows.
+
+```yaml
+import:
+  - catalog/eks/cert-manager
+  ...
+```
+
+The default catalog values `e.g. stacks/catalog/eks/cert-manager.yaml`
+
+```yaml
+components:
+  terraform:
+    cert-manager:
+      backend:
+        s3:
+          workspace_key_prefix: cert-manager
+      vars:
+        enabled: true
+        name: "cert-manager"
+        kubernetes_namespace: "cert-manager"
+        create_namespace: true
+
+        # use a local chart
+        cert_manager_issuer_chart: "./cert-manager-issuer/"
+        cert_manager_issuer_support_email_template: aws+%s@acme.com
+```
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_cert_manager"></a> [cert\_manager](#module\_cert\_manager) | cloudposse/helm-release/aws | 0.1.4 |
+| <a name="module_cert_manager_issuer"></a> [cert\_manager\_issuer](#module\_cert\_manager\_issuer) | cloudposse/helm-release/aws | 0.1.3 |
+| <a name="module_dns_delegated"></a> [dns\_delegated](#module\_dns\_delegated) | cloudposse/stack-config/yaml//modules/remote-state | 0.19.0 |
+| <a name="module_dns_gbl_delegated"></a> [dns\_gbl\_delegated](#module\_dns\_gbl\_delegated) | cloudposse/stack-config/yaml//modules/remote-state | 0.19.0 |
+| <a name="module_eks"></a> [eks](#module\_eks) | cloudposse/stack-config/yaml//modules/remote-state | 0.19.0 |
+| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
+| <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_eks_cluster.kubernetes](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster) | data source |
+| [aws_eks_cluster_auth.kubernetes](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster_auth) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br>This is for some rare cases where resources want additional configuration of tags<br>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
+| <a name="input_atomic"></a> [atomic](#input\_atomic) | If set, installation process purges chart on fail. The wait flag will be set automatically if atomic is used. | `bool` | `true` | no |
+| <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br>in the order they appear in the list. New attributes are appended to the<br>end of the list. The elements of the list are joined by the `delimiter`<br>and treated as a single ID element. | `list(string)` | `[]` | no |
+| <a name="input_cert_manager_chart"></a> [cert\_manager\_chart](#input\_cert\_manager\_chart) | Chart name to be installed. The chart name can be local path, a URL to a chart, or the name of the chart if `repository` is specified. It is also possible to use the `<repository>/<chart>` format here if you are running Terraform on a system that the repository has been added to with `helm repo add` but this is not recommended. | `string` | n/a | yes |
+| <a name="input_cert_manager_chart_version"></a> [cert\_manager\_chart\_version](#input\_cert\_manager\_chart\_version) | Specify the exact chart version to install. If this is not specified, the latest version is installed. | `string` | `null` | no |
+| <a name="input_cert_manager_description"></a> [cert\_manager\_description](#input\_cert\_manager\_description) | Set release description attribute (visible in the history). | `string` | `null` | no |
+| <a name="input_cert_manager_issuer_chart"></a> [cert\_manager\_issuer\_chart](#input\_cert\_manager\_issuer\_chart) | Chart name to be installed. The chart name can be local path, a URL to a chart, or the name of the chart if `repository` is specified. It is also possible to use the `<repository>/<chart>` format here if you are running Terraform on a system that the repository has been added to with `helm repo add` but this is not recommended. | `string` | n/a | yes |
+| <a name="input_cert_manager_issuer_chart_version"></a> [cert\_manager\_issuer\_chart\_version](#input\_cert\_manager\_issuer\_chart\_version) | Specify the exact chart version to install. If this is not specified, the latest version is installed. | `string` | `null` | no |
+| <a name="input_cert_manager_issuer_description"></a> [cert\_manager\_issuer\_description](#input\_cert\_manager\_issuer\_description) | Set release description attribute (visible in the history). | `string` | `null` | no |
+| <a name="input_cert_manager_issuer_repository"></a> [cert\_manager\_issuer\_repository](#input\_cert\_manager\_issuer\_repository) | Repository URL where to locate the requested chart. | `string` | `null` | no |
+| <a name="input_cert_manager_issuer_selfsigned_enabled"></a> [cert\_manager\_issuer\_selfsigned\_enabled](#input\_cert\_manager\_issuer\_selfsigned\_enabled) | Whether or not to use selfsigned issuer. | `bool` | `true` | no |
+| <a name="input_cert_manager_issuer_support_email_template"></a> [cert\_manager\_issuer\_support\_email\_template](#input\_cert\_manager\_issuer\_support\_email\_template) | The support email template format. | `string` | n/a | yes |
+| <a name="input_cert_manager_metrics_enabled"></a> [cert\_manager\_metrics\_enabled](#input\_cert\_manager\_metrics\_enabled) | Whether or not to enable metrics in the cert-manager. | `bool` | `false` | no |
+| <a name="input_cert_manager_repository"></a> [cert\_manager\_repository](#input\_cert\_manager\_repository) | Repository URL where to locate the requested chart. | `string` | `null` | no |
+| <a name="input_cert_manager_resources"></a> [cert\_manager\_resources](#input\_cert\_manager\_resources) | The cpu and memory of the cert manager's limits and requests. | <pre>object({<br>    limits = object({<br>      cpu    = string<br>      memory = string<br>    })<br>    requests = object({<br>      cpu    = string<br>      memory = string<br>    })<br>  })</pre> | <pre>{<br>  "limits": {<br>    "cpu": "200m",<br>    "memory": "256Mi"<br>  },<br>  "requests": {<br>    "cpu": "100m",<br>    "memory": "128Mi"<br>  }<br>}</pre> | no |
+| <a name="input_cleanup_on_fail"></a> [cleanup\_on\_fail](#input\_cleanup\_on\_fail) | Allow deletion of new resources created in this upgrade when upgrade fails. | `bool` | `true` | no |
+| <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "descriptor_formats": {},<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "labels_as_tags": [<br>    "unset"<br>  ],<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {},<br>  "tenant": null<br>}</pre> | no |
+| <a name="input_create_namespace"></a> [create\_namespace](#input\_create\_namespace) | Create the namespace if it does not yet exist. Defaults to `false`. | `bool` | `null` | no |
+| <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between ID elements.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
+| <a name="input_descriptor_formats"></a> [descriptor\_formats](#input\_descriptor\_formats) | Describe additional descriptors to be output in the `descriptors` output map.<br>Map of maps. Keys are names of descriptors. Values are maps of the form<br>`{<br>   format = string<br>   labels = list(string)<br>}`<br>(Type is `any` so the map values can later be enhanced to provide additional options.)<br>`format` is a Terraform format string to be passed to the `format()` function.<br>`labels` is a list of labels, in order, to pass to `format()` function.<br>Label values will be normalized before being passed to `format()` so they will be<br>identical to how they appear in `id`.<br>Default is `{}` (`descriptors` output will be empty). | `any` | `{}` | no |
+| <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
+| <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for keep the existing setting, which defaults to `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
+| <a name="input_import_profile_name"></a> [import\_profile\_name](#input\_import\_profile\_name) | AWS Profile name to use when importing a resource | `string` | `null` | no |
+| <a name="input_kubernetes_namespace"></a> [kubernetes\_namespace](#input\_kubernetes\_namespace) | The namespace to install the release into. | `string` | n/a | yes |
+| <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | Controls the letter case of the `tags` keys (label names) for tags generated by this module.<br>Does not affect keys of tags passed in via the `tags` input.<br>Possible values: `lower`, `title`, `upper`.<br>Default value: `title`. | `string` | `null` | no |
+| <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The order in which the labels (ID elements) appear in the `id`.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present. | `list(string)` | `null` | no |
+| <a name="input_label_value_case"></a> [label\_value\_case](#input\_label\_value\_case) | Controls the letter case of ID elements (labels) as included in `id`,<br>set as tag values, and output by this module individually.<br>Does not affect values of tags passed in via the `tags` input.<br>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br>Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.<br>Default value: `lower`. | `string` | `null` | no |
+| <a name="input_labels_as_tags"></a> [labels\_as\_tags](#input\_labels\_as\_tags) | Set of labels (ID elements) to include as tags in the `tags` output.<br>Default is to include all labels.<br>Tags with empty values will not be included in the `tags` output.<br>Set to `[]` to suppress all generated tags.<br>**Notes:**<br>  The value of the `name` tag, if included, will be the `id`, not the `name`.<br>  Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be<br>  changed in later chained modules. Attempts to change it will be silently ignored. | `set(string)` | <pre>[<br>  "default"<br>]</pre> | no |
+| <a name="input_letsencrypt_enabled"></a> [letsencrypt\_enabled](#input\_letsencrypt\_enabled) | Whether or not to use letsencrypt issuer and manager. If this is enabled, it will also provision an IAM role. | `bool` | `false` | no |
+| <a name="input_name"></a> [name](#input\_name) | ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.<br>This is the only ID element not also included as a `tag`.<br>The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input. | `string` | `null` | no |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique | `string` | `null` | no |
+| <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br>Characters matching the regex will be removed from the ID elements.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
+| <a name="input_region"></a> [region](#input\_region) | AWS Region | `string` | n/a | yes |
+| <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
+| <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |
+| <a name="input_timeout"></a> [timeout](#input\_timeout) | Time in seconds to wait for any individual kubernetes operation (like Jobs for hooks). Defaults to `300` seconds | `number` | `null` | no |
+| <a name="input_wait"></a> [wait](#input\_wait) | Will wait until all resources are in a ready state before marking the release as successful. It will wait for as long as `timeout`. Defaults to `true`. | `bool` | `null` | no |
+
+## Outputs
+
+No outputs.
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+## References

--- a/modules/cert-manager/cert-manager-issuer/.helmignore
+++ b/modules/cert-manager/cert-manager-issuer/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/modules/cert-manager/cert-manager-issuer/Chart.yaml
+++ b/modules/cert-manager/cert-manager-issuer/Chart.yaml
@@ -1,0 +1,25 @@
+apiVersion: v2
+name: cert-manager-issuer
+description: Provision an issuer for the certificate manager
+icon: https://raw.githubusercontent.com/jetstack/cert-manager/master/logo/logo.png
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.0.0"

--- a/modules/cert-manager/cert-manager-issuer/templates/letsencrypt-issuer.yaml
+++ b/modules/cert-manager/cert-manager-issuer/templates/letsencrypt-issuer.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.letsencrypt_installed }}
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: "letsencrypt-staging"
+spec:
+  acme:
+    # The ACME server URL
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    # Email address used for ACME registration
+    email: {{ printf .Values.support_email_template .Values.stage | quote }}
+    # Name of a secret used to store the ACME account private key
+    privateKeySecretRef:
+      name: letsencrypt-staging
+    solvers:
+      #            # Enable the HTTP-01 challenge provider
+      #            - http01:
+      #                ingress:
+      #                  class: nginx
+      # Enable the DNS-01 challenge provider
+      - dns01:
+          route53:
+            region: {{ .Values.dns_region | quote }}
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    # The ACME server URL
+    server: https://acme-v02.api.letsencrypt.org/directory
+    # Email address used for ACME registration
+    email: {{ printf .Values.support_email_template .Values.account | quote }}
+    # Name of a secret used to store the ACME account private key
+    privateKeySecretRef:
+      name: letsencrypt-prod
+    solvers:
+      #            # Enable the HTTP-01 challenge provider
+      #            - http01:
+      #                ingress:
+      #                  class: nginx
+      # Enable the DNS-01 challenge provider
+      - dns01:
+          route53:
+            region: {{ .Values.dns_region | quote }}
+{{- end }}

--- a/modules/cert-manager/cert-manager-issuer/templates/selfsigning-issuer.yaml
+++ b/modules/cert-manager/cert-manager-issuer/templates/selfsigning-issuer.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.selfsigned_installed }}
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: selfsigning-issuer
+spec:
+  selfSigned: {}
+{{- end }}

--- a/modules/cert-manager/cert-manager-issuer/values.yaml
+++ b/modules/cert-manager/cert-manager-issuer/values.yaml
@@ -1,0 +1,5 @@
+letsencrypt_installed: false
+
+selfsigned_installed: true
+
+support_email_template: aws+%v@example.com

--- a/modules/cert-manager/cert-manager-values.yaml
+++ b/modules/cert-manager/cert-manager-values.yaml
@@ -1,0 +1,20 @@
+rbac:
+  create: true
+installCRDs: true
+serviceAccount:
+  create: true
+securityContext:
+  enabled: true
+  fsGroup: 1001
+  runAsGroup: 1001
+prometheus:
+  servicemonitor:
+    prometheusInstance: default
+    targetPort: 9402
+    path: /metrics
+    interval: 60s
+    scrapeTimeout: 30s
+webhook:
+  enabled: true
+cainjector:
+  enabled: true

--- a/modules/cert-manager/context.tf
+++ b/modules/cert-manager/context.tf
@@ -1,0 +1,279 @@
+#
+# ONLY EDIT THIS FILE IN github.com/cloudposse/terraform-null-label
+# All other instances of this file should be a copy of that one
+#
+#
+# Copy this file from https://github.com/cloudposse/terraform-null-label/blob/master/exports/context.tf
+# and then place it in your Terraform module to automatically get
+# Cloud Posse's standard configuration inputs suitable for passing
+# to Cloud Posse modules.
+#
+# curl -sL https://raw.githubusercontent.com/cloudposse/terraform-null-label/master/exports/context.tf -o context.tf
+#
+# Modules should access the whole context as `module.this.context`
+# to get the input variables with nulls for defaults,
+# for example `context = module.this.context`,
+# and access individual variables as `module.this.<var>`,
+# with final values filled in.
+#
+# For example, when using defaults, `module.this.context.delimiter`
+# will be null, and `module.this.delimiter` will be `-` (hyphen).
+#
+
+module "this" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0" # requires Terraform >= 0.13.0
+
+  enabled             = var.enabled
+  namespace           = var.namespace
+  tenant              = var.tenant
+  environment         = var.environment
+  stage               = var.stage
+  name                = var.name
+  delimiter           = var.delimiter
+  attributes          = var.attributes
+  tags                = var.tags
+  additional_tag_map  = var.additional_tag_map
+  label_order         = var.label_order
+  regex_replace_chars = var.regex_replace_chars
+  id_length_limit     = var.id_length_limit
+  label_key_case      = var.label_key_case
+  label_value_case    = var.label_value_case
+  descriptor_formats  = var.descriptor_formats
+  labels_as_tags      = var.labels_as_tags
+
+  context = var.context
+}
+
+# Copy contents of cloudposse/terraform-null-label/variables.tf here
+
+variable "context" {
+  type = any
+  default = {
+    enabled             = true
+    namespace           = null
+    tenant              = null
+    environment         = null
+    stage               = null
+    name                = null
+    delimiter           = null
+    attributes          = []
+    tags                = {}
+    additional_tag_map  = {}
+    regex_replace_chars = null
+    label_order         = []
+    id_length_limit     = null
+    label_key_case      = null
+    label_value_case    = null
+    descriptor_formats  = {}
+    # Note: we have to use [] instead of null for unset lists due to
+    # https://github.com/hashicorp/terraform/issues/28137
+    # which was not fixed until Terraform 1.0.0,
+    # but we want the default to be all the labels in `label_order`
+    # and we want users to be able to prevent all tag generation
+    # by setting `labels_as_tags` to `[]`, so we need
+    # a different sentinel to indicate "default"
+    labels_as_tags = ["unset"]
+  }
+  description = <<-EOT
+    Single object for setting entire context at once.
+    See description of individual variables for details.
+    Leave string and numeric variables as `null` to use default value.
+    Individual variable settings (non-null) override settings in context object,
+    except for attributes, tags, and additional_tag_map, which are merged.
+  EOT
+
+  validation {
+    condition     = lookup(var.context, "label_key_case", null) == null ? true : contains(["lower", "title", "upper"], var.context["label_key_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+
+  validation {
+    condition     = lookup(var.context, "label_value_case", null) == null ? true : contains(["lower", "title", "upper", "none"], var.context["label_value_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+variable "enabled" {
+  type        = bool
+  default     = null
+  description = "Set to false to prevent the module from creating any resources"
+}
+
+variable "namespace" {
+  type        = string
+  default     = null
+  description = "ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique"
+}
+
+variable "tenant" {
+  type        = string
+  default     = null
+  description = "ID element _(Rarely used, not included by default)_. A customer identifier, indicating who this instance of a resource is for"
+}
+
+variable "environment" {
+  type        = string
+  default     = null
+  description = "ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT'"
+}
+
+variable "stage" {
+  type        = string
+  default     = null
+  description = "ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release'"
+}
+
+variable "name" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.
+    This is the only ID element not also included as a `tag`.
+    The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input.
+    EOT
+}
+
+variable "delimiter" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Delimiter to be used between ID elements.
+    Defaults to `-` (hyphen). Set to `""` to use no delimiter at all.
+  EOT
+}
+
+variable "attributes" {
+  type        = list(string)
+  default     = []
+  description = <<-EOT
+    ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,
+    in the order they appear in the list. New attributes are appended to the
+    end of the list. The elements of the list are joined by the `delimiter`
+    and treated as a single ID element.
+    EOT
+}
+
+variable "labels_as_tags" {
+  type        = set(string)
+  default     = ["default"]
+  description = <<-EOT
+    Set of labels (ID elements) to include as tags in the `tags` output.
+    Default is to include all labels.
+    Tags with empty values will not be included in the `tags` output.
+    Set to `[]` to suppress all generated tags.
+    **Notes:**
+      The value of the `name` tag, if included, will be the `id`, not the `name`.
+      Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be
+      changed in later chained modules. Attempts to change it will be silently ignored.
+    EOT
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+    Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).
+    Neither the tag keys nor the tag values will be modified by this module.
+    EOT
+}
+
+variable "additional_tag_map" {
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+    Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.
+    This is for some rare cases where resources want additional configuration of tags
+    and therefore take a list of maps with tag key, value, and additional configuration.
+    EOT
+}
+
+variable "label_order" {
+  type        = list(string)
+  default     = null
+  description = <<-EOT
+    The order in which the labels (ID elements) appear in the `id`.
+    Defaults to ["namespace", "environment", "stage", "name", "attributes"].
+    You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present.
+    EOT
+}
+
+variable "regex_replace_chars" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Terraform regular expression (regex) string.
+    Characters matching the regex will be removed from the ID elements.
+    If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits.
+  EOT
+}
+
+variable "id_length_limit" {
+  type        = number
+  default     = null
+  description = <<-EOT
+    Limit `id` to this many characters (minimum 6).
+    Set to `0` for unlimited length.
+    Set to `null` for keep the existing setting, which defaults to `0`.
+    Does not affect `id_full`.
+  EOT
+  validation {
+    condition     = var.id_length_limit == null ? true : var.id_length_limit >= 6 || var.id_length_limit == 0
+    error_message = "The id_length_limit must be >= 6 if supplied (not null), or 0 for unlimited length."
+  }
+}
+
+variable "label_key_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Controls the letter case of the `tags` keys (label names) for tags generated by this module.
+    Does not affect keys of tags passed in via the `tags` input.
+    Possible values: `lower`, `title`, `upper`.
+    Default value: `title`.
+  EOT
+
+  validation {
+    condition     = var.label_key_case == null ? true : contains(["lower", "title", "upper"], var.label_key_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+}
+
+variable "label_value_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Controls the letter case of ID elements (labels) as included in `id`,
+    set as tag values, and output by this module individually.
+    Does not affect values of tags passed in via the `tags` input.
+    Possible values: `lower`, `title`, `upper` and `none` (no transformation).
+    Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.
+    Default value: `lower`.
+  EOT
+
+  validation {
+    condition     = var.label_value_case == null ? true : contains(["lower", "title", "upper", "none"], var.label_value_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+variable "descriptor_formats" {
+  type        = any
+  default     = {}
+  description = <<-EOT
+    Describe additional descriptors to be output in the `descriptors` output map.
+    Map of maps. Keys are names of descriptors. Values are maps of the form
+    `{
+       format = string
+       labels = list(string)
+    }`
+    (Type is `any` so the map values can later be enhanced to provide additional options.)
+    `format` is a Terraform format string to be passed to the `format()` function.
+    `labels` is a list of labels, in order, to pass to `format()` function.
+    Label values will be normalized before being passed to `format()` so they will be
+    identical to how they appear in `id`.
+    Default is `{}` (`descriptors` output will be empty).
+    EOT
+}
+
+#### End of copy of cloudposse/terraform-null-label/variables.tf

--- a/modules/cert-manager/default.auto.tfvars
+++ b/modules/cert-manager/default.auto.tfvars
@@ -1,0 +1,7 @@
+enabled = false
+
+name = "cert-manager"
+
+cert_manager_repository    = "https://charts.jetstack.io"
+cert_manager_chart         = "cert-manager"
+cert_manager_chart_version = "v1.5.3"

--- a/modules/cert-manager/main.tf
+++ b/modules/cert-manager/main.tf
@@ -1,0 +1,147 @@
+locals {
+  enabled = module.this.enabled
+  # Role ARN of IAM Role created by the helm-release module
+  # e.g. arn:aws:iam::123456789012:role/acme-mgmt-uw2-dev-external-dns-external-dns@kube-system
+  # needs to be calculated manually in order to avoid a cyclic dependency.
+  iam_role_arn = "arn:${join("", data.aws_partition.current.*.partition)}:iam::${join("", data.aws_caller_identity.current.*.account_id)}:role/${module.this.id}-${module.this.name}@${var.kubernetes_namespace}"
+}
+
+data "aws_partition" "current" {
+  count = local.enabled ? 1 : 0
+}
+
+data "aws_caller_identity" "current" {
+  count = local.enabled ? 1 : 0
+}
+
+module "cert_manager" {
+  source  = "cloudposse/helm-release/aws"
+  version = "0.1.4"
+
+  name                 = module.this.name
+  chart                = var.cert_manager_chart
+  repository           = var.cert_manager_repository
+  description          = var.cert_manager_description
+  chart_version        = var.cert_manager_chart_version
+  kubernetes_namespace = var.kubernetes_namespace
+  create_namespace     = var.create_namespace
+  wait                 = var.wait
+  atomic               = var.atomic
+  cleanup_on_fail      = var.cleanup_on_fail
+  timeout              = var.timeout
+
+  # Only install IAM role if letsencrypt_installed is enabled
+  iam_role_enabled = var.letsencrypt_enabled
+
+  eks_cluster_oidc_issuer_url = module.eks.outputs.eks_cluster_identity_oidc_issuer
+
+  service_account_name      = module.this.name
+  service_account_namespace = var.kubernetes_namespace
+
+  iam_policy_statements = [
+    {
+      sid    = "GrantGetChange"
+      effect = "Allow"
+      actions = [
+        "route53:GetChange"
+      ]
+      resources = [
+        "arn:${join("", data.aws_partition.current.*.partition)}:route53:::change/*"
+      ]
+      conditions = []
+    },
+    {
+      sid    = "GrantListHostedZonesListResourceRecordSets"
+      effect = "Allow"
+      actions = [
+        "route53:ListHostedZonesByName"
+      ]
+      resources  = ["*"]
+      conditions = []
+    },
+    {
+      sid    = "GrantChangeResourceRecordSets"
+      effect = "Allow"
+      actions = [
+        "route53:ChangeResourceRecordSets",
+        "route53:ListResourceRecordSets",
+      ]
+      resources = [
+        for zone_id in concat(
+          [for value in module.dns_delegated.outputs.zones : value.zone_id],
+          [for value in module.dns_gbl_delegated.outputs.zones : value.zone_id]
+        ) :
+        "arn:${join("", data.aws_partition.current.*.partition)}:route53:::hostedzone/${zone_id}"
+      ]
+      conditions : []
+    }
+  ]
+
+  values = compact([
+    yamlencode({
+      fullnameOverride = module.this.name,
+      serviceAccount = {
+        name = module.this.name
+      },
+      resources = var.cert_manager_resources
+    }),
+    var.letsencrypt_enabled ? yamlencode({
+      ingressShim = {
+        defaultIssuerName                = "ClusterIssuer"
+        ingress_shim_default_issuer_name = "letsencrypt-staging"
+      },
+      serviceAccount = {
+        annotations = {
+          "eks.amazonaws.com/role-arn" = local.iam_role_arn
+        }
+      }
+    }) : "",
+    var.cert_manager_metrics_enabled ? yamlencode({
+      prometheus = {
+        enabled = var.cert_manager_metrics_enabled
+        servicemonitor = {
+          enabled = var.cert_manager_metrics_enabled
+        }
+      }
+    }) : "",
+    file("${path.module}/cert-manager-values.yaml"),
+  ])
+
+  context = module.this.context
+}
+
+module "cert_manager_issuer" {
+  source  = "cloudposse/helm-release/aws"
+  version = "0.1.3"
+
+  # Only install the issuer if either letsencrypt_installed or selfsigned_installed is true
+  enabled = local.enabled && (var.letsencrypt_enabled || var.cert_manager_issuer_selfsigned_enabled)
+
+  name                 = "${module.this.name}-issuer"
+  chart                = var.cert_manager_issuer_chart
+  repository           = var.cert_manager_issuer_repository
+  description          = var.cert_manager_issuer_description
+  chart_version        = var.cert_manager_issuer_chart_version
+  kubernetes_namespace = var.kubernetes_namespace
+  create_namespace     = var.create_namespace
+  wait                 = var.wait
+  atomic               = var.atomic
+  cleanup_on_fail      = var.cleanup_on_fail
+  timeout              = var.timeout
+
+  # NOTE: Use with the local chart
+  values = [
+    yamlencode({
+      letsencrypt_installed  = var.letsencrypt_enabled
+      selfsigned_installed   = var.cert_manager_issuer_selfsigned_enabled
+      account                = join("-", compact([module.this.tenant, module.this.stage]))
+      support_email_template = var.cert_manager_issuer_support_email_template
+    })
+  ]
+
+  context = module.this.context
+
+  depends_on = [
+    module.cert_manager # CRDs from cert-manager need to be installed first
+  ]
+}

--- a/modules/cert-manager/providers.tf
+++ b/modules/cert-manager/providers.tf
@@ -1,0 +1,36 @@
+provider "aws" {
+  region = var.region
+
+  profile = coalesce(var.import_profile_name, module.iam_roles.terraform_profile_name)
+}
+
+module "iam_roles" {
+  source  = "../account-map/modules/iam-roles"
+  context = module.this.context
+}
+
+variable "import_profile_name" {
+  type        = string
+  default     = null
+  description = "AWS Profile name to use when importing a resource"
+}
+
+data "aws_eks_cluster" "kubernetes" {
+  count = local.enabled ? 1 : 0
+
+  name = module.eks.outputs.eks_cluster_id
+}
+
+data "aws_eks_cluster_auth" "kubernetes" {
+  count = local.enabled ? 1 : 0
+
+  name = module.eks.outputs.eks_cluster_id
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = data.aws_eks_cluster.kubernetes[0].endpoint
+    token                  = data.aws_eks_cluster_auth.kubernetes[0].token
+    cluster_ca_certificate = base64decode(data.aws_eks_cluster.kubernetes[0].certificate_authority[0].data)
+  }
+}

--- a/modules/cert-manager/remote-state.tf
+++ b/modules/cert-manager/remote-state.tf
@@ -1,0 +1,30 @@
+module "eks" {
+  source  = "cloudposse/stack-config/yaml//modules/remote-state"
+  version = "0.19.0"
+
+  stack_config_local_path = "../../../stacks"
+  component               = "eks"
+
+  context = module.this.context
+}
+
+module "dns_delegated" {
+  source  = "cloudposse/stack-config/yaml//modules/remote-state"
+  version = "0.19.0"
+
+  stack_config_local_path = "../../../stacks"
+  component               = "dns-delegated"
+
+  context = module.this.context
+}
+
+module "dns_gbl_delegated" {
+  source  = "cloudposse/stack-config/yaml//modules/remote-state"
+  version = "0.19.0"
+
+  stack_config_local_path = "../../../stacks"
+  component               = "dns-delegated"
+  environment             = "gbl"
+
+  context = module.this.context
+}

--- a/modules/cert-manager/variables.tf
+++ b/modules/cert-manager/variables.tf
@@ -1,0 +1,138 @@
+variable "region" {
+  type        = string
+  description = "AWS Region"
+}
+
+## shared between cert_manager and cert_manager_issuer
+
+variable "letsencrypt_enabled" {
+  type        = bool
+  description = "Whether or not to use letsencrypt issuer and manager. If this is enabled, it will also provision an IAM role."
+  default     = false
+}
+
+## cert_manager
+
+variable "cert_manager_description" {
+  type        = string
+  description = "Set release description attribute (visible in the history)."
+  default     = null
+}
+
+variable "cert_manager_chart" {
+  type        = string
+  description = "Chart name to be installed. The chart name can be local path, a URL to a chart, or the name of the chart if `repository` is specified. It is also possible to use the `<repository>/<chart>` format here if you are running Terraform on a system that the repository has been added to with `helm repo add` but this is not recommended."
+}
+
+variable "cert_manager_repository" {
+  type        = string
+  description = "Repository URL where to locate the requested chart."
+  default     = null
+}
+
+variable "cert_manager_chart_version" {
+  type        = string
+  description = "Specify the exact chart version to install. If this is not specified, the latest version is installed."
+  default     = null
+}
+
+variable "cert_manager_resources" {
+  type = object({
+    limits = object({
+      cpu    = string
+      memory = string
+    })
+    requests = object({
+      cpu    = string
+      memory = string
+    })
+  })
+  description = "The cpu and memory of the cert manager's limits and requests."
+  default = {
+    limits = {
+      cpu    = "200m"
+      memory = "256Mi"
+    },
+    requests = {
+      cpu    = "100m"
+      memory = "128Mi"
+    }
+  }
+}
+
+variable "cert_manager_metrics_enabled" {
+  type        = bool
+  description = "Whether or not to enable metrics in the cert-manager."
+  default     = false
+}
+
+## cert_manager_issuer
+
+variable "cert_manager_issuer_description" {
+  type        = string
+  description = "Set release description attribute (visible in the history)."
+  default     = null
+}
+
+variable "cert_manager_issuer_chart" {
+  type        = string
+  description = "Chart name to be installed. The chart name can be local path, a URL to a chart, or the name of the chart if `repository` is specified. It is also possible to use the `<repository>/<chart>` format here if you are running Terraform on a system that the repository has been added to with `helm repo add` but this is not recommended."
+}
+
+variable "cert_manager_issuer_repository" {
+  type        = string
+  description = "Repository URL where to locate the requested chart."
+  default     = null
+}
+
+variable "cert_manager_issuer_chart_version" {
+  type        = string
+  description = "Specify the exact chart version to install. If this is not specified, the latest version is installed."
+  default     = null
+}
+
+variable "cert_manager_issuer_support_email_template" {
+  type        = string
+  description = "The support email template format."
+}
+
+variable "cert_manager_issuer_selfsigned_enabled" {
+  type        = bool
+  description = "Whether or not to use selfsigned issuer."
+  default     = true
+}
+
+variable "create_namespace" {
+  type        = bool
+  description = "Create the namespace if it does not yet exist. Defaults to `false`."
+  default     = null
+}
+
+variable "kubernetes_namespace" {
+  type        = string
+  description = "The namespace to install the release into."
+}
+
+variable "timeout" {
+  type        = number
+  description = "Time in seconds to wait for any individual kubernetes operation (like Jobs for hooks). Defaults to `300` seconds"
+  default     = null
+}
+
+variable "cleanup_on_fail" {
+  type        = bool
+  description = "Allow deletion of new resources created in this upgrade when upgrade fails."
+  default     = true
+}
+
+variable "atomic" {
+  type        = bool
+  description = "If set, installation process purges chart on fail. The wait flag will be set automatically if atomic is used."
+  default     = true
+}
+
+variable "wait" {
+  type        = bool
+  description = "Will wait until all resources are in a ready state before marking the release as successful. It will wait for as long as `timeout`. Defaults to `true`."
+  default     = null
+}

--- a/modules/cert-manager/versions.tf
+++ b/modules/cert-manager/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.0.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.0"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.0"
+    }
+  }
+}


### PR DESCRIPTION
## what
* Add `cert-manager` EKS component.
* Add `pre-commit` exception for `check-yaml` hook, for YAML templates in the Helm Chart included in the `cert-manager` component.

## why
* `cert-manager` allows for automatic issuing of X.509 certificates via k8s resources and annotations, and also supports issuers such as LetsEncrypt. 

## references
* N/A

