### PR TITLE
use https for for pre-commit-terraform repo

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
                 modules/github-actions-runner/runners/actions-runner/chart/templates/.*.yaml |
                 modules/echo-server/charts/echo-server/templates/.*.yaml
             )$
-  - repo: git://github.com/antonbabenko/pre-commit-terraform
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.55.0
     hooks:
       - id: terraform_fmt


### PR DESCRIPTION
## what
* use `https://` for the `pre-commit-terraform` repo attribute

## why
* The `git://` scheme is no longer accepted by GitHub

## references
* https://github.blog/2021-09-01-improving-git-protocol-security-github/

## NOTE
* this currently causes pre-commit to fail locally
