### PR TITLE
CPLIVE-279: Added `argocd-repo`

### DIFF
--- a/modules/argocd-repo/README.md
+++ b/modules/argocd-repo/README.md
@@ -175,7 +175,7 @@ $ terraform import -var "import_profile_name=eg-mgmt-gbl-corp-admin" -var-file="
 
 
 ## References
-  * [cloudposse/terraform-aws-components](https://github.com/cloudposse/terraform-aws-components/tree/master/modules/TODO) - Cloud Posse's upstream component
+  * [cloudposse/terraform-aws-components](https://github.com/cloudposse/terraform-aws-components/tree/master/modules/argocd-repo) - Cloud Posse's upstream component
 
 
 [<img src="https://cloudposse.com/logo-300x69.svg" height="32" align="right"/>](https://cpco.io/component)

--- a/modules/argocd-repo/README.md
+++ b/modules/argocd-repo/README.md
@@ -1,0 +1,181 @@
+# Component: `argocd-repo`
+
+This component is responsible for creating and managing an ArgoCD desired state repository.
+
+## Usage
+
+**Stack Level**: Regional
+
+The following are example snippets of how to use this component:
+
+```yaml
+# stacks/argocd/repo/default.yaml
+components:
+  terraform:
+    argocd-repo:
+      vars:
+        enabled: true
+        github_user: ci-acme
+        github_user_email: ci@acme.com
+        github_organization: ACME
+        github_codeowner_teams:
+          - "@ACME/cloud-admins"
+          - "@ACME/cloud-posse"
+        # the team must be present in the org where the repository lives
+        # team_slug is the name of the team without the org
+        # e.g. `@cloudposse/engineering` is just `engineering`
+        permissions:
+          - team_slug: admins
+            permission: admin
+          - team_slug: bots
+            permission: admin
+          - team_slug: engineering
+            permission: push
+```
+
+```yaml
+# stacks/argocd/repo/non-prod.yaml
+import:
+  - catalog/argocd/repo/defaults
+
+components:
+  terraform:
+    argocd-deploy-non-prod:
+      component: argocd-repo
+      settings:
+        spacelift:
+          workspace_enabled: true
+      vars:
+        name: argocd-deploy-non-prod
+        description: "ArgoCD desired state repository (Non-production) for ACME applications"
+        environments:
+          - tenant: mgmt
+            environment: uw2
+            stage: sandbox
+```
+
+```yaml
+# stacks/mgmt-gbl-corp.yaml
+import:
+...
+  - catalog/argocd/repo/non-prod
+...
+```
+
+If the repository already exists, it will need to be imported (replace names of IAM profile var file accordingly):
+
+```bash
+$ export TF_VAR_github_token_override=[REDACTED]
+$ atmos terraform varfile argocd-deploy-non-prod -s mgmt-gbl-corp
+$ cd components/terraform/argocd-repo
+$ terraform import -var "import_profile_name=eg-mgmt-gbl-corp-admin" -var-file="mgmt-gbl-corp-argocd-deploy-non-prod.terraform.tfvars.json" "github_repository.default[0]" argocd-deploy-non-prod
+$ atmos terraform varfile argocd-deploy-non-prod -s mgmt-gbl-corp
+$ cd components/terraform/argocd-repo
+$ terraform import -var "import_profile_name=eg-mgmt-gbl-corp-admin" -var-file="mgmt-gbl-corp-argocd-deploy-non-prod.terraform.tfvars.json" "github_branch.default[0]" argocd-deploy-non-prod:main
+$ cd components/terraform/argocd-repo
+$ terraform import -var "import_profile_name=eg-mgmt-gbl-corp-admin" -var-file="mgmt-gbl-corp-argocd-deploy-non-prod.terraform.tfvars.json" "github_branch_default.default[0]" argocd-deploy-non-prod
+```
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
+| <a name="requirement_github"></a> [github](#requirement\_github) | >= 4.0 |
+| <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 3.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
+| <a name="provider_github"></a> [github](#provider\_github) | >= 4.0 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | >= 3.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
+| <a name="module_store_write"></a> [store\_write](#module\_store\_write) | cloudposse/ssm-parameter-store/aws | 0.10.0 |
+| <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [github_branch_default.default](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/branch_default) | resource |
+| [github_branch_protection.default](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/branch_protection) | resource |
+| [github_repository.default](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository) | resource |
+| [github_repository_deploy_key.default](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_deploy_key) | resource |
+| [github_repository_file.application_set](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_file) | resource |
+| [github_repository_file.codeowners_file](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_file) | resource |
+| [github_repository_file.gitignore](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_file) | resource |
+| [github_repository_file.pull_request_template](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_file) | resource |
+| [github_repository_file.readme](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_file) | resource |
+| [github_team_repository.default](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_repository) | resource |
+| [tls_private_key.default](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
+| [aws_ssm_parameter.github_api_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
+| [github_team.default](https://registry.terraform.io/providers/integrations/github/latest/docs/data-sources/team) | data source |
+| [github_user.automation_user](https://registry.terraform.io/providers/integrations/github/latest/docs/data-sources/user) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br>This is for some rare cases where resources want additional configuration of tags<br>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
+| <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br>in the order they appear in the list. New attributes are appended to the<br>end of the list. The elements of the list are joined by the `delimiter`<br>and treated as a single ID element. | `list(string)` | `[]` | no |
+| <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "descriptor_formats": {},<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "labels_as_tags": [<br>    "unset"<br>  ],<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {},<br>  "tenant": null<br>}</pre> | no |
+| <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between ID elements.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
+| <a name="input_description"></a> [description](#input\_description) | The description of the repository | `string` | `null` | no |
+| <a name="input_descriptor_formats"></a> [descriptor\_formats](#input\_descriptor\_formats) | Describe additional descriptors to be output in the `descriptors` output map.<br>Map of maps. Keys are names of descriptors. Values are maps of the form<br>`{<br>   format = string<br>   labels = list(string)<br>}`<br>(Type is `any` so the map values can later be enhanced to provide additional options.)<br>`format` is a Terraform format string to be passed to the `format()` function.<br>`labels` is a list of labels, in order, to pass to `format()` function.<br>Label values will be normalized before being passed to `format()` so they will be<br>identical to how they appear in `id`.<br>Default is `{}` (`descriptors` output will be empty). | `any` | `{}` | no |
+| <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
+| <a name="input_environments"></a> [environments](#input\_environments) | Environments to populate `applicationset.yaml` files and repository deploy keys (for ArgoCD) for.<br><br>`auto-sync` determines whether or not the ArgoCD application will be automatically synced. | <pre>list(object({<br>    tenant      = string<br>    environment = string<br>    stage       = string<br>    auto-sync   = bool<br>  }))</pre> | `[]` | no |
+| <a name="input_github_base_url"></a> [github\_base\_url](#input\_github\_base\_url) | This is the target GitHub base API endpoint. Providing a value is a requirement when working with GitHub Enterprise. It is optional to provide this value and it can also be sourced from the `GITHUB_BASE_URL` environment variable. The value must end with a slash, for example: `https://terraformtesting-ghe.westus.cloudapp.azure.com/` | `string` | `null` | no |
+| <a name="input_github_codeowner_teams"></a> [github\_codeowner\_teams](#input\_github\_codeowner\_teams) | List of teams to use when populating the CODEOWNERS file.<br><br>For example: `["@ACME/cloud-admins", "@ACME/cloud-developers"]`. | `list(string)` | n/a | yes |
+| <a name="input_github_organization"></a> [github\_organization](#input\_github\_organization) | GitHub Organization | `string` | n/a | yes |
+| <a name="input_github_token_override"></a> [github\_token\_override](#input\_github\_token\_override) | Use the value of this variable as the GitHub token instead of reading it from SSM | `string` | `null` | no |
+| <a name="input_github_user"></a> [github\_user](#input\_github\_user) | Github user | `string` | n/a | yes |
+| <a name="input_github_user_email"></a> [github\_user\_email](#input\_github\_user\_email) | Github user email | `string` | n/a | yes |
+| <a name="input_gitignore_entries"></a> [gitignore\_entries](#input\_gitignore\_entries) | List of .gitignore entries to use when populating the .gitignore file.<br><br>For example: `[".idea/", ".vscode/"]`. | `list(string)` | n/a | yes |
+| <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for keep the existing setting, which defaults to `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
+| <a name="input_import_profile_name"></a> [import\_profile\_name](#input\_import\_profile\_name) | AWS Profile name to use when importing a resource | `string` | `null` | no |
+| <a name="input_import_role_arn"></a> [import\_role\_arn](#input\_import\_role\_arn) | IAM Role ARN to use when importing a resource | `string` | `null` | no |
+| <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | Controls the letter case of the `tags` keys (label names) for tags generated by this module.<br>Does not affect keys of tags passed in via the `tags` input.<br>Possible values: `lower`, `title`, `upper`.<br>Default value: `title`. | `string` | `null` | no |
+| <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The order in which the labels (ID elements) appear in the `id`.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present. | `list(string)` | `null` | no |
+| <a name="input_label_value_case"></a> [label\_value\_case](#input\_label\_value\_case) | Controls the letter case of ID elements (labels) as included in `id`,<br>set as tag values, and output by this module individually.<br>Does not affect values of tags passed in via the `tags` input.<br>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br>Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.<br>Default value: `lower`. | `string` | `null` | no |
+| <a name="input_labels_as_tags"></a> [labels\_as\_tags](#input\_labels\_as\_tags) | Set of labels (ID elements) to include as tags in the `tags` output.<br>Default is to include all labels.<br>Tags with empty values will not be included in the `tags` output.<br>Set to `[]` to suppress all generated tags.<br>**Notes:**<br>  The value of the `name` tag, if included, will be the `id`, not the `name`.<br>  Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be<br>  changed in later chained modules. Attempts to change it will be silently ignored. | `set(string)` | <pre>[<br>  "default"<br>]</pre> | no |
+| <a name="input_name"></a> [name](#input\_name) | ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.<br>This is the only ID element not also included as a `tag`.<br>The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input. | `string` | `null` | no |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique | `string` | `null` | no |
+| <a name="input_permissions"></a> [permissions](#input\_permissions) | A list of Repository Permission objects used to configure the team permissions of the repository<br><br>`team_slug` should be the name of the team without the `@{org}` e.g. `@cloudposse/team` => `team`<br>`permission` is just one of the available values listed below | <pre>list(object({<br>    team_slug  = string,<br>    permission = string<br>  }))</pre> | `[]` | no |
+| <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br>Characters matching the regex will be removed from the ID elements.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
+| <a name="input_region"></a> [region](#input\_region) | AWS Region | `string` | n/a | yes |
+| <a name="input_slack_channel"></a> [slack\_channel](#input\_slack\_channel) | The name of the slack channel to configure ArgoCD notifications for | `string` | `null` | no |
+| <a name="input_ssm_github_api_key"></a> [ssm\_github\_api\_key](#input\_ssm\_github\_api\_key) | SSM path to the GitHub API key | `string` | `"/argocd/github/api_key"` | no |
+| <a name="input_ssm_github_deploy_key_format"></a> [ssm\_github\_deploy\_key\_format](#input\_ssm\_github\_deploy\_key\_format) | Format string of the SSM parameter path to which the deploy keys will be written to (%s will be replaced with the environment name) | `string` | `"/argocd/deploy_keys/%s"` | no |
+| <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
+| <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_deploy_keys_ssm_path_format"></a> [deploy\_keys\_ssm\_path\_format](#output\_deploy\_keys\_ssm\_path\_format) | SSM Parameter Store path format for the repository's deploy keys |
+| <a name="output_deploy_keys_ssm_paths"></a> [deploy\_keys\_ssm\_paths](#output\_deploy\_keys\_ssm\_paths) | SSM Parameter Store paths for the repository's deploy keys |
+| <a name="output_repository_default_branch"></a> [repository\_default\_branch](#output\_repository\_default\_branch) | Repository default branch |
+| <a name="output_repository_description"></a> [repository\_description](#output\_repository\_description) | Repository description |
+| <a name="output_repository_git_clone_url"></a> [repository\_git\_clone\_url](#output\_repository\_git\_clone\_url) | Repository git clone URL |
+| <a name="output_repository_ssh_clone_url"></a> [repository\_ssh\_clone\_url](#output\_repository\_ssh\_clone\_url) | Repository SSH clone URL |
+| <a name="output_repository_url"></a> [repository\_url](#output\_repository\_url) | Repository URL |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+
+## References
+  * [cloudposse/terraform-aws-components](https://github.com/cloudposse/terraform-aws-components/tree/master/modules/TODO) - Cloud Posse's upstream component
+
+
+[<img src="https://cloudposse.com/logo-300x69.svg" height="32" align="right"/>](https://cpco.io/component)

--- a/modules/argocd-repo/applicationset.tf
+++ b/modules/argocd-repo/applicationset.tf
@@ -1,0 +1,19 @@
+resource "github_repository_file" "application_set" {
+  for_each = local.environments
+
+  repository = join("", github_repository.default.*.name)
+  branch     = join("", github_repository.default.*.default_branch)
+  file       = "${each.value.tenant != null ? format("%s/", each.value.tenant) : ""}${each.value.environment}-${each.value.stage}/${local.manifest_kubernetes_namespace}/applicationset.yaml"
+  content = templatefile("${path.module}/templates/applicationset.yaml.tpl", {
+    environment   = each.key
+    auto-sync     = each.value.auto-sync
+    name          = module.this.namespace
+    namespace     = local.manifest_kubernetes_namespace
+    ssh_url       = join("", github_repository.default.*.ssh_clone_url)
+    slack_channel = var.slack_channel
+  })
+  commit_message      = "Initialize environment: `${each.key}`."
+  commit_author       = var.github_user
+  commit_email        = var.github_user_email
+  overwrite_on_create = true
+}

--- a/modules/argocd-repo/context.tf
+++ b/modules/argocd-repo/context.tf
@@ -1,0 +1,279 @@
+#
+# ONLY EDIT THIS FILE IN github.com/cloudposse/terraform-null-label
+# All other instances of this file should be a copy of that one
+#
+#
+# Copy this file from https://github.com/cloudposse/terraform-null-label/blob/master/exports/context.tf
+# and then place it in your Terraform module to automatically get
+# Cloud Posse's standard configuration inputs suitable for passing
+# to Cloud Posse modules.
+#
+# curl -sL https://raw.githubusercontent.com/cloudposse/terraform-null-label/master/exports/context.tf -o context.tf
+#
+# Modules should access the whole context as `module.this.context`
+# to get the input variables with nulls for defaults,
+# for example `context = module.this.context`,
+# and access individual variables as `module.this.<var>`,
+# with final values filled in.
+#
+# For example, when using defaults, `module.this.context.delimiter`
+# will be null, and `module.this.delimiter` will be `-` (hyphen).
+#
+
+module "this" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0" # requires Terraform >= 0.13.0
+
+  enabled             = var.enabled
+  namespace           = var.namespace
+  tenant              = var.tenant
+  environment         = var.environment
+  stage               = var.stage
+  name                = var.name
+  delimiter           = var.delimiter
+  attributes          = var.attributes
+  tags                = var.tags
+  additional_tag_map  = var.additional_tag_map
+  label_order         = var.label_order
+  regex_replace_chars = var.regex_replace_chars
+  id_length_limit     = var.id_length_limit
+  label_key_case      = var.label_key_case
+  label_value_case    = var.label_value_case
+  descriptor_formats  = var.descriptor_formats
+  labels_as_tags      = var.labels_as_tags
+
+  context = var.context
+}
+
+# Copy contents of cloudposse/terraform-null-label/variables.tf here
+
+variable "context" {
+  type = any
+  default = {
+    enabled             = true
+    namespace           = null
+    tenant              = null
+    environment         = null
+    stage               = null
+    name                = null
+    delimiter           = null
+    attributes          = []
+    tags                = {}
+    additional_tag_map  = {}
+    regex_replace_chars = null
+    label_order         = []
+    id_length_limit     = null
+    label_key_case      = null
+    label_value_case    = null
+    descriptor_formats  = {}
+    # Note: we have to use [] instead of null for unset lists due to
+    # https://github.com/hashicorp/terraform/issues/28137
+    # which was not fixed until Terraform 1.0.0,
+    # but we want the default to be all the labels in `label_order`
+    # and we want users to be able to prevent all tag generation
+    # by setting `labels_as_tags` to `[]`, so we need
+    # a different sentinel to indicate "default"
+    labels_as_tags = ["unset"]
+  }
+  description = <<-EOT
+    Single object for setting entire context at once.
+    See description of individual variables for details.
+    Leave string and numeric variables as `null` to use default value.
+    Individual variable settings (non-null) override settings in context object,
+    except for attributes, tags, and additional_tag_map, which are merged.
+  EOT
+
+  validation {
+    condition     = lookup(var.context, "label_key_case", null) == null ? true : contains(["lower", "title", "upper"], var.context["label_key_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+
+  validation {
+    condition     = lookup(var.context, "label_value_case", null) == null ? true : contains(["lower", "title", "upper", "none"], var.context["label_value_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+variable "enabled" {
+  type        = bool
+  default     = null
+  description = "Set to false to prevent the module from creating any resources"
+}
+
+variable "namespace" {
+  type        = string
+  default     = null
+  description = "ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique"
+}
+
+variable "tenant" {
+  type        = string
+  default     = null
+  description = "ID element _(Rarely used, not included by default)_. A customer identifier, indicating who this instance of a resource is for"
+}
+
+variable "environment" {
+  type        = string
+  default     = null
+  description = "ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT'"
+}
+
+variable "stage" {
+  type        = string
+  default     = null
+  description = "ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release'"
+}
+
+variable "name" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.
+    This is the only ID element not also included as a `tag`.
+    The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input.
+    EOT
+}
+
+variable "delimiter" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Delimiter to be used between ID elements.
+    Defaults to `-` (hyphen). Set to `""` to use no delimiter at all.
+  EOT
+}
+
+variable "attributes" {
+  type        = list(string)
+  default     = []
+  description = <<-EOT
+    ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,
+    in the order they appear in the list. New attributes are appended to the
+    end of the list. The elements of the list are joined by the `delimiter`
+    and treated as a single ID element.
+    EOT
+}
+
+variable "labels_as_tags" {
+  type        = set(string)
+  default     = ["default"]
+  description = <<-EOT
+    Set of labels (ID elements) to include as tags in the `tags` output.
+    Default is to include all labels.
+    Tags with empty values will not be included in the `tags` output.
+    Set to `[]` to suppress all generated tags.
+    **Notes:**
+      The value of the `name` tag, if included, will be the `id`, not the `name`.
+      Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be
+      changed in later chained modules. Attempts to change it will be silently ignored.
+    EOT
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+    Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).
+    Neither the tag keys nor the tag values will be modified by this module.
+    EOT
+}
+
+variable "additional_tag_map" {
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+    Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.
+    This is for some rare cases where resources want additional configuration of tags
+    and therefore take a list of maps with tag key, value, and additional configuration.
+    EOT
+}
+
+variable "label_order" {
+  type        = list(string)
+  default     = null
+  description = <<-EOT
+    The order in which the labels (ID elements) appear in the `id`.
+    Defaults to ["namespace", "environment", "stage", "name", "attributes"].
+    You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present.
+    EOT
+}
+
+variable "regex_replace_chars" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Terraform regular expression (regex) string.
+    Characters matching the regex will be removed from the ID elements.
+    If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits.
+  EOT
+}
+
+variable "id_length_limit" {
+  type        = number
+  default     = null
+  description = <<-EOT
+    Limit `id` to this many characters (minimum 6).
+    Set to `0` for unlimited length.
+    Set to `null` for keep the existing setting, which defaults to `0`.
+    Does not affect `id_full`.
+  EOT
+  validation {
+    condition     = var.id_length_limit == null ? true : var.id_length_limit >= 6 || var.id_length_limit == 0
+    error_message = "The id_length_limit must be >= 6 if supplied (not null), or 0 for unlimited length."
+  }
+}
+
+variable "label_key_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Controls the letter case of the `tags` keys (label names) for tags generated by this module.
+    Does not affect keys of tags passed in via the `tags` input.
+    Possible values: `lower`, `title`, `upper`.
+    Default value: `title`.
+  EOT
+
+  validation {
+    condition     = var.label_key_case == null ? true : contains(["lower", "title", "upper"], var.label_key_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+}
+
+variable "label_value_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Controls the letter case of ID elements (labels) as included in `id`,
+    set as tag values, and output by this module individually.
+    Does not affect values of tags passed in via the `tags` input.
+    Possible values: `lower`, `title`, `upper` and `none` (no transformation).
+    Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.
+    Default value: `lower`.
+  EOT
+
+  validation {
+    condition     = var.label_value_case == null ? true : contains(["lower", "title", "upper", "none"], var.label_value_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+variable "descriptor_formats" {
+  type        = any
+  default     = {}
+  description = <<-EOT
+    Describe additional descriptors to be output in the `descriptors` output map.
+    Map of maps. Keys are names of descriptors. Values are maps of the form
+    `{
+       format = string
+       labels = list(string)
+    }`
+    (Type is `any` so the map values can later be enhanced to provide additional options.)
+    `format` is a Terraform format string to be passed to the `format()` function.
+    `labels` is a list of labels, in order, to pass to `format()` function.
+    Label values will be normalized before being passed to `format()` so they will be
+    identical to how they appear in `id`.
+    Default is `{}` (`descriptors` output will be empty).
+    EOT
+}
+
+#### End of copy of cloudposse/terraform-null-label/variables.tf

--- a/modules/argocd-repo/default.auto.tfvars
+++ b/modules/argocd-repo/default.auto.tfvars
@@ -1,0 +1,3 @@
+# This file is included by default in terraform plans
+
+enabled = false

--- a/modules/argocd-repo/git-files.tf
+++ b/modules/argocd-repo/git-files.tf
@@ -1,0 +1,59 @@
+resource "github_repository_file" "gitignore" {
+  count = local.enabled ? 1 : 0
+
+  repository = join("", github_repository.default.*.name)
+  branch     = join("", github_repository.default.*.default_branch)
+  file       = ".gitignore"
+  content = templatefile("${path.module}/templates/.gitignore.tpl", {
+    entries = var.gitignore_entries
+  })
+  commit_message      = "Create .gitignore file."
+  commit_author       = var.github_user
+  commit_email        = var.github_user_email
+  overwrite_on_create = true
+}
+
+resource "github_repository_file" "readme" {
+  count = local.enabled ? 1 : 0
+
+  repository = join("", github_repository.default.*.name)
+  branch     = join("", github_repository.default.*.default_branch)
+  file       = "README.md"
+  content = templatefile("${path.module}/templates/README.md.tpl", {
+    repository_name        = join("", github_repository.default.*.name)
+    repository_description = join("", github_repository.default.*.description)
+    github_organization    = var.github_organization
+  })
+  commit_message      = "Create README.md file."
+  commit_author       = var.github_user
+  commit_email        = var.github_user_email
+  overwrite_on_create = true
+}
+
+resource "github_repository_file" "codeowners_file" {
+  count = local.enabled ? 1 : 0
+
+  repository = join("", github_repository.default.*.name)
+  branch     = join("", github_repository.default.*.default_branch)
+  file       = ".github/CODEOWNERS"
+  content = templatefile("${path.module}/templates/CODEOWNERS.tpl", {
+    codeowners = var.github_codeowner_teams
+  })
+  commit_message      = "Create CODEOWNERS file."
+  commit_author       = var.github_user
+  commit_email        = var.github_user_email
+  overwrite_on_create = true
+}
+
+resource "github_repository_file" "pull_request_template" {
+  count = local.enabled ? 1 : 0
+
+  repository          = join("", github_repository.default.*.name)
+  branch              = join("", github_repository.default.*.default_branch)
+  file                = ".github/PULL_REQUEST_TEMPLATE.md"
+  content             = file("${path.module}/templates/PULL_REQUEST_TEMPLATE.md")
+  commit_message      = "Create PULL_REQUEST_TEMPLATE.md file."
+  commit_author       = var.github_user
+  commit_email        = var.github_user_email
+  overwrite_on_create = true
+}

--- a/modules/argocd-repo/main.tf
+++ b/modules/argocd-repo/main.tf
@@ -1,0 +1,103 @@
+locals {
+  enabled = module.this.enabled
+  environments = local.enabled ? {
+    for env in var.environments :
+    (format(
+      "${env.tenant != null ? "%[1]s/" : ""}%[2]s-%[3]s",
+      env.tenant,
+      env.environment,
+      env.stage,
+    )) => env
+  } : {}
+  manifest_kubernetes_namespace = "argocd"
+
+  team_slugs = toset(compact([
+    for permission in var.permissions : lookup(permission, "team_slug", null)
+  ]))
+
+  team_ids = [
+    for team in data.github_team.default : team.id
+  ]
+
+  team_permissions = {
+    for index, id in local.team_ids : (var.permissions[index].team_slug) => {
+      id         = id
+      permission = var.permissions[index].permission
+    }
+  }
+}
+
+resource "github_repository" "default" {
+  count = local.enabled ? 1 : 0
+
+  name        = module.this.name
+  description = var.description
+  auto_init   = true # will create a 'main' branch
+
+  visibility = "private"
+}
+
+resource "github_branch_default" "default" {
+  count = local.enabled ? 1 : 0
+
+  repository = join("", github_repository.default.*.name)
+  branch     = join("", github_repository.default.*.default_branch)
+}
+
+data "github_user" "automation_user" {
+  count = local.enabled ? 1 : 0
+
+  username = var.github_user
+}
+
+resource "github_branch_protection" "default" {
+  # This resource enforces PRs needing to be opened in order for changes to be made, except for automated commits to
+  # the main branch. Those commits made by the automation user, which is an admin.
+  count = local.enabled ? 1 : 0
+
+  repository_id = join("", github_repository.default.*.name)
+
+  pattern          = join("", github_branch_default.default.*.branch)
+  enforce_admins   = false # needs to be false in order to allow automation user to push
+  allows_deletions = true
+
+  required_pull_request_reviews {
+    dismiss_stale_reviews      = true
+    restrict_dismissals        = true
+    require_code_owner_reviews = true
+  }
+
+  push_restrictions = [
+    join("", data.github_user.automation_user.*.node_id),
+  ]
+}
+
+data "github_team" "default" {
+  for_each = local.team_slugs
+
+  slug = each.value
+}
+
+resource "github_team_repository" "default" {
+  for_each = local.team_permissions
+
+  repository = join("", github_repository.default[*].name)
+  team_id    = each.value.id
+  permission = each.value.permission
+}
+
+resource "tls_private_key" "default" {
+  for_each = local.environments
+
+  algorithm = "RSA"
+  rsa_bits  = "2048"
+}
+
+resource "github_repository_deploy_key" "default" {
+  for_each = local.environments
+
+  title      = "Deploy key for ArgoCD environment: ${each.key} (${join("", github_repository.default.*.default_branch)} branch)"
+  repository = join("", github_repository.default.*.name)
+  key        = tls_private_key.default[each.key].public_key_openssh
+  read_only  = true
+}

--- a/modules/argocd-repo/outputs.tf
+++ b/modules/argocd-repo/outputs.tf
@@ -1,0 +1,34 @@
+output "deploy_keys_ssm_paths" {
+  description = "SSM Parameter Store paths for the repository's deploy keys"
+  value       = module.store_write.names
+}
+
+output "deploy_keys_ssm_path_format" {
+  description = "SSM Parameter Store path format for the repository's deploy keys"
+  value       = local.enabled ? var.ssm_github_deploy_key_format : null
+}
+
+output "repository_description" {
+  description = "Repository description"
+  value       = join("", github_repository.default.*.description)
+}
+
+output "repository_default_branch" {
+  description = "Repository default branch"
+  value       = join("", github_repository.default.*.default_branch)
+}
+
+output "repository_url" {
+  description = "Repository URL"
+  value       = join("", github_repository.default.*.html_url)
+}
+
+output "repository_git_clone_url" {
+  description = "Repository git clone URL"
+  value       = join("", github_repository.default.*.git_clone_url)
+}
+
+output "repository_ssh_clone_url" {
+  description = "Repository SSH clone URL"
+  value       = join("", github_repository.default.*.ssh_clone_url)
+}

--- a/modules/argocd-repo/providers.tf
+++ b/modules/argocd-repo/providers.tf
@@ -1,0 +1,35 @@
+provider "aws" {
+  region = var.region
+
+  profile = module.iam_roles.profiles_enabled ? coalesce(var.import_profile_name, module.iam_roles.terraform_profile_name) : null
+
+  dynamic "assume_role" {
+    for_each = module.iam_roles.profiles_enabled ? [] : ["role"]
+    content {
+      role_arn = coalesce(var.import_role_arn, module.iam_roles.terraform_role_arn)
+    }
+  }
+}
+
+module "iam_roles" {
+  source  = "../account-map/modules/iam-roles"
+  context = module.this.context
+}
+
+variable "import_profile_name" {
+  type        = string
+  default     = null
+  description = "AWS Profile name to use when importing a resource"
+}
+
+variable "import_role_arn" {
+  type        = string
+  default     = null
+  description = "IAM Role ARN to use when importing a resource"
+}
+
+provider "github" {
+  base_url = var.github_base_url
+  owner    = var.github_organization
+  token    = local.github_token
+}

--- a/modules/argocd-repo/ssm.tf
+++ b/modules/argocd-repo/ssm.tf
@@ -1,0 +1,26 @@
+locals {
+  github_token = local.enabled ? coalesce(var.github_token_override, data.aws_ssm_parameter.github_api_key[0].value) : ""
+}
+
+data "aws_ssm_parameter" "github_api_key" {
+  count           = local.enabled ? 1 : 0
+  name            = var.ssm_github_api_key
+  with_decryption = true
+}
+
+module "store_write" {
+  source  = "cloudposse/ssm-parameter-store/aws"
+  version = "0.10.0"
+
+  parameter_write = [for k, v in local.environments :
+    {
+      name        = format(var.ssm_github_deploy_key_format, k)
+      value       = tls_private_key.default[k].private_key_pem
+      type        = "SecureString"
+      overwrite   = true
+      description = github_repository_deploy_key.default[k].title
+    }
+  ]
+
+  context = module.this.context
+}

--- a/modules/argocd-repo/templates/.gitignore.tpl
+++ b/modules/argocd-repo/templates/.gitignore.tpl
@@ -1,0 +1,6 @@
+# This file has been programmatically generated and committed by the argocd-repo Terraform component in the infrastructure
+# monorepo. It can be updated to contain further entries by adjusting var.gitignore_entries in the aforementioned component.
+
+%{ for entry in entries ~}
+${entry}
+%{ endfor ~}

--- a/modules/argocd-repo/templates/CODEOWNERS.tpl
+++ b/modules/argocd-repo/templates/CODEOWNERS.tpl
@@ -1,0 +1,4 @@
+# Use this file to define individuals or teams that are responsible for code in a repository.
+# Read more: https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners
+
+* %{ for codeowner in codeowners }${codeowner} %{ endfor }

--- a/modules/argocd-repo/templates/PULL_REQUEST_TEMPLATE.md
+++ b/modules/argocd-repo/templates/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## what
+
+- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
+- Use bullet points to be concise and to the point.
+
+## why
+
+- Provide the justifications for the changes (e.g. business case).
+- Describe why these changes were made (e.g. why do these commits fix the problem?)
+- Use bullet points to be concise and to the point.
+
+## references
+
+- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow).
+- Use `closes #123`, if this PR closes a GitHub issue `#123`

--- a/modules/argocd-repo/templates/README.md.tpl
+++ b/modules/argocd-repo/templates/README.md.tpl
@@ -1,0 +1,14 @@
+# `${repository_name}`
+
+${repository_description}.
+
+## What This Repository Does
+
+This repository accepts inbound commits from CD workflows using the `cd/argocd` composite action in `${github_organization}/github_actions`.
+
+In particular, these CD workflows render application Kubernetes manifests using their respective Helm charts and commits
+them to an `apps/[app name]/` subdirectory in each environment's directory.
+
+The `applicationset.yaml` file in each environment directory's `argocd/` subdirectory is referenced by ArgoCD deployment
+in each environment's dedicated EKS cluster. This ApplicationSet manifest makes use of [Git Generators](https://argocd-applicationset.readthedocs.io/en/stable/Generators-Git/)
+in order to dynamically create ArgoCD Application objects based on the manifests in the `apps/[app name]/` directory.

--- a/modules/argocd-repo/templates/applicationset.yaml.tpl
+++ b/modules/argocd-repo/templates/applicationset.yaml.tpl
@@ -1,0 +1,85 @@
+# This file has been programmatically generated and committed by the argocd-repo Terraform component in the infrastructure
+# monorepo. It can be adjusted by modifying templates/applicationset.yaml.tpl in the aforementioned component.
+
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  annotations:
+    argocd-autopilot.argoproj-labs.io/default-dest-server: https://kubernetes.default.svc
+    argocd.argoproj.io/sync-options: PruneLast=true
+    argocd.argoproj.io/sync-wave: "-2"
+    notifications.argoproj.io/subscribe.on-deployed.slack: ${slack_channel}
+    notifications.argoproj.io/subscribe.on-health-degraded.slack: ${slack_channel}
+    notifications.argoproj.io/subscribe.on-sync-failed.slack: ${slack_channel}
+    notifications.argoproj.io/subscribe.on-sync-running.slack: ${slack_channel}
+    notifications.argoproj.io/subscribe.on-sync-status-unknown.slack: ${slack_channel}
+    notifications.argoproj.io/subscribe.on-sync-succeeded.slack: ${slack_channel}
+    notifications.argoproj.io/subscribe.on-deployed.datadog: ""
+    notifications.argoproj.io/subscribe.on-health-degraded.datadog: ""
+    notifications.argoproj.io/subscribe.on-sync-failed.datadog: ""
+    notifications.argoproj.io/subscribe.on-sync-running.datadog: ""
+    notifications.argoproj.io/subscribe.on-sync-status-unknown.datadog: ""
+    notifications.argoproj.io/subscribe.on-sync-succeeded.datadog: ""
+    notifications.argoproj.io/subscribe.on-deleted.slack: ${slack_channel}
+    notifications.argoproj.io/subscribe.on-deployed.github-deployment: ""
+    notifications.argoproj.io/subscribe.on-deployed.github-commit-status: ""
+    notifications.argoproj.io/subscribe.on-deleted.github-deployment: ""
+  creationTimestamp: null
+  name: ${name}
+  namespace: ${namespace}
+spec:
+  clusterResourceWhitelist:
+    - group: '*'
+      kind: '*'
+  description: ${name} project
+  destinations:
+    - namespace: '*'
+      server: '*'
+  namespaceResourceWhitelist:
+    - group: '*'
+      kind: '*'
+  sourceRepos:
+    - '*'
+status: {}
+
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+  creationTimestamp: null
+  name: ${name}
+  namespace: ${namespace}
+spec:
+  generators:
+    - git:
+        repoURL: ${ssh_url}
+        revision: HEAD
+        files:
+          - path: ${environment}/apps/*/*/config.yaml
+  template:
+    metadata:
+      annotations:
+        deployment_id: '{{deployment_id}}'
+        app_repository: '{{app_repository}}'
+        app_commit: '{{app_commit}}'
+        app_hostname: 'https://{{app_hostname}}'
+      name: '{{name}}'
+    spec:
+      project: ${name}
+      source:
+        repoURL: ${ssh_url}
+        targetRevision: HEAD
+        path: '{{manifests}}'
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: '{{namespace}}'
+      syncPolicy:
+%{if auto-sync ~}
+        automated:
+          prune: true
+          selfHeal: true
+%{ endif ~}
+        syncOptions:
+          - CreateNamespace=true

--- a/modules/argocd-repo/variables.tf
+++ b/modules/argocd-repo/variables.tf
@@ -1,0 +1,111 @@
+variable "region" {
+  type        = string
+  description = "AWS Region"
+}
+
+variable "description" {
+  type        = string
+  description = "The description of the repository"
+  default     = null
+}
+
+variable "environments" {
+  type = list(object({
+    tenant      = string
+    environment = string
+    stage       = string
+    auto-sync   = bool
+  }))
+  description = <<-EOT
+  Environments to populate `applicationset.yaml` files and repository deploy keys (for ArgoCD) for.
+
+  `auto-sync` determines whether or not the ArgoCD application will be automatically synced.
+  EOT
+  default     = []
+}
+
+variable "gitignore_entries" {
+  type        = list(string)
+  description = <<-EOT
+  List of .gitignore entries to use when populating the .gitignore file.
+
+  For example: `[".idea/", ".vscode/"]`.
+  EOT
+}
+
+variable "github_base_url" {
+  type        = string
+  description = "This is the target GitHub base API endpoint. Providing a value is a requirement when working with GitHub Enterprise. It is optional to provide this value and it can also be sourced from the `GITHUB_BASE_URL` environment variable. The value must end with a slash, for example: `https://terraformtesting-ghe.westus.cloudapp.azure.com/`"
+  default     = null
+}
+
+variable "github_codeowner_teams" {
+  type        = list(string)
+  description = <<-EOT
+  List of teams to use when populating the CODEOWNERS file.
+
+  For example: `["@ACME/cloud-admins", "@ACME/cloud-developers"]`.
+  EOT
+}
+
+variable "github_user" {
+  type        = string
+  description = "Github user"
+}
+
+variable "github_user_email" {
+  type        = string
+  description = "Github user email"
+}
+
+variable "github_organization" {
+  type        = string
+  description = "GitHub Organization"
+}
+
+variable "github_token_override" {
+  type        = string
+  description = "Use the value of this variable as the GitHub token instead of reading it from SSM"
+  default     = null
+}
+
+variable "ssm_github_api_key" {
+  type        = string
+  description = "SSM path to the GitHub API key"
+  default     = "/argocd/github/api_key"
+}
+
+variable "ssm_github_deploy_key_format" {
+  type        = string
+  description = "Format string of the SSM parameter path to which the deploy keys will be written to (%s will be replaced with the environment name)"
+  default     = "/argocd/deploy_keys/%s"
+}
+
+variable "permissions" {
+  type = list(object({
+    team_slug  = string,
+    permission = string
+  }))
+  description = <<-EOT
+    A list of Repository Permission objects used to configure the team permissions of the repository
+
+    `team_slug` should be the name of the team without the `@{org}` e.g. `@cloudposse/team` => `team`
+    `permission` is just one of the available values listed below
+  EOT
+
+  default = []
+
+  validation {
+    condition = alltrue([
+      for obj in var.permissions : can(contains(["pull", "triage", "push", "maintain", "admin"], obj.permission))
+    ])
+
+    error_message = "Permission value must be a subset of [pull, triage, push, maintain, admin]."
+  }
+}
+
+variable "slack_channel" {
+  type        = string
+  description = "The name of the slack channel to configure ArgoCD notifications for"
+  default     = null
+}

--- a/modules/argocd-repo/versions.tf
+++ b/modules/argocd-repo/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.0.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+    github = {
+      source  = "integrations/github"
+      version = ">= 4.0"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = ">= 3.0"
+    }
+  }
+}


### PR DESCRIPTION
## what
- Added component for `argocd-repo`

## why
- Setting up vendoring in CPLIVE requires up-to-date, upstreamed components

## references
- CPLIVE-279