### PR TITLE
adding manifest=true to all helm providers

### DIFF
--- a/modules/alb-controller/providers.tf
+++ b/modules/alb-controller/providers.tf
@@ -33,4 +33,7 @@ provider "helm" {
     token                  = local.enabled ? data.aws_eks_cluster_auth.kubernetes[0].token : null
     cluster_ca_certificate = local.enabled ? base64decode(data.aws_eks_cluster.kubernetes[0].certificate_authority[0].data) : null
   }
+  experiments {
+    manifest = true
+  }
 }

--- a/modules/aws-node-termination-handler/providers.tf
+++ b/modules/aws-node-termination-handler/providers.tf
@@ -33,4 +33,7 @@ provider "helm" {
     token                  = local.enabled ? data.aws_eks_cluster_auth.kubernetes[0].token : null
     cluster_ca_certificate = local.enabled ? base64decode(data.aws_eks_cluster.kubernetes[0].certificate_authority[0].data) : null
   }
+  experiments {
+    manifest = true
+  }
 }

--- a/modules/cert-manager/providers.tf
+++ b/modules/cert-manager/providers.tf
@@ -45,4 +45,7 @@ provider "helm" {
     token                  = local.enabled ? data.aws_eks_cluster_auth.kubernetes[0].token : null
     cluster_ca_certificate = local.enabled ? base64decode(data.aws_eks_cluster.kubernetes[0].certificate_authority[0].data) : null
   }
+  experiments {
+    manifest = true
+  }
 }

--- a/modules/echo-server/providers.tf
+++ b/modules/echo-server/providers.tf
@@ -45,4 +45,7 @@ provider "helm" {
     token                  = local.enabled ? data.aws_eks_cluster_auth.kubernetes[0].token : null
     cluster_ca_certificate = local.enabled ? base64decode(data.aws_eks_cluster.kubernetes[0].certificate_authority[0].data) : null
   }
+  experiments {
+    manifest = true
+  }
 }

--- a/modules/external-dns/providers.tf
+++ b/modules/external-dns/providers.tf
@@ -33,4 +33,7 @@ provider "helm" {
     token                  = local.enabled ? data.aws_eks_cluster_auth.kubernetes[0].token : null
     cluster_ca_certificate = local.enabled ? base64decode(data.aws_eks_cluster.kubernetes[0].certificate_authority[0].data) : null
   }
+  experiments {
+    manifest = true
+  }
 }

--- a/modules/github-actions-runner/providers.tf
+++ b/modules/github-actions-runner/providers.tf
@@ -45,4 +45,7 @@ provider "helm" {
     token                  = local.enabled ? data.aws_eks_cluster_auth.kubernetes[0].token : null
     cluster_ca_certificate = local.enabled ? base64decode(data.aws_eks_cluster.kubernetes[0].certificate_authority[0].data) : null
   }
+  experiments {
+    manifest = true
+  }
 }

--- a/modules/idp-roles/providers.tf
+++ b/modules/idp-roles/providers.tf
@@ -45,4 +45,7 @@ provider "helm" {
     token                  = local.enabled ? data.aws_eks_cluster_auth.kubernetes[0].token : null
     cluster_ca_certificate = local.enabled ? base64decode(data.aws_eks_cluster.kubernetes[0].certificate_authority[0].data) : null
   }
+  experiments {
+    manifest = true
+  }
 }


### PR DESCRIPTION
## what
* This will add the ability to detect drift in local Helm charts.

## why
* The inability to detect drift in local Helm charts was a major limitation in the `helm` provider. Now, we have local helm chart under the control of terrafom.

## references
* https://github.com/databus23/helm-diff/issues/176
* https://github.com/hashicorp/terraform-provider-helm/pull/702
* https://github.com/databus23/helm-diff/pull/304