### PR TITLE
Correct `iam_policy_statements` for `s3-bucket` Component

### DIFF
--- a/modules/s3-bucket/README.md
+++ b/modules/s3-bucket/README.md
@@ -94,9 +94,9 @@ components:
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_account_map"></a> [account\_map](#module\_account\_map) | cloudposse/stack-config/yaml//modules/remote-state | 0.22.3 |
-| <a name="module_bucket_policy"></a> [bucket\_policy](#module\_bucket\_policy) | cloudposse/iam-policy/aws | 0.3.0 |
+| <a name="module_bucket_policy"></a> [bucket\_policy](#module\_bucket\_policy) | cloudposse/iam-policy/aws | 0.4.0 |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
-| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | cloudposse/s3-bucket/aws | 2.0.1 |
+| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | cloudposse/s3-bucket/aws | 2.0.3 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 
 ## Resources
@@ -135,6 +135,7 @@ components:
 | <a name="input_environment"></a> [environment](#input\_environment) | ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | <a name="input_force_destroy"></a> [force\_destroy](#input\_force\_destroy) | When `true`, permits a non-empty S3 bucket to be deleted by first deleting all objects in the bucket.<br>THESE OBJECTS ARE NOT RECOVERABLE even if they were versioned and stored in Glacier. | `bool` | `false` | no |
 | <a name="input_grants"></a> [grants](#input\_grants) | A list of policy grants for the bucket, taking a list of permissions.<br>Conflicts with `acl`. Set `acl` to `null` to use this. | <pre>list(object({<br>    id          = string<br>    type        = string<br>    permissions = list(string)<br>    uri         = string<br>  }))</pre> | `[]` | no |
+| <a name="input_iam_policy_statements"></a> [iam\_policy\_statements](#input\_iam\_policy\_statements) | Map of IAM policy statements to use in the bucket policy. | `any` | `{}` | no |
 | <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for keep the existing setting, which defaults to `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
 | <a name="input_ignore_public_acls"></a> [ignore\_public\_acls](#input\_ignore\_public\_acls) | Set to `false` to disable the ignoring of public access lists on the bucket | `bool` | `true` | no |
 | <a name="input_import_profile_name"></a> [import\_profile\_name](#input\_import\_profile\_name) | AWS Profile name to use when importing a resource | `string` | `null` | no |

--- a/modules/s3-bucket/main.tf
+++ b/modules/s3-bucket/main.tf
@@ -23,16 +23,16 @@ data "template_file" "bucket_policy" {
 
 module "bucket_policy" {
   source  = "cloudposse/iam-policy/aws"
-  version = "0.3.0"
+  version = "0.4.0"
 
-  iam_policy_statements = var.source_policy_documents
+  iam_policy_statements = var.iam_policy_statements
 
   context = module.this.context
 }
 
 module "s3_bucket" {
   source  = "cloudposse/s3-bucket/aws"
-  version = "2.0.1"
+  version = "2.0.3"
 
   bucket_name = var.bucket_name
 

--- a/modules/s3-bucket/variables.tf
+++ b/modules/s3-bucket/variables.tf
@@ -361,3 +361,10 @@ variable "custom_policy_enabled" {
   type        = bool
   default     = false
 }
+
+variable "iam_policy_statements" {
+  type        = any
+  description = "Map of IAM policy statements to use in the bucket policy."
+  default     = {}
+}
+


### PR DESCRIPTION
## what
- Added `var.iam_policy_statements` and use it to set the `iam_policy_statements` for `"cloudposse/iam-policy/aws"`

## why
- Previously had `source_policy_documents` set that value. That variable is a list of policies, not an actual policy statement list. Updated to correct variable

## references
- Required to resolve issue with AWS Global Accelerator. See [Slack thread](https://cloudposse.slack.com/archives/CA4TC65HS/p1660238441939829)