### PR TITLE
Updating role_arn logic and README example

### DIFF
--- a/modules/lakeformation/README.md
+++ b/modules/lakeformation/README.md
@@ -41,7 +41,7 @@ components:
         enabled: true
         name: lakeformation-example
         s3_bucket_arn: arn:aws:s3:::some-test-bucket
-        role_arn: arn:aws:iam::012345678912:role/AWSServiceRoleForLakeFormationDataAccess # Use the service-linked role
+        create_service_linked_role: true
         admin_arn_list:
           - arn:aws:iam::012345678912:role/my-admin-role
         lf_tags:
@@ -80,7 +80,8 @@ components:
 
 | Name | Type |
 |------|------|
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_service_linked_role.lakeformation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_service_linked_role) | resource |
+| [aws_iam_role.lakeformation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_role) | data source |
 
 ## Inputs
 
@@ -91,6 +92,7 @@ components:
 | <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br>in the order they appear in the list. New attributes are appended to the<br>end of the list. The elements of the list are joined by the `delimiter`<br>and treated as a single ID element. | `list(string)` | `[]` | no |
 | <a name="input_catalog_id"></a> [catalog\_id](#input\_catalog\_id) | (Optional) Identifier for the Data Catalog. If not provided, the account ID will be used. | `string` | `null` | no |
 | <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "descriptor_formats": {},<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "labels_as_tags": [<br>    "unset"<br>  ],<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {},<br>  "tenant": null<br>}</pre> | no |
+| <a name="input_create_service_linked_role"></a> [create\_service\_linked\_role](#input\_create\_service\_linked\_role) | Set to 'true' to create service-linked role for Lake Formation (can only be done once!) | `bool` | `false` | no |
 | <a name="input_database_default_permissions"></a> [database\_default\_permissions](#input\_database\_default\_permissions) | (Optional) Up to three configuration blocks of principal permissions for default create database permissions. | `list(map(any))` | `[]` | no |
 | <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between ID elements.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
 | <a name="input_descriptor_formats"></a> [descriptor\_formats](#input\_descriptor\_formats) | Describe additional descriptors to be output in the `descriptors` output map.<br>Map of maps. Keys are names of descriptors. Values are maps of the form<br>`{<br>   format = string<br>   labels = list(string)<br>}`<br>(Type is `any` so the map values can later be enhanced to provide additional options.)<br>`format` is a Terraform format string to be passed to the `format()` function.<br>`labels` is a list of labels, in order, to pass to `format()` function.<br>Label values will be normalized before being passed to `format()` so they will be<br>identical to how they appear in `id`.<br>Default is `{}` (`descriptors` output will be empty). | `any` | `{}` | no |

--- a/modules/lakeformation/variables.tf
+++ b/modules/lakeformation/variables.tf
@@ -14,6 +14,12 @@ variable "role_arn" {
   default     = null
 }
 
+variable "create_service_linked_role" {
+  description = "Set to 'true' to create service-linked role for Lake Formation (can only be done once!)"
+  type        = bool
+  default     = false
+}
+
 variable "catalog_id" {
   description = "(Optional) Identifier for the Data Catalog. If not provided, the account ID will be used."
   type        = string


### PR DESCRIPTION
## what
* Allowing user to specify if the service-linked role should be created or not, and adding some logic to determine which role to use
* Updating example in `README`

