### PR TITLE
update github-runners to support using registration token directly

### DIFF
--- a/modules/github-runners/README.md
+++ b/modules/github-runners/README.md
@@ -2,6 +2,10 @@
 
 This component is responsible for provisioning EC2 instances for GitHub runners.
 
+## Pre-Requisites
+
+Before using this component, you must obtain a Github Runner registration token and store it in SSM parameter store. Please see the [Reference Architecture documentation](https://cloudposse.atlassian.net/wiki/spaces/REFARCH/pages/1180303385/github-runners) for details on how to do this.
+
 ## Usage
 
 **Stack Level**: Regional
@@ -13,7 +17,7 @@ components:
   terraform:
     github-runners:
       vars:
-        github_scope: company
+        github_org: cloudposse
         instance_type: "t3.small"
         min_size: 1
         max_size: 10

--- a/modules/github-runners/templates/deregister-github-runner
+++ b/modules/github-runners/templates/deregister-github-runner
@@ -5,14 +5,11 @@ imdsv2_token=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-e
 aws_region=$(curl -H "X-aws-ec2-metadata-token: $imdsv2_token" --silent http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r .region)
 
 # retrieve GitHub PAT
-github_token=$(aws ssm get-parameter --name ${github_token_ssm_path} --region $aws_region --with-decryption | jq -r .Parameter.Value)
-
-# generate GitHub Actions Runner remove token
-remove_token=$(curl -s -X POST https://api.github.com/orgs/${github_org}/actions/runners/remove-token -H "accept: application/vnd.github.everest-preview+json" -H "authorization: token $github_token" | jq -r '.token')
+remove_token=$(aws ssm get-parameter --name ${github_token_ssm_path} --region $aws_region --with-decryption | jq -r .Parameter.Value)
 
 # remove GitHub Actions Runner
 pushd /opt/actions-runner
 ./svc.sh stop
 ./svc.sh uninstall
-sudo -u ec2-user ./config.sh remove --token $remove_token
+sudo -u ec2-user ./config.sh remove --unattended --token $remove_token
 popd

--- a/modules/github-runners/variables.tf
+++ b/modules/github-runners/variables.tf
@@ -59,6 +59,12 @@ variable "github_org" {
   type        = string
 }
 
+variable "github_repo" {
+  description = "GitHub Repo e.g. infra-live. If specified, the runner will be created for the repo rather than for the organization."
+  type        = string
+  default     = null
+}
+
 variable "wait_for_capacity_timeout" {
   type        = string
   description = "A maximum duration that Terraform should wait for ASG instances to be healthy before timing out. (See also Waiting for Capacity below.) Setting this to '0' causes Terraform to skip all Capacity Waiting behavior"
@@ -89,7 +95,7 @@ variable "ssm_path" {
 
 variable "runner_version" {
   type        = string
-  default     = "2.283.1"
+  default     = "2.288.1"
   description = "GitHub runner release version"
 }
 


### PR DESCRIPTION
## what

Github now supports obtaining a scoped (Organization or Repository) registration token directly through the UI, which would eliminate the need for any kind of long-lived credentials to be stored. It would be great if we could specify the registration token rather than a PAT and the actions-runner-controller could just use the registration token directly rather than using the API to obtain one.

## why

Currently, the component supports providing a Github Personal Access Token (PAT) and uses that token to call the Github API to request a Runner registration token. Using this method requires users to create and store a privileged (Admin scoped) token that has more permissions than it requires.

## references
* Additional information in the [RefArch documentation](https://cloudposse.atlassian.net/wiki/spaces/REFARCH/pages/1180303385/github-runners)
