### PR TITLE
`snowflake-account` and `snowflake-database`

### DIFF
--- a/modules/snowflake-account/README.md
+++ b/modules/snowflake-account/README.md
@@ -1,0 +1,156 @@
+# Component: `snowflake-account`
+
+This component sets up the requirements for all other Snowflake components, including creating the Terraform service user. Before running this component, follow the manual, Click-Ops steps below to create a Snowflake subscription.
+
+## Deployment Steps
+
+1. Open the AWS Console for the given stack.
+2. Go to AWS Marketplace Subscriptions.
+3. Click "Manage Subscriptions", click "Discover products", type "Snowflake" in the search bar. 
+4. Select "Snowflake Data Cloud"
+5. Click "Continue to Subscribe"
+
+6. Fill out the information steps using the following as an example. Note, the provided email cannot use labels such as `mdev+sbx01@example.com`.
+```
+  First Name: John
+  Last Name: Smith
+  Email: aws@example.com
+  Company: Example
+  Country: United States
+```
+7. Select "Standard" and the current region. In this example, we chose "US East (Ohio)" which is the same as `us-east-1`.
+7. Continue and wait for Sign Up to complete. Note the Snowflake account ID; you can find this in the newly accessible Snowflake console in the top right of the window. 
+8. Check for the Account Activation email. Note, this may be collected in a Slack notifications channel for easy access.
+9. Follow the given link to create the Admin user with username `admin` and a strong password. Be sure to save that password somewhere secure.
+10. Upload that password to AWS Parameter Store under `/snowflake/$ACCOUNT/users/admin/password`, where `ACCOUNT` is the value given during the subscription process. This password will only be used to create a private key, and all other authentication will be done with said key. Below is an example of how to do that with a [chamber](https://github.com/segmentio/chamber) command:
+```
+AWS_PROFILE=$NAMESPACE-$TENANT-gbl-sbx01-admin chamber write /snowflake/$ACCOUNT/users/admin/ admin $PASSWORD
+```
+11. Finally, use atmos to deploy this component: 
+```
+atmos terraform deploy snowflake/account --stack $TENANT-use2-sbx01
+```
+
+
+## Usage
+
+**Stack Level**: Regional
+
+Here's an example snippet for how to use this component:
+
+```yaml
+components:
+  terraform:
+    snowflake-account:
+      settings:
+        spacelift:
+          workspace_enabled: false
+      vars:
+        enabled: true
+        snowflake_account: "AB12345"
+        snowflake_account_region: "us-east-2"
+        snowflake_user_email_format: "aws.dev+%s@example.com"
+        tags:
+          Team: data
+          Service: snowflake
+```
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.0 |
+| <a name="requirement_snowflake"></a> [snowflake](#requirement\_snowflake) | ~> 0.25.36 |
+| <a name="requirement_tls"></a> [tls](#requirement\_tls) | ~> 3.1.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+| <a name="provider_snowflake"></a> [snowflake](#provider\_snowflake) | ~> 0.25.36 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | ~> 3.1.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_account"></a> [account](#module\_account) | cloudposse/stack-config/yaml//modules/remote-state | 0.22.0 |
+| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
+| <a name="module_introspection"></a> [introspection](#module\_introspection) | cloudposse/label/null | 0.25.0 |
+| <a name="module_snowflake_account"></a> [snowflake\_account](#module\_snowflake\_account) | cloudposse/label/null | 0.25.0 |
+| <a name="module_snowflake_role"></a> [snowflake\_role](#module\_snowflake\_role) | cloudposse/label/null | 0.25.0 |
+| <a name="module_snowflake_warehouse"></a> [snowflake\_warehouse](#module\_snowflake\_warehouse) | cloudposse/label/null | 0.25.0 |
+| <a name="module_ssm_parameters"></a> [ssm\_parameters](#module\_ssm\_parameters) | cloudposse/ssm-parameter-store/aws | 0.9.1 |
+| <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
+| <a name="module_utils"></a> [utils](#module\_utils) | cloudposse/utils/aws | 0.8.1 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [random_password.terraform_user_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
+| [snowflake_role.terraform](https://registry.terraform.io/providers/chanzuckerberg/snowflake/latest/docs/resources/role) | resource |
+| [snowflake_role_grants.grant_custom_roles](https://registry.terraform.io/providers/chanzuckerberg/snowflake/latest/docs/resources/role_grants) | resource |
+| [snowflake_role_grants.grant_system_roles](https://registry.terraform.io/providers/chanzuckerberg/snowflake/latest/docs/resources/role_grants) | resource |
+| [snowflake_user.terraform](https://registry.terraform.io/providers/chanzuckerberg/snowflake/latest/docs/resources/user) | resource |
+| [snowflake_warehouse.default](https://registry.terraform.io/providers/chanzuckerberg/snowflake/latest/docs/resources/warehouse) | resource |
+| [tls_private_key.terraform_user_key](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
+| [aws_ssm_parameter.snowflake_password](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br>This is for some rare cases where resources want additional configuration of tags<br>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
+| <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br>in the order they appear in the list. New attributes are appended to the<br>end of the list. The elements of the list are joined by the `delimiter`<br>and treated as a single ID element. | `list(string)` | `[]` | no |
+| <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "descriptor_formats": {},<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "labels_as_tags": [<br>    "unset"<br>  ],<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {},<br>  "tenant": null<br>}</pre> | no |
+| <a name="input_default_warehouse_size"></a> [default\_warehouse\_size](#input\_default\_warehouse\_size) | The size for the default Snowflake Warehouse | `string` | `"xsmall"` | no |
+| <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between ID elements.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
+| <a name="input_descriptor_formats"></a> [descriptor\_formats](#input\_descriptor\_formats) | Describe additional descriptors to be output in the `descriptors` output map.<br>Map of maps. Keys are names of descriptors. Values are maps of the form<br>`{<br>   format = string<br>   labels = list(string)<br>}`<br>(Type is `any` so the map values can later be enhanced to provide additional options.)<br>`format` is a Terraform format string to be passed to the `format()` function.<br>`labels` is a list of labels, in order, to pass to `format()` function.<br>Label values will be normalized before being passed to `format()` so they will be<br>identical to how they appear in `id`.<br>Default is `{}` (`descriptors` output will be empty). | `any` | `{}` | no |
+| <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
+| <a name="input_global_environment_name"></a> [global\_environment\_name](#input\_global\_environment\_name) | Global environment name | `string` | `"gbl"` | no |
+| <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for keep the existing setting, which defaults to `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
+| <a name="input_import_profile_name"></a> [import\_profile\_name](#input\_import\_profile\_name) | AWS Profile name to use when importing a resource | `string` | `null` | no |
+| <a name="input_import_role_arn"></a> [import\_role\_arn](#input\_import\_role\_arn) | IAM Role ARN to use when importing a resource | `string` | `null` | no |
+| <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | Controls the letter case of the `tags` keys (label names) for tags generated by this module.<br>Does not affect keys of tags passed in via the `tags` input.<br>Possible values: `lower`, `title`, `upper`.<br>Default value: `title`. | `string` | `null` | no |
+| <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The order in which the labels (ID elements) appear in the `id`.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present. | `list(string)` | `null` | no |
+| <a name="input_label_value_case"></a> [label\_value\_case](#input\_label\_value\_case) | Controls the letter case of ID elements (labels) as included in `id`,<br>set as tag values, and output by this module individually.<br>Does not affect values of tags passed in via the `tags` input.<br>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br>Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.<br>Default value: `lower`. | `string` | `null` | no |
+| <a name="input_labels_as_tags"></a> [labels\_as\_tags](#input\_labels\_as\_tags) | Set of labels (ID elements) to include as tags in the `tags` output.<br>Default is to include all labels.<br>Tags with empty values will not be included in the `tags` output.<br>Set to `[]` to suppress all generated tags.<br>**Notes:**<br>  The value of the `name` tag, if included, will be the `id`, not the `name`.<br>  Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be<br>  changed in later chained modules. Attempts to change it will be silently ignored. | `set(string)` | <pre>[<br>  "default"<br>]</pre> | no |
+| <a name="input_name"></a> [name](#input\_name) | ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.<br>This is the only ID element not also included as a `tag`.<br>The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input. | `string` | `null` | no |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique | `string` | `null` | no |
+| <a name="input_privileged"></a> [privileged](#input\_privileged) | True if the default provider already has access to the backend | `bool` | `false` | no |
+| <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br>Characters matching the regex will be removed from the ID elements.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
+| <a name="input_region"></a> [region](#input\_region) | AWS Region | `string` | n/a | yes |
+| <a name="input_required_tags"></a> [required\_tags](#input\_required\_tags) | List of required tag names | `list(string)` | `[]` | no |
+| <a name="input_root_account_stage_name"></a> [root\_account\_stage\_name](#input\_root\_account\_stage\_name) | The stage name for the AWS Organization root (master) account | `string` | `"root"` | no |
+| <a name="input_service_user_id"></a> [service\_user\_id](#input\_service\_user\_id) | The identifier for the service user created to manage infrastructure. | `string` | `"terraform"` | no |
+| <a name="input_snowflake_account"></a> [snowflake\_account](#input\_snowflake\_account) | The Snowflake account given with the AWS Marketplace Subscription. | `string` | n/a | yes |
+| <a name="input_snowflake_account_region"></a> [snowflake\_account\_region](#input\_snowflake\_account\_region) | AWS Region with the Snowflake subscription | `string` | n/a | yes |
+| <a name="input_snowflake_admin_username"></a> [snowflake\_admin\_username](#input\_snowflake\_admin\_username) | Snowflake admin username created with the initial account subscription. | `string` | `"admin"` | no |
+| <a name="input_snowflake_role_description"></a> [snowflake\_role\_description](#input\_snowflake\_role\_description) | Comment to attach to the Snowflake Role. | `string` | `"Terraform service user role."` | no |
+| <a name="input_snowflake_username_format"></a> [snowflake\_username\_format](#input\_snowflake\_username\_format) | Snowflake username format | `string` | `"%s-%s"` | no |
+| <a name="input_ssm_path_snowflake_user_format"></a> [ssm\_path\_snowflake\_user\_format](#input\_ssm\_path\_snowflake\_user\_format) | SSM parameter path format for a Snowflake user. For example, /snowflake/{{ account }}/users/{{ username }}/ | `string` | `"/%s/%s/%s/%s/%s"` | no |
+| <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
+| <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |
+| <a name="input_terraform_user_first_name"></a> [terraform\_user\_first\_name](#input\_terraform\_user\_first\_name) | Snowflake Terraform first name given with User creation | `string` | `"Terrafrom"` | no |
+| <a name="input_terraform_user_last_name"></a> [terraform\_user\_last\_name](#input\_terraform\_user\_last\_name) | Snowflake Terraform last name given with User creation | `string` | `"User"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_snowflake_account"></a> [snowflake\_account](#output\_snowflake\_account) | The Snowflake account ID. |
+| <a name="output_snowflake_region"></a> [snowflake\_region](#output\_snowflake\_region) | The AWS Region with the Snowflake account. |
+| <a name="output_snowflake_terraform_role"></a> [snowflake\_terraform\_role](#output\_snowflake\_terraform\_role) | The name of the role given to the Terraform service user. |
+| <a name="output_ssm_path_terraform_user_name"></a> [ssm\_path\_terraform\_user\_name](#output\_ssm\_path\_terraform\_user\_name) | The path to the SSM parameter for the Terraform user name. |
+| <a name="output_ssm_path_terraform_user_private_key"></a> [ssm\_path\_terraform\_user\_private\_key](#output\_ssm\_path\_terraform\_user\_private\_key) | The path to the SSM parameter for the Terraform user private key. |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+
+[<img src="https://cloudposse.com/logo-300x69.svg" height="32" align="right"/>](https://cpco.io/component)

--- a/modules/snowflake-account/context.tf
+++ b/modules/snowflake-account/context.tf
@@ -1,0 +1,279 @@
+#
+# ONLY EDIT THIS FILE IN github.com/cloudposse/terraform-null-label
+# All other instances of this file should be a copy of that one
+#
+#
+# Copy this file from https://github.com/cloudposse/terraform-null-label/blob/master/exports/context.tf
+# and then place it in your Terraform module to automatically get
+# Cloud Posse's standard configuration inputs suitable for passing
+# to Cloud Posse modules.
+#
+# curl -sL https://raw.githubusercontent.com/cloudposse/terraform-null-label/master/exports/context.tf -o context.tf
+#
+# Modules should access the whole context as `module.this.context`
+# to get the input variables with nulls for defaults,
+# for example `context = module.this.context`,
+# and access individual variables as `module.this.<var>`,
+# with final values filled in.
+#
+# For example, when using defaults, `module.this.context.delimiter`
+# will be null, and `module.this.delimiter` will be `-` (hyphen).
+#
+
+module "this" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0" # requires Terraform >= 0.13.0
+
+  enabled             = var.enabled
+  namespace           = var.namespace
+  tenant              = var.tenant
+  environment         = var.environment
+  stage               = var.stage
+  name                = var.name
+  delimiter           = var.delimiter
+  attributes          = var.attributes
+  tags                = var.tags
+  additional_tag_map  = var.additional_tag_map
+  label_order         = var.label_order
+  regex_replace_chars = var.regex_replace_chars
+  id_length_limit     = var.id_length_limit
+  label_key_case      = var.label_key_case
+  label_value_case    = var.label_value_case
+  descriptor_formats  = var.descriptor_formats
+  labels_as_tags      = var.labels_as_tags
+
+  context = var.context
+}
+
+# Copy contents of cloudposse/terraform-null-label/variables.tf here
+
+variable "context" {
+  type = any
+  default = {
+    enabled             = true
+    namespace           = null
+    tenant              = null
+    environment         = null
+    stage               = null
+    name                = null
+    delimiter           = null
+    attributes          = []
+    tags                = {}
+    additional_tag_map  = {}
+    regex_replace_chars = null
+    label_order         = []
+    id_length_limit     = null
+    label_key_case      = null
+    label_value_case    = null
+    descriptor_formats  = {}
+    # Note: we have to use [] instead of null for unset lists due to
+    # https://github.com/hashicorp/terraform/issues/28137
+    # which was not fixed until Terraform 1.0.0,
+    # but we want the default to be all the labels in `label_order`
+    # and we want users to be able to prevent all tag generation
+    # by setting `labels_as_tags` to `[]`, so we need
+    # a different sentinel to indicate "default"
+    labels_as_tags = ["unset"]
+  }
+  description = <<-EOT
+    Single object for setting entire context at once.
+    See description of individual variables for details.
+    Leave string and numeric variables as `null` to use default value.
+    Individual variable settings (non-null) override settings in context object,
+    except for attributes, tags, and additional_tag_map, which are merged.
+  EOT
+
+  validation {
+    condition     = lookup(var.context, "label_key_case", null) == null ? true : contains(["lower", "title", "upper"], var.context["label_key_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+
+  validation {
+    condition     = lookup(var.context, "label_value_case", null) == null ? true : contains(["lower", "title", "upper", "none"], var.context["label_value_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+variable "enabled" {
+  type        = bool
+  default     = null
+  description = "Set to false to prevent the module from creating any resources"
+}
+
+variable "namespace" {
+  type        = string
+  default     = null
+  description = "ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique"
+}
+
+variable "tenant" {
+  type        = string
+  default     = null
+  description = "ID element _(Rarely used, not included by default)_. A customer identifier, indicating who this instance of a resource is for"
+}
+
+variable "environment" {
+  type        = string
+  default     = null
+  description = "ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT'"
+}
+
+variable "stage" {
+  type        = string
+  default     = null
+  description = "ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release'"
+}
+
+variable "name" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.
+    This is the only ID element not also included as a `tag`.
+    The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input.
+    EOT
+}
+
+variable "delimiter" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Delimiter to be used between ID elements.
+    Defaults to `-` (hyphen). Set to `""` to use no delimiter at all.
+  EOT
+}
+
+variable "attributes" {
+  type        = list(string)
+  default     = []
+  description = <<-EOT
+    ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,
+    in the order they appear in the list. New attributes are appended to the
+    end of the list. The elements of the list are joined by the `delimiter`
+    and treated as a single ID element.
+    EOT
+}
+
+variable "labels_as_tags" {
+  type        = set(string)
+  default     = ["default"]
+  description = <<-EOT
+    Set of labels (ID elements) to include as tags in the `tags` output.
+    Default is to include all labels.
+    Tags with empty values will not be included in the `tags` output.
+    Set to `[]` to suppress all generated tags.
+    **Notes:**
+      The value of the `name` tag, if included, will be the `id`, not the `name`.
+      Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be
+      changed in later chained modules. Attempts to change it will be silently ignored.
+    EOT
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+    Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).
+    Neither the tag keys nor the tag values will be modified by this module.
+    EOT
+}
+
+variable "additional_tag_map" {
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+    Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.
+    This is for some rare cases where resources want additional configuration of tags
+    and therefore take a list of maps with tag key, value, and additional configuration.
+    EOT
+}
+
+variable "label_order" {
+  type        = list(string)
+  default     = null
+  description = <<-EOT
+    The order in which the labels (ID elements) appear in the `id`.
+    Defaults to ["namespace", "environment", "stage", "name", "attributes"].
+    You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present.
+    EOT
+}
+
+variable "regex_replace_chars" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Terraform regular expression (regex) string.
+    Characters matching the regex will be removed from the ID elements.
+    If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits.
+  EOT
+}
+
+variable "id_length_limit" {
+  type        = number
+  default     = null
+  description = <<-EOT
+    Limit `id` to this many characters (minimum 6).
+    Set to `0` for unlimited length.
+    Set to `null` for keep the existing setting, which defaults to `0`.
+    Does not affect `id_full`.
+  EOT
+  validation {
+    condition     = var.id_length_limit == null ? true : var.id_length_limit >= 6 || var.id_length_limit == 0
+    error_message = "The id_length_limit must be >= 6 if supplied (not null), or 0 for unlimited length."
+  }
+}
+
+variable "label_key_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Controls the letter case of the `tags` keys (label names) for tags generated by this module.
+    Does not affect keys of tags passed in via the `tags` input.
+    Possible values: `lower`, `title`, `upper`.
+    Default value: `title`.
+  EOT
+
+  validation {
+    condition     = var.label_key_case == null ? true : contains(["lower", "title", "upper"], var.label_key_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+}
+
+variable "label_value_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Controls the letter case of ID elements (labels) as included in `id`,
+    set as tag values, and output by this module individually.
+    Does not affect values of tags passed in via the `tags` input.
+    Possible values: `lower`, `title`, `upper` and `none` (no transformation).
+    Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.
+    Default value: `lower`.
+  EOT
+
+  validation {
+    condition     = var.label_value_case == null ? true : contains(["lower", "title", "upper", "none"], var.label_value_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+variable "descriptor_formats" {
+  type        = any
+  default     = {}
+  description = <<-EOT
+    Describe additional descriptors to be output in the `descriptors` output map.
+    Map of maps. Keys are names of descriptors. Values are maps of the form
+    `{
+       format = string
+       labels = list(string)
+    }`
+    (Type is `any` so the map values can later be enhanced to provide additional options.)
+    `format` is a Terraform format string to be passed to the `format()` function.
+    `labels` is a list of labels, in order, to pass to `format()` function.
+    Label values will be normalized before being passed to `format()` so they will be
+    identical to how they appear in `id`.
+    Default is `{}` (`descriptors` output will be empty).
+    EOT
+}
+
+#### End of copy of cloudposse/terraform-null-label/variables.tf

--- a/modules/snowflake-account/default.auto.tfvars
+++ b/modules/snowflake-account/default.auto.tfvars
@@ -1,0 +1,3 @@
+# This file is included by default in terraform plans
+
+enabled = false

--- a/modules/snowflake-account/introspection.mixin.tf
+++ b/modules/snowflake-account/introspection.mixin.tf
@@ -1,0 +1,26 @@
+locals {
+  # Throw an error if lookup fails
+  # tflint-ignore: terraform_unused_declarations
+  check_required_tags = module.this.enabled ? [
+    for k in var.required_tags :
+    lookup(module.this.tags, k)
+  ] : []
+}
+
+variable "required_tags" {
+  type        = list(string)
+  description = "List of required tag names"
+  default     = []
+}
+
+# introspection module will contain the additional tags
+module "introspection" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0"
+
+  tags = merge(var.tags, {
+    "Component" = basename(abspath(path.module))
+  })
+
+  context = module.this.context
+}

--- a/modules/snowflake-account/main.tf
+++ b/modules/snowflake-account/main.tf
@@ -1,0 +1,183 @@
+locals {
+  enabled = module.introspection.enabled
+
+  snowflake_user_email = format(module.account.outputs.account_email_format, module.introspection.stage)
+
+  ssm_path_admin_user_name            = format(var.ssm_path_snowflake_user_format, "snowflake", var.snowflake_account, "users", local.admin_username, "username")
+  ssm_path_admin_user_password        = format(var.ssm_path_snowflake_user_format, "snowflake", var.snowflake_account, "users", local.admin_username, "password")
+  ssm_path_terraform_user_name        = format(var.ssm_path_snowflake_user_format, "snowflake", var.snowflake_account, "users", local.terraform_username, "username")
+  ssm_path_terraform_user_password    = format(var.ssm_path_snowflake_user_format, "snowflake", var.snowflake_account, "users", local.terraform_username, "password")
+  ssm_path_terraform_user_private_key = format(var.ssm_path_snowflake_user_format, "snowflake", var.snowflake_account, "users", local.terraform_username, "private_key")
+
+  # Fixed username given manually during Snowflake account creation.
+  # This user is only used to create the terraform service user
+  admin_username = var.snowflake_admin_username
+
+  terraform_username = format(var.snowflake_username_format, module.snowflake_account.id, var.service_user_id)
+
+  snowflake_terraform_role = local.enabled ? module.snowflake_role.id : ""
+}
+
+module "utils" {
+  source  = "cloudposse/utils/aws"
+  version = "0.8.1"
+  context = module.introspection.context
+}
+
+module "snowflake_account" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0"
+
+  # Change to use the Snowflake region, typically the same as the given stack
+  environment = lookup(module.utils.region_az_alt_code_maps["to_short"], var.snowflake_account_region)
+
+  context = module.introspection.context
+}
+
+# Identifier for the virtual warehouse; must be unique for your account. In addition, the identifier must start with an alphabetic character and cannot contain spaces or special characters unless the entire identifier string is enclosed in double quotes (e.g. "My object" ).
+module "snowflake_warehouse" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0"
+
+  # Change to use the Snowflake region, typically the same as the given stack
+  environment = lookup(module.utils.region_az_alt_code_maps["to_short"], var.snowflake_account_region)
+
+  attributes = ["default", "wh"]
+
+  # Hyphens are not allowed, but underscores are allowed
+  delimiter = "_"
+
+  # Since Warehouse names are case-sensitive, best practice is to make all names upper case
+  label_value_case = "upper"
+
+  context = module.introspection.context
+}
+
+resource "snowflake_warehouse" "default" {
+  count = local.enabled ? 1 : 0
+
+  name           = module.snowflake_warehouse.id
+  comment        = "The default warehouse used to hold required users."
+  warehouse_size = var.default_warehouse_size
+}
+
+resource "random_password" "terraform_user_password" {
+  count = local.enabled ? 1 : 0
+
+  length           = 16
+  special          = true
+  override_special = "_%@"
+}
+
+resource "tls_private_key" "terraform_user_key" {
+  count = local.enabled ? 1 : 0
+
+  algorithm = "RSA"
+}
+
+resource "snowflake_user" "terraform" {
+  count = local.enabled ? 1 : 0
+
+  name       = "Snowflake Terraform User"
+  login_name = local.terraform_username
+  comment    = "Terraform service user"
+  password   = random_password.terraform_user_password[0].result
+
+  disabled     = false
+  display_name = local.terraform_username
+  email        = local.snowflake_user_email
+
+  first_name = var.terraform_user_first_name
+  last_name  = var.terraform_user_last_name
+
+  default_warehouse = snowflake_warehouse.default[0].name
+  default_role      = snowflake_role.terraform[0].name
+
+  # Key must be in a single line string with the ---*--- prefix and suffix removed
+  rsa_public_key = replace(trimsuffix(trimprefix(chomp(tls_private_key.terraform_user_key[0].public_key_pem), "-----BEGIN PUBLIC KEY-----"), "-----END PUBLIC KEY-----"), "\n", "")
+
+  must_change_password = false
+}
+
+# The identifier must start with an alphabetic character and cannot contain spaces or special characters unless the entire identifier string is enclosed in double quotes (e.g. "My object"). Identifiers enclosed in double quotes are also case-sensitive.
+module "snowflake_role" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0"
+
+  environment      = lookup(module.utils.region_az_alt_code_maps["to_short"], var.snowflake_account_region)
+  attributes       = ["terraform", "role"]
+  delimiter        = ""
+  label_value_case = "title"
+
+  context = module.introspection.context
+}
+
+# Snowflake recommends using custom roles in all cases. Assign system roles to those custom roles to grant appropriate permission.
+resource "snowflake_role" "terraform" {
+  count = local.enabled ? 1 : 0
+
+  name    = module.snowflake_role.id
+  comment = var.snowflake_role_description
+}
+
+resource "snowflake_role_grants" "grant_system_roles" {
+  count = local.enabled ? 1 : 0
+
+  role_name = "ACCOUNTADMIN"
+
+  # Snowflake resource names are enclosed in quotes intentionally per Idenitier Requirements:
+  # https://docs.snowflake.com/en/sql-reference/identifiers-syntax.html#identifier-requirements
+  roles = [
+    "${snowflake_role.terraform[0].name}",
+  ]
+}
+
+resource "snowflake_role_grants" "grant_custom_roles" {
+  count = local.enabled ? 1 : 0
+
+  role_name = snowflake_role.terraform[0].name
+
+  # Snowflake resource names are enclosed in quotes intentionally per Idenitier Requirements:
+  # https://docs.snowflake.com/en/sql-reference/identifiers-syntax.html#identifier-requirements
+  users = [
+    "${snowflake_user.terraform[0].name}",
+  ]
+}
+
+module "ssm_parameters" {
+  source  = "cloudposse/ssm-parameter-store/aws"
+  version = "0.9.1"
+
+  parameter_write = [
+    {
+      name        = local.ssm_path_admin_user_name
+      value       = local.admin_username
+      type        = "String"
+      overwrite   = "false"
+      description = "Snowflake Admin User Name"
+    },
+    {
+      name        = local.ssm_path_terraform_user_name
+      value       = local.terraform_username
+      type        = "String"
+      overwrite   = "false"
+      description = "Snowflake Terraform User Name"
+    },
+    {
+      name        = local.ssm_path_terraform_user_password
+      value       = random_password.terraform_user_password[0].result
+      type        = "SecureString"
+      overwrite   = "false"
+      description = "Snowflake Terraform User Password"
+    },
+    {
+      name        = local.ssm_path_terraform_user_private_key
+      value       = tls_private_key.terraform_user_key[0].private_key_pem
+      type        = "SecureString"
+      overwrite   = "false"
+      description = "Snowflake Terraform User Private Key"
+    }
+  ]
+
+  context = module.introspection.context
+}

--- a/modules/snowflake-account/outputs.tf
+++ b/modules/snowflake-account/outputs.tf
@@ -1,0 +1,24 @@
+output "snowflake_account" {
+  value       = var.snowflake_account
+  description = "The Snowflake account ID."
+}
+
+output "snowflake_region" {
+  value       = var.snowflake_account_region
+  description = "The AWS Region with the Snowflake account."
+}
+
+output "snowflake_terraform_role" {
+  value       = local.snowflake_terraform_role
+  description = "The name of the role given to the Terraform service user."
+}
+
+output "ssm_path_terraform_user_name" {
+  value       = local.ssm_path_terraform_user_name
+  description = "The path to the SSM parameter for the Terraform user name."
+}
+
+output "ssm_path_terraform_user_private_key" {
+  value       = local.ssm_path_terraform_user_private_key
+  description = "The path to the SSM parameter for the Terraform user private key."
+}

--- a/modules/snowflake-account/providers.tf
+++ b/modules/snowflake-account/providers.tf
@@ -1,0 +1,41 @@
+provider "aws" {
+  region = var.region
+
+  profile = module.iam_roles.profiles_enabled ? coalesce(var.import_profile_name, module.iam_roles.terraform_profile_name) : null
+  dynamic "assume_role" {
+    for_each = module.iam_roles.profiles_enabled ? [] : ["role"]
+    content {
+      role_arn = coalesce(var.import_role_arn, module.iam_roles.terraform_role_arn)
+    }
+  }
+}
+
+module "iam_roles" {
+  source  = "../account-map/modules/iam-roles"
+  context = module.this.context
+}
+
+variable "import_profile_name" {
+  type        = string
+  default     = null
+  description = "AWS Profile name to use when importing a resource"
+}
+
+variable "import_role_arn" {
+  type        = string
+  default     = null
+  description = "IAM Role ARN to use when importing a resource"
+}
+
+data "aws_ssm_parameter" "snowflake_password" {
+  count           = local.enabled ? 1 : 0
+  name            = local.ssm_path_admin_user_password
+  with_decryption = true
+}
+
+provider "snowflake" {
+  account  = var.snowflake_account
+  region   = "${var.snowflake_account_region}.aws" # required to append ".aws" to region, see https://github.com/chanzuckerberg/terraform-provider-snowflake/issues/529
+  username = local.admin_username
+  password = data.aws_ssm_parameter.snowflake_password[0].value
+}

--- a/modules/snowflake-account/remote-state.tf
+++ b/modules/snowflake-account/remote-state.tf
@@ -1,6 +1,6 @@
 module "account" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "0.22.0"
+  version = "0.22.1"
 
   component   = "account"
   stage       = var.root_account_stage_name

--- a/modules/snowflake-account/remote-state.tf
+++ b/modules/snowflake-account/remote-state.tf
@@ -1,0 +1,11 @@
+module "account" {
+  source  = "cloudposse/stack-config/yaml//modules/remote-state"
+  version = "0.22.0"
+
+  component   = "account"
+  stage       = var.root_account_stage_name
+  environment = var.global_environment_name
+  privileged  = var.privileged
+
+  context = module.introspection.context
+}

--- a/modules/snowflake-account/variables.tf
+++ b/modules/snowflake-account/variables.tf
@@ -1,0 +1,80 @@
+variable "region" {
+  type        = string
+  description = "AWS Region"
+}
+
+variable "snowflake_account" {
+  type        = string
+  description = "The Snowflake account given with the AWS Marketplace Subscription."
+}
+
+variable "snowflake_account_region" {
+  type        = string
+  description = "AWS Region with the Snowflake subscription"
+}
+
+variable "ssm_path_snowflake_user_format" {
+  type        = string
+  default     = "/%s/%s/%s/%s/%s"
+  description = "SSM parameter path format for a Snowflake user. For example, /snowflake/{{ account }}/users/{{ username }}/"
+}
+
+variable "snowflake_username_format" {
+  type        = string
+  default     = "%s-%s"
+  description = "Snowflake username format"
+}
+
+variable "snowflake_admin_username" {
+  type        = string
+  default     = "admin"
+  description = "Snowflake admin username created with the initial account subscription."
+}
+
+variable "default_warehouse_size" {
+  type        = string
+  default     = "xsmall"
+  description = "The size for the default Snowflake Warehouse"
+}
+
+variable "terraform_user_first_name" {
+  type        = string
+  default     = "Terrafrom"
+  description = "Snowflake Terraform first name given with User creation"
+}
+
+variable "terraform_user_last_name" {
+  type        = string
+  default     = "User"
+  description = "Snowflake Terraform last name given with User creation"
+}
+
+variable "root_account_stage_name" {
+  type        = string
+  default     = "root"
+  description = "The stage name for the AWS Organization root (master) account"
+}
+
+variable "global_environment_name" {
+  type        = string
+  default     = "gbl"
+  description = "Global environment name"
+}
+
+variable "privileged" {
+  type        = bool
+  description = "True if the default provider already has access to the backend"
+  default     = false
+}
+
+variable "service_user_id" {
+  type        = string
+  description = "The identifier for the service user created to manage infrastructure."
+  default     = "terraform"
+}
+
+variable "snowflake_role_description" {
+  type        = string
+  description = "Comment to attach to the Snowflake Role."
+  default     = "Terraform service user role."
+}

--- a/modules/snowflake-account/versions.tf
+++ b/modules/snowflake-account/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     tls = {
       source  = "hashicorp/tls"
-      version = "~> 3.1.0"
+      version = "~> 3.0"
     }
   }
 }

--- a/modules/snowflake-account/versions.tf
+++ b/modules/snowflake-account/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     snowflake = {
       source  = "chanzuckerberg/snowflake"
-      version = "~> 0.25.36"
+      version = "~> 0.25"
     }
     tls = {
       source  = "hashicorp/tls"

--- a/modules/snowflake-account/versions.tf
+++ b/modules/snowflake-account/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.0.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+    snowflake = {
+      source  = "chanzuckerberg/snowflake"
+      version = "~> 0.25.36"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 3.1.0"
+    }
+  }
+}

--- a/modules/snowflake-database/README.md
+++ b/modules/snowflake-database/README.md
@@ -1,0 +1,133 @@
+# Component: `snowflake-database`
+
+All data in Snowflake is stored in database tables, logically structured as collections of columns and rows. This component will create and control a Snowflake database, schema, and set of tables. 
+
+## Usage
+
+**Stack Level**: Regional
+
+Here's an example snippet for how to use this component:
+
+```yaml
+components:
+  terraform:
+    snowflake-database:
+      vars:
+        enabled: true
+        tags:
+          Team: data
+          Service: snowflake
+        tables:
+          example:
+            comment: "An example table"
+            columns:
+              - name: "data"
+                type: "text"
+              - name: "DATE"
+                type: "TIMESTAMP_NTZ(9)"
+              - name: "extra"
+                type: "VARIANT"
+                comment: "extra data"
+            primary_key:
+              name: "pk"
+              keys:
+                - "data"
+        views:
+          select-example:
+            comment: "An example view"
+            statement: |
+              select * from "example";
+```
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.0 |
+| <a name="requirement_snowflake"></a> [snowflake](#requirement\_snowflake) | ~> 0.25.36 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.0 |
+| <a name="provider_snowflake"></a> [snowflake](#provider\_snowflake) | ~> 0.25.36 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
+| <a name="module_introspection"></a> [introspection](#module\_introspection) | cloudposse/label/null | 0.25.0 |
+| <a name="module_snowflake_account"></a> [snowflake\_account](#module\_snowflake\_account) | cloudposse/stack-config/yaml//modules/remote-state | 0.22.0 |
+| <a name="module_snowflake_database"></a> [snowflake\_database](#module\_snowflake\_database) | cloudposse/label/null | 0.25.0 |
+| <a name="module_snowflake_label"></a> [snowflake\_label](#module\_snowflake\_label) | cloudposse/label/null | 0.25.0 |
+| <a name="module_snowflake_schema"></a> [snowflake\_schema](#module\_snowflake\_schema) | cloudposse/label/null | 0.25.0 |
+| <a name="module_snowflake_sequence"></a> [snowflake\_sequence](#module\_snowflake\_sequence) | cloudposse/label/null | 0.25.0 |
+| <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
+| <a name="module_utils"></a> [utils](#module\_utils) | cloudposse/utils/aws | 0.8.1 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [snowflake_database.this](https://registry.terraform.io/providers/chanzuckerberg/snowflake/latest/docs/resources/database) | resource |
+| [snowflake_database_grant.grant](https://registry.terraform.io/providers/chanzuckerberg/snowflake/latest/docs/resources/database_grant) | resource |
+| [snowflake_schema.this](https://registry.terraform.io/providers/chanzuckerberg/snowflake/latest/docs/resources/schema) | resource |
+| [snowflake_schema_grant.grant](https://registry.terraform.io/providers/chanzuckerberg/snowflake/latest/docs/resources/schema_grant) | resource |
+| [snowflake_sequence.this](https://registry.terraform.io/providers/chanzuckerberg/snowflake/latest/docs/resources/sequence) | resource |
+| [snowflake_table.tables](https://registry.terraform.io/providers/chanzuckerberg/snowflake/latest/docs/resources/table) | resource |
+| [snowflake_table_grant.grant](https://registry.terraform.io/providers/chanzuckerberg/snowflake/latest/docs/resources/table_grant) | resource |
+| [snowflake_view.view](https://registry.terraform.io/providers/chanzuckerberg/snowflake/latest/docs/resources/view) | resource |
+| [snowflake_view_grant.grant](https://registry.terraform.io/providers/chanzuckerberg/snowflake/latest/docs/resources/view_grant) | resource |
+| [aws_ssm_parameter.snowflake_private_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
+| [aws_ssm_parameter.snowflake_username](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br>This is for some rare cases where resources want additional configuration of tags<br>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
+| <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br>in the order they appear in the list. New attributes are appended to the<br>end of the list. The elements of the list are joined by the `delimiter`<br>and treated as a single ID element. | `list(string)` | `[]` | no |
+| <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "descriptor_formats": {},<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "labels_as_tags": [<br>    "unset"<br>  ],<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {},<br>  "tenant": null<br>}</pre> | no |
+| <a name="input_data_retention_time_in_days"></a> [data\_retention\_time\_in\_days](#input\_data\_retention\_time\_in\_days) | Time in days to retain data in Snowflake databases, schemas, and tables by default. | `string` | `1` | no |
+| <a name="input_database_comment"></a> [database\_comment](#input\_database\_comment) | The comment to give to the provisioned database. | `string` | `"A database created for managing programmatically created Snowflake schemas and tables."` | no |
+| <a name="input_database_grants"></a> [database\_grants](#input\_database\_grants) | A list of Grants to give to the database created with component. | `list(string)` | `[]` | no |
+| <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between ID elements.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
+| <a name="input_descriptor_formats"></a> [descriptor\_formats](#input\_descriptor\_formats) | Describe additional descriptors to be output in the `descriptors` output map.<br>Map of maps. Keys are names of descriptors. Values are maps of the form<br>`{<br>   format = string<br>   labels = list(string)<br>}`<br>(Type is `any` so the map values can later be enhanced to provide additional options.)<br>`format` is a Terraform format string to be passed to the `format()` function.<br>`labels` is a list of labels, in order, to pass to `format()` function.<br>Label values will be normalized before being passed to `format()` so they will be<br>identical to how they appear in `id`.<br>Default is `{}` (`descriptors` output will be empty). | `any` | `{}` | no |
+| <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
+| <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for keep the existing setting, which defaults to `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
+| <a name="input_import_profile_name"></a> [import\_profile\_name](#input\_import\_profile\_name) | AWS Profile name to use when importing a resource | `string` | `null` | no |
+| <a name="input_import_role_arn"></a> [import\_role\_arn](#input\_import\_role\_arn) | IAM Role ARN to use when importing a resource | `string` | `null` | no |
+| <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | Controls the letter case of the `tags` keys (label names) for tags generated by this module.<br>Does not affect keys of tags passed in via the `tags` input.<br>Possible values: `lower`, `title`, `upper`.<br>Default value: `title`. | `string` | `null` | no |
+| <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The order in which the labels (ID elements) appear in the `id`.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present. | `list(string)` | `null` | no |
+| <a name="input_label_value_case"></a> [label\_value\_case](#input\_label\_value\_case) | Controls the letter case of ID elements (labels) as included in `id`,<br>set as tag values, and output by this module individually.<br>Does not affect values of tags passed in via the `tags` input.<br>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br>Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.<br>Default value: `lower`. | `string` | `null` | no |
+| <a name="input_labels_as_tags"></a> [labels\_as\_tags](#input\_labels\_as\_tags) | Set of labels (ID elements) to include as tags in the `tags` output.<br>Default is to include all labels.<br>Tags with empty values will not be included in the `tags` output.<br>Set to `[]` to suppress all generated tags.<br>**Notes:**<br>  The value of the `name` tag, if included, will be the `id`, not the `name`.<br>  Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be<br>  changed in later chained modules. Attempts to change it will be silently ignored. | `set(string)` | <pre>[<br>  "default"<br>]</pre> | no |
+| <a name="input_name"></a> [name](#input\_name) | ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.<br>This is the only ID element not also included as a `tag`.<br>The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input. | `string` | `null` | no |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique | `string` | `null` | no |
+| <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br>Characters matching the regex will be removed from the ID elements.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
+| <a name="input_region"></a> [region](#input\_region) | AWS Region | `string` | n/a | yes |
+| <a name="input_required_tags"></a> [required\_tags](#input\_required\_tags) | List of required tag names | `list(string)` | `[]` | no |
+| <a name="input_schema_grants"></a> [schema\_grants](#input\_schema\_grants) | A list of Grants to give to the schema created with component. | `list(string)` | `[]` | no |
+| <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
+| <a name="input_table_grants"></a> [table\_grants](#input\_table\_grants) | A list of Grants to give to the tables created with component. | `list(string)` | `[]` | no |
+| <a name="input_tables"></a> [tables](#input\_tables) | A map of tables to create for Snowflake. A schema and database will be assigned for this group of tables. | `map(any)` | `{}` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
+| <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |
+| <a name="input_view_grants"></a> [view\_grants](#input\_view\_grants) | A list of Grants to give to the views created with component. | `list(string)` | `[]` | no |
+| <a name="input_views"></a> [views](#input\_views) | A map of views to create for Snowflake. The same schema and database will be assigned as for tables. | `map(any)` | `{}` | no |
+
+## Outputs
+
+No outputs.
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+
+## References
+* [cloudposse/terraform-aws-components](https://github.com/cloudposse/terraform-aws-components/tree/master/modules/TODO) - Cloud Posse's upstream component
+
+
+[<img src="https://cloudposse.com/logo-300x69.svg" height="32" align="right"/>](https://cpco.io/component)

--- a/modules/snowflake-database/context.tf
+++ b/modules/snowflake-database/context.tf
@@ -1,0 +1,279 @@
+#
+# ONLY EDIT THIS FILE IN github.com/cloudposse/terraform-null-label
+# All other instances of this file should be a copy of that one
+#
+#
+# Copy this file from https://github.com/cloudposse/terraform-null-label/blob/master/exports/context.tf
+# and then place it in your Terraform module to automatically get
+# Cloud Posse's standard configuration inputs suitable for passing
+# to Cloud Posse modules.
+#
+# curl -sL https://raw.githubusercontent.com/cloudposse/terraform-null-label/master/exports/context.tf -o context.tf
+#
+# Modules should access the whole context as `module.this.context`
+# to get the input variables with nulls for defaults,
+# for example `context = module.this.context`,
+# and access individual variables as `module.this.<var>`,
+# with final values filled in.
+#
+# For example, when using defaults, `module.this.context.delimiter`
+# will be null, and `module.this.delimiter` will be `-` (hyphen).
+#
+
+module "this" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0" # requires Terraform >= 0.13.0
+
+  enabled             = var.enabled
+  namespace           = var.namespace
+  tenant              = var.tenant
+  environment         = var.environment
+  stage               = var.stage
+  name                = var.name
+  delimiter           = var.delimiter
+  attributes          = var.attributes
+  tags                = var.tags
+  additional_tag_map  = var.additional_tag_map
+  label_order         = var.label_order
+  regex_replace_chars = var.regex_replace_chars
+  id_length_limit     = var.id_length_limit
+  label_key_case      = var.label_key_case
+  label_value_case    = var.label_value_case
+  descriptor_formats  = var.descriptor_formats
+  labels_as_tags      = var.labels_as_tags
+
+  context = var.context
+}
+
+# Copy contents of cloudposse/terraform-null-label/variables.tf here
+
+variable "context" {
+  type = any
+  default = {
+    enabled             = true
+    namespace           = null
+    tenant              = null
+    environment         = null
+    stage               = null
+    name                = null
+    delimiter           = null
+    attributes          = []
+    tags                = {}
+    additional_tag_map  = {}
+    regex_replace_chars = null
+    label_order         = []
+    id_length_limit     = null
+    label_key_case      = null
+    label_value_case    = null
+    descriptor_formats  = {}
+    # Note: we have to use [] instead of null for unset lists due to
+    # https://github.com/hashicorp/terraform/issues/28137
+    # which was not fixed until Terraform 1.0.0,
+    # but we want the default to be all the labels in `label_order`
+    # and we want users to be able to prevent all tag generation
+    # by setting `labels_as_tags` to `[]`, so we need
+    # a different sentinel to indicate "default"
+    labels_as_tags = ["unset"]
+  }
+  description = <<-EOT
+    Single object for setting entire context at once.
+    See description of individual variables for details.
+    Leave string and numeric variables as `null` to use default value.
+    Individual variable settings (non-null) override settings in context object,
+    except for attributes, tags, and additional_tag_map, which are merged.
+  EOT
+
+  validation {
+    condition     = lookup(var.context, "label_key_case", null) == null ? true : contains(["lower", "title", "upper"], var.context["label_key_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+
+  validation {
+    condition     = lookup(var.context, "label_value_case", null) == null ? true : contains(["lower", "title", "upper", "none"], var.context["label_value_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+variable "enabled" {
+  type        = bool
+  default     = null
+  description = "Set to false to prevent the module from creating any resources"
+}
+
+variable "namespace" {
+  type        = string
+  default     = null
+  description = "ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique"
+}
+
+variable "tenant" {
+  type        = string
+  default     = null
+  description = "ID element _(Rarely used, not included by default)_. A customer identifier, indicating who this instance of a resource is for"
+}
+
+variable "environment" {
+  type        = string
+  default     = null
+  description = "ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT'"
+}
+
+variable "stage" {
+  type        = string
+  default     = null
+  description = "ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release'"
+}
+
+variable "name" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.
+    This is the only ID element not also included as a `tag`.
+    The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input.
+    EOT
+}
+
+variable "delimiter" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Delimiter to be used between ID elements.
+    Defaults to `-` (hyphen). Set to `""` to use no delimiter at all.
+  EOT
+}
+
+variable "attributes" {
+  type        = list(string)
+  default     = []
+  description = <<-EOT
+    ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,
+    in the order they appear in the list. New attributes are appended to the
+    end of the list. The elements of the list are joined by the `delimiter`
+    and treated as a single ID element.
+    EOT
+}
+
+variable "labels_as_tags" {
+  type        = set(string)
+  default     = ["default"]
+  description = <<-EOT
+    Set of labels (ID elements) to include as tags in the `tags` output.
+    Default is to include all labels.
+    Tags with empty values will not be included in the `tags` output.
+    Set to `[]` to suppress all generated tags.
+    **Notes:**
+      The value of the `name` tag, if included, will be the `id`, not the `name`.
+      Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be
+      changed in later chained modules. Attempts to change it will be silently ignored.
+    EOT
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+    Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).
+    Neither the tag keys nor the tag values will be modified by this module.
+    EOT
+}
+
+variable "additional_tag_map" {
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+    Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.
+    This is for some rare cases where resources want additional configuration of tags
+    and therefore take a list of maps with tag key, value, and additional configuration.
+    EOT
+}
+
+variable "label_order" {
+  type        = list(string)
+  default     = null
+  description = <<-EOT
+    The order in which the labels (ID elements) appear in the `id`.
+    Defaults to ["namespace", "environment", "stage", "name", "attributes"].
+    You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present.
+    EOT
+}
+
+variable "regex_replace_chars" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Terraform regular expression (regex) string.
+    Characters matching the regex will be removed from the ID elements.
+    If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits.
+  EOT
+}
+
+variable "id_length_limit" {
+  type        = number
+  default     = null
+  description = <<-EOT
+    Limit `id` to this many characters (minimum 6).
+    Set to `0` for unlimited length.
+    Set to `null` for keep the existing setting, which defaults to `0`.
+    Does not affect `id_full`.
+  EOT
+  validation {
+    condition     = var.id_length_limit == null ? true : var.id_length_limit >= 6 || var.id_length_limit == 0
+    error_message = "The id_length_limit must be >= 6 if supplied (not null), or 0 for unlimited length."
+  }
+}
+
+variable "label_key_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Controls the letter case of the `tags` keys (label names) for tags generated by this module.
+    Does not affect keys of tags passed in via the `tags` input.
+    Possible values: `lower`, `title`, `upper`.
+    Default value: `title`.
+  EOT
+
+  validation {
+    condition     = var.label_key_case == null ? true : contains(["lower", "title", "upper"], var.label_key_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+}
+
+variable "label_value_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Controls the letter case of ID elements (labels) as included in `id`,
+    set as tag values, and output by this module individually.
+    Does not affect values of tags passed in via the `tags` input.
+    Possible values: `lower`, `title`, `upper` and `none` (no transformation).
+    Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.
+    Default value: `lower`.
+  EOT
+
+  validation {
+    condition     = var.label_value_case == null ? true : contains(["lower", "title", "upper", "none"], var.label_value_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+variable "descriptor_formats" {
+  type        = any
+  default     = {}
+  description = <<-EOT
+    Describe additional descriptors to be output in the `descriptors` output map.
+    Map of maps. Keys are names of descriptors. Values are maps of the form
+    `{
+       format = string
+       labels = list(string)
+    }`
+    (Type is `any` so the map values can later be enhanced to provide additional options.)
+    `format` is a Terraform format string to be passed to the `format()` function.
+    `labels` is a list of labels, in order, to pass to `format()` function.
+    Label values will be normalized before being passed to `format()` so they will be
+    identical to how they appear in `id`.
+    Default is `{}` (`descriptors` output will be empty).
+    EOT
+}
+
+#### End of copy of cloudposse/terraform-null-label/variables.tf

--- a/modules/snowflake-database/default.auto.tfvars
+++ b/modules/snowflake-database/default.auto.tfvars
@@ -1,0 +1,8 @@
+# This file is included by default in terraform plans
+
+enabled = false
+
+database_grants = ["MODIFY", "MONITOR", "USAGE"]
+schema_grants   = ["MODIFY", "MONITOR", "USAGE", "CREATE TABLE", "CREATE VIEW"]
+table_grants    = ["SELECT", "INSERT", "UPDATE", "DELETE", "TRUNCATE", "REFERENCES"]
+view_grants     = ["SELECT", "REFERENCES"]

--- a/modules/snowflake-database/grants.tf
+++ b/modules/snowflake-database/grants.tf
@@ -1,0 +1,48 @@
+resource "snowflake_database_grant" "grant" {
+  for_each = toset(local.database_grants)
+
+  database_name = snowflake_database.this[0].name
+
+  privilege = each.key
+  roles     = [local.snowflake_terraform_role]
+
+  with_grant_option = true
+}
+
+resource "snowflake_schema_grant" "grant" {
+  for_each = toset(local.schema_grants)
+
+  database_name = snowflake_database.this[0].name
+
+  privilege = each.key
+  roles     = [local.snowflake_terraform_role]
+
+  on_future         = true
+  with_grant_option = true
+}
+
+resource "snowflake_table_grant" "grant" {
+  for_each = toset(local.table_grants)
+
+  database_name = snowflake_schema.this[0].database
+  schema_name   = snowflake_schema.this[0].name
+
+  privilege = each.key
+  roles     = [local.snowflake_terraform_role]
+
+  on_future         = true
+  with_grant_option = true
+}
+
+resource "snowflake_view_grant" "grant" {
+  for_each = toset(local.view_grants)
+
+  database_name = snowflake_schema.this[0].database
+  schema_name   = snowflake_schema.this[0].name
+
+  privilege = each.key
+  roles     = [local.snowflake_terraform_role]
+
+  on_future         = true
+  with_grant_option = true
+}

--- a/modules/snowflake-database/introspection.mixin.tf
+++ b/modules/snowflake-database/introspection.mixin.tf
@@ -1,0 +1,26 @@
+locals {
+  # Throw an error if lookup fails
+  # tflint-ignore: terraform_unused_declarations
+  check_required_tags = module.this.enabled ? [
+    for k in var.required_tags :
+    lookup(module.this.tags, k)
+  ] : []
+}
+
+variable "required_tags" {
+  type        = list(string)
+  description = "List of required tag names"
+  default     = []
+}
+
+# introspection module will contain the additional tags
+module "introspection" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0"
+
+  tags = merge(var.tags, {
+    "Component" = basename(abspath(path.module))
+  })
+
+  context = module.this.context
+}

--- a/modules/snowflake-database/main.tf
+++ b/modules/snowflake-database/main.tf
@@ -1,0 +1,167 @@
+locals {
+  enabled                  = module.introspection.enabled
+  snowflake_account_region = module.snowflake_account.outputs.snowflake_region
+  snowflake_account        = module.snowflake_account.outputs.snowflake_account
+  snowflake_terraform_role = module.snowflake_account.outputs.snowflake_terraform_role
+
+  tables = local.enabled ? var.tables : {}
+  views  = local.enabled ? var.views : {}
+
+  database_grants = local.enabled ? var.database_grants : []
+  schema_grants   = local.enabled ? var.schema_grants : []
+  table_grants    = local.enabled ? var.table_grants : []
+  view_grants     = local.enabled ? var.view_grants : []
+}
+
+module "utils" {
+  source  = "cloudposse/utils/aws"
+  version = "0.8.1"
+  context = module.introspection.context
+}
+
+# Create a standard label to define resource name for Snowflake best practice.
+module "snowflake_label" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0"
+
+  environment      = lookup(module.utils.region_az_alt_code_maps["to_short"], local.snowflake_account_region)
+  delimiter        = "_"
+  label_value_case = "upper"
+
+  context = module.introspection.context
+}
+
+module "snowflake_database" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0"
+
+  attributes = ["db"]
+  context    = module.snowflake_label.context
+}
+
+resource "snowflake_database" "this" {
+  count = local.enabled ? 1 : 0
+
+  name                        = module.snowflake_database.id
+  comment                     = var.database_comment
+  data_retention_time_in_days = var.data_retention_time_in_days
+}
+
+module "snowflake_schema" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0"
+
+  attributes = ["schema"]
+  context    = module.snowflake_label.context
+}
+
+resource "snowflake_schema" "this" {
+  count = local.enabled ? 1 : 0
+
+  database = snowflake_database.this[0].name
+  name     = module.snowflake_schema.id
+
+  depends_on = [
+    snowflake_schema_grant.grant
+  ]
+}
+
+module "snowflake_sequence" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0"
+
+  attributes = ["sequence"]
+  context    = module.snowflake_label.context
+}
+
+resource "snowflake_sequence" "this" {
+  count = local.enabled ? 1 : 0
+
+  database = snowflake_schema.this[0].database
+  schema   = snowflake_schema.this[0].name
+  name     = module.snowflake_sequence.id
+}
+
+resource "snowflake_table" "tables" {
+  for_each = local.tables
+
+  database            = snowflake_schema.this[0].database
+  schema              = snowflake_schema.this[0].name
+  data_retention_days = snowflake_schema.this[0].data_retention_days
+
+  name    = each.key
+  comment = each.value.comment
+
+  column {
+    name     = "id"
+    type     = "int"
+    nullable = true
+
+    default {
+      sequence = snowflake_sequence.this[0].fully_qualified_name
+    }
+  }
+
+  dynamic "column" {
+    for_each = each.value.columns
+    content {
+      name = column.value["name"]
+      type = column.value["type"]
+    }
+  }
+
+  primary_key {
+    name = each.value.primary_key.name
+    keys = each.value.primary_key.keys
+  }
+
+  depends_on = [
+    snowflake_table_grant.grant
+  ]
+
+  # Ignore changes to column type because of a known issue with the provider. 
+  # Terraform will show changes on plan for updating the type, even though there are not any changes.
+  # https://github.com/chanzuckerberg/terraform-provider-snowflake/issues/494
+  #
+  # Furthermore, Terraform doesn't support wildcards or variables in the lifecycle block, so either we can ignore all changes to `column` or need to list out all indices manually.
+  # """
+  # A single static variable reference is required: only attribute access and indexing with constant keys. 
+  # No calculations, function calls, template expressions, etc are allowed here.
+  # """
+  # https://github.com/hashicorp/terraform/issues/5666
+  lifecycle {
+    ignore_changes = [
+      column[0].type,
+      column[1].type,
+      column[2].type,
+      column[3].type,
+      column[4].type,
+      column[5].type,
+      column[6].type,
+      column[7].type,
+      column[8].type,
+      column[9].type,
+      column[10].type,
+    ]
+  }
+}
+
+resource "snowflake_view" "view" {
+  for_each = local.views
+
+  database = snowflake_schema.this[0].database
+  schema   = snowflake_schema.this[0].name
+
+  name    = each.key
+  comment = each.value.comment
+
+  statement = each.value.statement
+
+  or_replace = false
+  is_secure  = false
+
+  depends_on = [
+    snowflake_view_grant.grant,
+    snowflake_table.tables
+  ]
+}

--- a/modules/snowflake-database/providers.tf
+++ b/modules/snowflake-database/providers.tf
@@ -1,0 +1,47 @@
+provider "aws" {
+  region = var.region
+
+  profile = module.iam_roles.profiles_enabled ? coalesce(var.import_profile_name, module.iam_roles.terraform_profile_name) : null
+  dynamic "assume_role" {
+    for_each = module.iam_roles.profiles_enabled ? [] : ["role"]
+    content {
+      role_arn = coalesce(var.import_role_arn, module.iam_roles.terraform_role_arn)
+    }
+  }
+}
+
+module "iam_roles" {
+  source  = "../account-map/modules/iam-roles"
+  context = module.this.context
+}
+
+variable "import_profile_name" {
+  type        = string
+  default     = null
+  description = "AWS Profile name to use when importing a resource"
+}
+
+variable "import_role_arn" {
+  type        = string
+  default     = null
+  description = "IAM Role ARN to use when importing a resource"
+}
+
+data "aws_ssm_parameter" "snowflake_username" {
+  count = local.enabled ? 1 : 0
+  name  = module.snowflake_account.outputs.ssm_path_terraform_user_name
+}
+
+data "aws_ssm_parameter" "snowflake_private_key" {
+  count           = local.enabled ? 1 : 0
+  name            = module.snowflake_account.outputs.ssm_path_terraform_user_private_key
+  with_decryption = true
+}
+
+provider "snowflake" {
+  account = local.snowflake_account
+  # required to append ".aws" to region, see https://github.com/chanzuckerberg/terraform-provider-snowflake/issues/529
+  region      = "${local.snowflake_account_region}.aws"
+  username    = data.aws_ssm_parameter.snowflake_username[0].value
+  private_key = data.aws_ssm_parameter.snowflake_private_key[0].value
+}

--- a/modules/snowflake-database/remote-state.tf
+++ b/modules/snowflake-database/remote-state.tf
@@ -1,0 +1,8 @@
+module "snowflake_account" {
+  source  = "cloudposse/stack-config/yaml//modules/remote-state"
+  version = "0.22.0"
+
+  component = "snowflake-account"
+
+  context = module.introspection.context
+}

--- a/modules/snowflake-database/remote-state.tf
+++ b/modules/snowflake-database/remote-state.tf
@@ -1,6 +1,6 @@
 module "snowflake_account" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "0.22.0"
+  version = "0.22.1"
 
   component = "snowflake-account"
 

--- a/modules/snowflake-database/variables.tf
+++ b/modules/snowflake-database/variables.tf
@@ -1,0 +1,52 @@
+variable "region" {
+  type        = string
+  description = "AWS Region"
+}
+
+variable "data_retention_time_in_days" {
+  type        = string
+  description = "Time in days to retain data in Snowflake databases, schemas, and tables by default."
+  default     = 1
+}
+
+variable "tables" {
+  type        = map(any)
+  description = "A map of tables to create for Snowflake. A schema and database will be assigned for this group of tables."
+  default     = {}
+}
+
+variable "views" {
+  type        = map(any)
+  description = "A map of views to create for Snowflake. The same schema and database will be assigned as for tables."
+  default     = {}
+}
+
+variable "database_grants" {
+  type        = list(string)
+  description = "A list of Grants to give to the database created with component."
+  default     = []
+}
+
+variable "schema_grants" {
+  type        = list(string)
+  description = "A list of Grants to give to the schema created with component."
+  default     = []
+}
+
+variable "table_grants" {
+  type        = list(string)
+  description = "A list of Grants to give to the tables created with component."
+  default     = []
+}
+
+variable "view_grants" {
+  type        = list(string)
+  description = "A list of Grants to give to the views created with component."
+  default     = []
+}
+
+variable "database_comment" {
+  type        = string
+  description = "The comment to give to the provisioned database."
+  default     = "A database created for managing programmatically created Snowflake schemas and tables."
+}

--- a/modules/snowflake-database/versions.tf
+++ b/modules/snowflake-database/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     snowflake = {
       source  = "chanzuckerberg/snowflake"
-      version = "~> 0.25.36"
+      version = "~> 0.25"
     }
   }
 }

--- a/modules/snowflake-database/versions.tf
+++ b/modules/snowflake-database/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.0.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+    snowflake = {
+      source  = "chanzuckerberg/snowflake"
+      version = "~> 0.25.36"
+    }
+  }
+}


### PR DESCRIPTION
## what
- Added modules for `snowflake-account` and `snowflake-database`

## why
- Provided examples for using Snowflake
- `snowflake-account` creates the requirements for running snowflake components
- `snowflake-database` is an example snowflake component

## NOTE
* If you are adding a new component to `terraform-aws-components`, you must add a label to the pull request specifying the earliest major and minor versions of Terraform for which the component must remain backwards compatible. (E.g., `terraform/0.15`, `terraform/0.12`, etc.). If compatibility with pre-1.0 versions of Terraform is not required, just select the `terraform/1.x` label.
* The chosen label will determine the version of Terraform that will be used in this pull request's `pre-commit` status checks.
