### PR TITLE
update(iam-primary-roles): use aws_partition data source for arn

### DIFF
--- a/modules/iam-primary-roles/README.md
+++ b/modules/iam-primary-roles/README.md
@@ -133,12 +133,14 @@ components:
 | [aws_iam_policy.delegated_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.aggregated](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.cicd](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.delegated_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.empty](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.primary_roles_assume](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.saml_provider_assume](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 | [terraform_remote_state.account_map](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 | [terraform_remote_state.sso](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 

--- a/modules/iam-primary-roles/cicd-policy.tf
+++ b/modules/iam-primary-roles/cicd-policy.tf
@@ -7,7 +7,7 @@ data "aws_iam_policy_document" "cicd" {
       "sts:TagSession",
     ]
     resources = [
-      format("arn:%s:iam::*:role/*-helm", data.aws_partition.current.partition),
+      format("arn:%s:iam::%s:role/*-helm", data.aws_partition.current.partition, data.aws_caller_identity.current.account_id),
       //"arn:aws:iam::*:role/*-terraform",
     ]
   }

--- a/modules/iam-primary-roles/cicd-policy.tf
+++ b/modules/iam-primary-roles/cicd-policy.tf
@@ -7,7 +7,7 @@ data "aws_iam_policy_document" "cicd" {
       "sts:TagSession",
     ]
     resources = [
-      "arn:aws:iam::*:role/*-helm",
+      "arn:aws-us-gov:iam::*:role/*-helm",
       //"arn:aws:iam::*:role/*-terraform",
     ]
   }
@@ -16,7 +16,7 @@ data "aws_iam_policy_document" "cicd" {
     effect  = "Deny"
     actions = ["sts:AssumeRole"]
     resources = [
-      "arn:aws:iam::xxx:role/*"
+      "arn:aws-us-gov:iam::xxx:role/*"
     ]
   }
   statement {

--- a/modules/iam-primary-roles/cicd-policy.tf
+++ b/modules/iam-primary-roles/cicd-policy.tf
@@ -7,7 +7,7 @@ data "aws_iam_policy_document" "cicd" {
       "sts:TagSession",
     ]
     resources = [
-      "arn:aws:iam::*:role/*-helm",
+      format("arn:%s:iam::*:role/*-helm", data.aws_partition.current.partition),
       //"arn:aws:iam::*:role/*-terraform",
     ]
   }
@@ -16,7 +16,7 @@ data "aws_iam_policy_document" "cicd" {
     effect  = "Deny"
     actions = ["sts:AssumeRole"]
     resources = [
-      "arn:aws:iam::xxx:role/*"
+      format("arn:%s:iam::xxx:role/*", data.aws_partition.current.partition)
     ]
   }
   statement {

--- a/modules/iam-primary-roles/cicd-policy.tf
+++ b/modules/iam-primary-roles/cicd-policy.tf
@@ -7,7 +7,7 @@ data "aws_iam_policy_document" "cicd" {
       "sts:TagSession",
     ]
     resources = [
-      "arn:aws-us-gov:iam::*:role/*-helm",
+      "arn:aws:iam::*:role/*-helm",
       //"arn:aws:iam::*:role/*-terraform",
     ]
   }
@@ -16,7 +16,7 @@ data "aws_iam_policy_document" "cicd" {
     effect  = "Deny"
     actions = ["sts:AssumeRole"]
     resources = [
-      "arn:aws-us-gov:iam::xxx:role/*"
+      "arn:aws:iam::xxx:role/*"
     ]
   }
   statement {

--- a/modules/iam-primary-roles/delegated-assume-role.tf
+++ b/modules/iam-primary-roles/delegated-assume-role.tf
@@ -10,7 +10,7 @@ data "aws_iam_policy_document" "delegated_assume_role" {
     effect  = "Allow"
     actions = ["sts:AssumeRole"]
     resources = [
-      "arn:aws:iam::*:role/*",
+      format("arn:%s:iam::*:role/*", data.aws_partition.current.partition),
     ]
   }
 
@@ -19,9 +19,9 @@ data "aws_iam_policy_document" "delegated_assume_role" {
     effect  = "Deny"
     actions = ["sts:AssumeRole"]
     resources = [
-      format("arn:aws:iam::%s:role/*", local.root_account_id),
-      format("arn:aws:iam::%s:role/*", local.identity_account_id),
-      format("arn:aws:iam::%s:role/*", local.audit_account_id),
+      format("arn:%s:iam::%s:role/*", data.aws_partition.current.partition, local.root_account_id),
+      format("arn:%s:iam::%s:role/*", data.aws_partition.current.partition, local.identity_account_id),
+      format("arn:%s:iam::%s:role/*", data.aws_partition.current.partition, local.audit_account_id),
     ]
   }
 }

--- a/modules/iam-primary-roles/main.tf
+++ b/modules/iam-primary-roles/main.tf
@@ -28,7 +28,7 @@ locals {
   allowed_assume_role_principals_map = {
     for target_role, config in local.roles_config : target_role => [
       for source_role in config.trusted_primary_roles : # aws_iam_role.default[role].arn
-      format("arn:%s:iam::%s:role/%s", data.aws_partition.current.partition, var.primary_account_id, local.role_name_map[source_role]) if !contains([target_role, "cicd"], source_role)
+      format("arn:%s:iam::%s:role/%s", data.aws_partition.current.partition, var.primary_account_id, local.role_name_map[source_role]) if ! contains([target_role, "cicd"], source_role)
     ]
   }
 }
@@ -67,7 +67,7 @@ data "aws_iam_policy_document" "primary_roles_assume" {
   for_each = local.roles_config
 
   dynamic "statement" {
-    for_each = !local.assume_role_restricted || length(local.allowed_assume_role_principals_map[each.key]) > 0 ? ["has_principals"] : []
+    for_each = ! local.assume_role_restricted || length(local.allowed_assume_role_principals_map[each.key]) > 0 ? ["has_principals"] : []
     content {
       sid = "IdentityAccountAssume"
       actions = [

--- a/modules/iam-primary-roles/tfstate-context.tf
+++ b/modules/iam-primary-roles/tfstate-context.tf
@@ -18,7 +18,7 @@ variable "tfstate_account_id" {
 
 variable "tfstate_role_arn_template" {
   type        = string
-  default     = "arn:aws-us-gov:iam::%s:role/%s-%s-%s-%s"
+  default     = "arn:aws:iam::%s:role/%s-%s-%s-%s"
   description = "IAM Role ARN template for accessing the Terraform remote state"
 }
 

--- a/modules/iam-primary-roles/tfstate-context.tf
+++ b/modules/iam-primary-roles/tfstate-context.tf
@@ -18,7 +18,7 @@ variable "tfstate_account_id" {
 
 variable "tfstate_role_arn_template" {
   type        = string
-  default     = "arn:aws:iam::%s:role/%s-%s-%s-%s"
+  default     = "arn:aws-us-gov:iam::%s:role/%s-%s-%s-%s"
   description = "IAM Role ARN template for accessing the Terraform remote state"
 }
 


### PR DESCRIPTION
## what
* added aws_partition data source 

## why
* support deployments in Commercial and GovCloud regions
