### PR TITLE
elasticache-redis: Use `cluster_name` override and correct dns env

### DIFF
--- a/modules/elasticache-redis/main.tf
+++ b/modules/elasticache-redis/main.tf
@@ -62,8 +62,8 @@ module "redis_clusters" {
 
   for_each = var.redis_clusters
 
-  cluster_name  = replace(each.key, "_", "-")
-  dns_subdomain = replace(each.key, "_", "-")
+  cluster_name  = lookup(each.value, "cluster_name", replace(each.key, "_", "-"))
+  dns_subdomain = join(".", [lookup(each.value, "cluster_name", replace(each.key, "_", "-")), module.this.environment])
 
   instance_type      = each.value.instance_type
   num_replicas       = lookup(each.value, "num_replicas", 1)

--- a/modules/elasticache-redis/outputs.tf
+++ b/modules/elasticache-redis/outputs.tf
@@ -1,4 +1,4 @@
 output "redis_clusters" {
   description = "Redis cluster objects"
-  value       = local.clusters
+  value       = local.enabled ? local.clusters : {}
 }


### PR DESCRIPTION
## what
* elasticache-redis: Use `cluster_name` override and correct dns env

## why
* Updates

## references
N/A
