### PR TITLE
Add `aurora-mysql` Components

### DIFF
--- a/modules/aurora-mysql-resources/README.md
+++ b/modules/aurora-mysql-resources/README.md
@@ -1,0 +1,133 @@
+# Component: `aurora-mysql-resources`
+
+This component is responsible for provisioning Aurora MySQL resources: additional databases, users, permissions, grants, etc.
+
+NOTE: Creating additional users (including read-only users) and databases requires Spacelift, since that action to be done via the mysql provider, and by default only the automation account is whitelisted by the Aurora cluster.
+
+## Usage
+
+**Stack Level**: Regional
+
+Here's an example snippet for how to use this component.
+
+`stacks/catalog/aurora-mysql/resources/defaults.yaml` file (base component for Aurora MySQL Resources with default settings):
+
+```yaml
+components:
+  terraform:
+    aurora-mysql-resources/defaults:
+      metadata:
+        type: abstract
+      vars:
+        enabled: true
+```
+
+Example (not actual)
+`stacks/uw2-dev.yaml` file (override the default settings for the cluster resources in the `dev` account, create an additional database and user):
+
+```yaml
+import:
+  - catalog/aurora-mysql/resources/defaults
+
+components:
+  terraform:
+    aurora-mysql-resources/dev:
+      metadata:
+        component: aurora-mysql-resources
+        inherits:
+          - aurora-mysql-resources/defaults
+      vars:
+        aurora_mysql_component_name: aurora-mysql/dev
+        additional_users:
+          example:
+            db_user: example
+            db_password: ""
+            grants:
+              - grant: [ "ALL" ]
+                db: example
+                object_type: database
+                schema: null
+```
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
+| <a name="requirement_mysql"></a> [mysql](#requirement\_mysql) | >= 1.9 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
+| <a name="provider_mysql"></a> [mysql](#provider\_mysql) | >= 1.9 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_additional_grants"></a> [additional\_grants](#module\_additional\_grants) | ./modules/mysql-user | n/a |
+| <a name="module_additional_users"></a> [additional\_users](#module\_additional\_users) | ./modules/mysql-user | n/a |
+| <a name="module_aurora_mysql"></a> [aurora\_mysql](#module\_aurora\_mysql) | cloudposse/stack-config/yaml//modules/remote-state | 0.22.4 |
+| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
+| <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [mysql_database.additional](https://registry.terraform.io/providers/terraform-providers/mysql/latest/docs/resources/database) | resource |
+| [aws_ssm_parameter.password](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_additional_databases"></a> [additional\_databases](#input\_additional\_databases) | n/a | `set(string)` | `[]` | no |
+| <a name="input_additional_grants"></a> [additional\_grants](#input\_additional\_grants) | Create additional database user with specified grants.<br>If `var.ssm_password_source` is set, passwords will be retrieved from SSM parameter store,<br>otherwise, passwords will be generated and stored in SSM parameter store under the service's key. | <pre>map(list(object({<br>    grant : list(string)<br>    db : string<br>  })))</pre> | `{}` | no |
+| <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br>This is for some rare cases where resources want additional configuration of tags<br>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
+| <a name="input_additional_users"></a> [additional\_users](#input\_additional\_users) | Create additional database user for a service, specifying username, grants, and optional password.<br>If no password is specified, one will be generated. Username and password will be stored in<br>SSM parameter store under the service's key. | <pre>map(object({<br>    db_user : string<br>    db_password : string<br>    grants : list(object({<br>      grant : list(string)<br>      db : string<br>    }))<br>  }))</pre> | `{}` | no |
+| <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br>in the order they appear in the list. New attributes are appended to the<br>end of the list. The elements of the list are joined by the `delimiter`<br>and treated as a single ID element. | `list(string)` | `[]` | no |
+| <a name="input_aurora_mysql_component_name"></a> [aurora\_mysql\_component\_name](#input\_aurora\_mysql\_component\_name) | Aurora MySQL component name to read the remote state from | `string` | n/a | yes |
+| <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "descriptor_formats": {},<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "labels_as_tags": [<br>    "unset"<br>  ],<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {},<br>  "tenant": null<br>}</pre> | no |
+| <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between ID elements.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
+| <a name="input_descriptor_formats"></a> [descriptor\_formats](#input\_descriptor\_formats) | Describe additional descriptors to be output in the `descriptors` output map.<br>Map of maps. Keys are names of descriptors. Values are maps of the form<br>`{<br>   format = string<br>   labels = list(string)<br>}`<br>(Type is `any` so the map values can later be enhanced to provide additional options.)<br>`format` is a Terraform format string to be passed to the `format()` function.<br>`labels` is a list of labels, in order, to pass to `format()` function.<br>Label values will be normalized before being passed to `format()` so they will be<br>identical to how they appear in `id`.<br>Default is `{}` (`descriptors` output will be empty). | `any` | `{}` | no |
+| <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
+| <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for keep the existing setting, which defaults to `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
+| <a name="input_import_profile_name"></a> [import\_profile\_name](#input\_import\_profile\_name) | AWS Profile name to use when importing a resource | `string` | `null` | no |
+| <a name="input_import_role_arn"></a> [import\_role\_arn](#input\_import\_role\_arn) | IAM Role ARN to use when importing a resource | `string` | `null` | no |
+| <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | Controls the letter case of the `tags` keys (label names) for tags generated by this module.<br>Does not affect keys of tags passed in via the `tags` input.<br>Possible values: `lower`, `title`, `upper`.<br>Default value: `title`. | `string` | `null` | no |
+| <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The order in which the labels (ID elements) appear in the `id`.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present. | `list(string)` | `null` | no |
+| <a name="input_label_value_case"></a> [label\_value\_case](#input\_label\_value\_case) | Controls the letter case of ID elements (labels) as included in `id`,<br>set as tag values, and output by this module individually.<br>Does not affect values of tags passed in via the `tags` input.<br>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br>Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.<br>Default value: `lower`. | `string` | `null` | no |
+| <a name="input_labels_as_tags"></a> [labels\_as\_tags](#input\_labels\_as\_tags) | Set of labels (ID elements) to include as tags in the `tags` output.<br>Default is to include all labels.<br>Tags with empty values will not be included in the `tags` output.<br>Set to `[]` to suppress all generated tags.<br>**Notes:**<br>  The value of the `name` tag, if included, will be the `id`, not the `name`.<br>  Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be<br>  changed in later chained modules. Attempts to change it will be silently ignored. | `set(string)` | <pre>[<br>  "default"<br>]</pre> | no |
+| <a name="input_mysql_admin_password"></a> [mysql\_admin\_password](#input\_mysql\_admin\_password) | MySQL password for the admin user | `string` | `""` | no |
+| <a name="input_mysql_cluster_enabled"></a> [mysql\_cluster\_enabled](#input\_mysql\_cluster\_enabled) | Set to `false` to prevent the module from creating any resources | `string` | `true` | no |
+| <a name="input_mysql_db_name"></a> [mysql\_db\_name](#input\_mysql\_db\_name) | Database name (default is not to create a database | `string` | `""` | no |
+| <a name="input_name"></a> [name](#input\_name) | ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.<br>This is the only ID element not also included as a `tag`.<br>The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input. | `string` | `null` | no |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique | `string` | `null` | no |
+| <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br>Characters matching the regex will be removed from the ID elements.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
+| <a name="input_region"></a> [region](#input\_region) | AWS Region | `string` | n/a | yes |
+| <a name="input_ssm_password_source"></a> [ssm\_password\_source](#input\_ssm\_password\_source) | If set, DB user passwords will be retrieved from SSM using the key `format(var.ssm_password_source, local.db_username)` | `string` | `""` | no |
+| <a name="input_ssm_path_prefix"></a> [ssm\_path\_prefix](#input\_ssm\_path\_prefix) | SSM path prefix | `string` | `"rds"` | no |
+| <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
+| <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_additional_grants"></a> [additional\_grants](#output\_additional\_grants) | Additional DB users created |
+| <a name="output_additional_users"></a> [additional\_users](#output\_additional\_users) | Additional DB users created |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+
+## References
+* [cloudposse/terraform-aws-components](https://github.com/cloudposse/terraform-aws-components/tree/master/modules/aurora-mysql-resources) - Cloud Posse's upstream component
+
+
+[<img src="https://cloudposse.com/logo-300x69.svg" height="32" align="right"/>](https://cpco.io/component)

--- a/modules/aurora-mysql-resources/context.tf
+++ b/modules/aurora-mysql-resources/context.tf
@@ -1,0 +1,279 @@
+#
+# ONLY EDIT THIS FILE IN github.com/cloudposse/terraform-null-label
+# All other instances of this file should be a copy of that one
+#
+#
+# Copy this file from https://github.com/cloudposse/terraform-null-label/blob/master/exports/context.tf
+# and then place it in your Terraform module to automatically get
+# Cloud Posse's standard configuration inputs suitable for passing
+# to Cloud Posse modules.
+#
+# curl -sL https://raw.githubusercontent.com/cloudposse/terraform-null-label/master/exports/context.tf -o context.tf
+#
+# Modules should access the whole context as `module.this.context`
+# to get the input variables with nulls for defaults,
+# for example `context = module.this.context`,
+# and access individual variables as `module.this.<var>`,
+# with final values filled in.
+#
+# For example, when using defaults, `module.this.context.delimiter`
+# will be null, and `module.this.delimiter` will be `-` (hyphen).
+#
+
+module "this" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0" # requires Terraform >= 0.13.0
+
+  enabled             = var.enabled
+  namespace           = var.namespace
+  tenant              = var.tenant
+  environment         = var.environment
+  stage               = var.stage
+  name                = var.name
+  delimiter           = var.delimiter
+  attributes          = var.attributes
+  tags                = var.tags
+  additional_tag_map  = var.additional_tag_map
+  label_order         = var.label_order
+  regex_replace_chars = var.regex_replace_chars
+  id_length_limit     = var.id_length_limit
+  label_key_case      = var.label_key_case
+  label_value_case    = var.label_value_case
+  descriptor_formats  = var.descriptor_formats
+  labels_as_tags      = var.labels_as_tags
+
+  context = var.context
+}
+
+# Copy contents of cloudposse/terraform-null-label/variables.tf here
+
+variable "context" {
+  type = any
+  default = {
+    enabled             = true
+    namespace           = null
+    tenant              = null
+    environment         = null
+    stage               = null
+    name                = null
+    delimiter           = null
+    attributes          = []
+    tags                = {}
+    additional_tag_map  = {}
+    regex_replace_chars = null
+    label_order         = []
+    id_length_limit     = null
+    label_key_case      = null
+    label_value_case    = null
+    descriptor_formats  = {}
+    # Note: we have to use [] instead of null for unset lists due to
+    # https://github.com/hashicorp/terraform/issues/28137
+    # which was not fixed until Terraform 1.0.0,
+    # but we want the default to be all the labels in `label_order`
+    # and we want users to be able to prevent all tag generation
+    # by setting `labels_as_tags` to `[]`, so we need
+    # a different sentinel to indicate "default"
+    labels_as_tags = ["unset"]
+  }
+  description = <<-EOT
+    Single object for setting entire context at once.
+    See description of individual variables for details.
+    Leave string and numeric variables as `null` to use default value.
+    Individual variable settings (non-null) override settings in context object,
+    except for attributes, tags, and additional_tag_map, which are merged.
+  EOT
+
+  validation {
+    condition     = lookup(var.context, "label_key_case", null) == null ? true : contains(["lower", "title", "upper"], var.context["label_key_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+
+  validation {
+    condition     = lookup(var.context, "label_value_case", null) == null ? true : contains(["lower", "title", "upper", "none"], var.context["label_value_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+variable "enabled" {
+  type        = bool
+  default     = null
+  description = "Set to false to prevent the module from creating any resources"
+}
+
+variable "namespace" {
+  type        = string
+  default     = null
+  description = "ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique"
+}
+
+variable "tenant" {
+  type        = string
+  default     = null
+  description = "ID element _(Rarely used, not included by default)_. A customer identifier, indicating who this instance of a resource is for"
+}
+
+variable "environment" {
+  type        = string
+  default     = null
+  description = "ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT'"
+}
+
+variable "stage" {
+  type        = string
+  default     = null
+  description = "ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release'"
+}
+
+variable "name" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.
+    This is the only ID element not also included as a `tag`.
+    The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input.
+    EOT
+}
+
+variable "delimiter" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Delimiter to be used between ID elements.
+    Defaults to `-` (hyphen). Set to `""` to use no delimiter at all.
+  EOT
+}
+
+variable "attributes" {
+  type        = list(string)
+  default     = []
+  description = <<-EOT
+    ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,
+    in the order they appear in the list. New attributes are appended to the
+    end of the list. The elements of the list are joined by the `delimiter`
+    and treated as a single ID element.
+    EOT
+}
+
+variable "labels_as_tags" {
+  type        = set(string)
+  default     = ["default"]
+  description = <<-EOT
+    Set of labels (ID elements) to include as tags in the `tags` output.
+    Default is to include all labels.
+    Tags with empty values will not be included in the `tags` output.
+    Set to `[]` to suppress all generated tags.
+    **Notes:**
+      The value of the `name` tag, if included, will be the `id`, not the `name`.
+      Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be
+      changed in later chained modules. Attempts to change it will be silently ignored.
+    EOT
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+    Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).
+    Neither the tag keys nor the tag values will be modified by this module.
+    EOT
+}
+
+variable "additional_tag_map" {
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+    Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.
+    This is for some rare cases where resources want additional configuration of tags
+    and therefore take a list of maps with tag key, value, and additional configuration.
+    EOT
+}
+
+variable "label_order" {
+  type        = list(string)
+  default     = null
+  description = <<-EOT
+    The order in which the labels (ID elements) appear in the `id`.
+    Defaults to ["namespace", "environment", "stage", "name", "attributes"].
+    You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present.
+    EOT
+}
+
+variable "regex_replace_chars" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Terraform regular expression (regex) string.
+    Characters matching the regex will be removed from the ID elements.
+    If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits.
+  EOT
+}
+
+variable "id_length_limit" {
+  type        = number
+  default     = null
+  description = <<-EOT
+    Limit `id` to this many characters (minimum 6).
+    Set to `0` for unlimited length.
+    Set to `null` for keep the existing setting, which defaults to `0`.
+    Does not affect `id_full`.
+  EOT
+  validation {
+    condition     = var.id_length_limit == null ? true : var.id_length_limit >= 6 || var.id_length_limit == 0
+    error_message = "The id_length_limit must be >= 6 if supplied (not null), or 0 for unlimited length."
+  }
+}
+
+variable "label_key_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Controls the letter case of the `tags` keys (label names) for tags generated by this module.
+    Does not affect keys of tags passed in via the `tags` input.
+    Possible values: `lower`, `title`, `upper`.
+    Default value: `title`.
+  EOT
+
+  validation {
+    condition     = var.label_key_case == null ? true : contains(["lower", "title", "upper"], var.label_key_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+}
+
+variable "label_value_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Controls the letter case of ID elements (labels) as included in `id`,
+    set as tag values, and output by this module individually.
+    Does not affect values of tags passed in via the `tags` input.
+    Possible values: `lower`, `title`, `upper` and `none` (no transformation).
+    Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.
+    Default value: `lower`.
+  EOT
+
+  validation {
+    condition     = var.label_value_case == null ? true : contains(["lower", "title", "upper", "none"], var.label_value_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+variable "descriptor_formats" {
+  type        = any
+  default     = {}
+  description = <<-EOT
+    Describe additional descriptors to be output in the `descriptors` output map.
+    Map of maps. Keys are names of descriptors. Values are maps of the form
+    `{
+       format = string
+       labels = list(string)
+    }`
+    (Type is `any` so the map values can later be enhanced to provide additional options.)
+    `format` is a Terraform format string to be passed to the `format()` function.
+    `labels` is a list of labels, in order, to pass to `format()` function.
+    Label values will be normalized before being passed to `format()` so they will be
+    identical to how they appear in `id`.
+    Default is `{}` (`descriptors` output will be empty).
+    EOT
+}
+
+#### End of copy of cloudposse/terraform-null-label/variables.tf

--- a/modules/aurora-mysql-resources/main.tf
+++ b/modules/aurora-mysql-resources/main.tf
@@ -1,0 +1,66 @@
+locals {
+  enabled       = module.this.enabled
+  mysql_enabled = var.mysql_cluster_enabled && local.enabled
+
+  fetch_passwords         = local.enabled && length(var.ssm_password_source) > 0
+  password_users_to_fetch = local.fetch_passwords ? toset(concat([local.mysql_admin_user], keys(var.additional_grants))) : []
+
+  mysql_admin_user     = module.aurora_mysql.outputs.aurora_mysql_master_username
+  mysql_admin_password = local.fetch_passwords ? data.aws_ssm_parameter.password[local.mysql_admin_user].value : var.mysql_admin_password
+
+  kms_key_arn = module.aurora_mysql.outputs.kms_key_arn
+}
+
+data "aws_ssm_parameter" "password" {
+  for_each = local.password_users_to_fetch
+
+  name = format(var.ssm_password_source, each.key)
+
+  with_decryption = true
+}
+
+resource "mysql_database" "additional" {
+  for_each = local.mysql_enabled ? var.additional_databases : []
+
+  name = each.key
+}
+
+module "additional_users" {
+  for_each = var.additional_users
+  source   = "./modules/mysql-user"
+
+  service_name    = each.key
+  db_user         = each.value.db_user
+  db_password     = each.value.db_password
+  grants          = each.value.grants
+  ssm_path_prefix = var.ssm_path_prefix
+  kms_key_id      = local.kms_key_arn
+
+  depends_on = [
+    mysql_database.additional,
+  ]
+
+  context = module.this.context
+}
+
+module "additional_grants" {
+  for_each = var.additional_grants
+  source   = "./modules/mysql-user"
+
+  service_name    = each.key
+  db_password     = local.fetch_passwords ? data.aws_ssm_parameter.password[each.key].value : ""
+  grants          = each.value
+  ssm_path_prefix = var.ssm_path_prefix
+  # There is a difference in how Terraform formats the "not" (`!`) operator
+  # between Terraform version 0.13 and 0.14 so we avoid using it to
+  # avoid formatting wars.
+  save_password_in_ssm = local.fetch_passwords ? false : true
+  kms_key_id           = local.kms_key_arn
+
+  depends_on = [
+    mysql_database.additional,
+  ]
+
+  context = module.this.context
+}
+

--- a/modules/aurora-mysql-resources/modules/mysql-user/context.tf
+++ b/modules/aurora-mysql-resources/modules/mysql-user/context.tf
@@ -1,0 +1,279 @@
+#
+# ONLY EDIT THIS FILE IN github.com/cloudposse/terraform-null-label
+# All other instances of this file should be a copy of that one
+#
+#
+# Copy this file from https://github.com/cloudposse/terraform-null-label/blob/master/exports/context.tf
+# and then place it in your Terraform module to automatically get
+# Cloud Posse's standard configuration inputs suitable for passing
+# to Cloud Posse modules.
+#
+# curl -sL https://raw.githubusercontent.com/cloudposse/terraform-null-label/master/exports/context.tf -o context.tf
+#
+# Modules should access the whole context as `module.this.context`
+# to get the input variables with nulls for defaults,
+# for example `context = module.this.context`,
+# and access individual variables as `module.this.<var>`,
+# with final values filled in.
+#
+# For example, when using defaults, `module.this.context.delimiter`
+# will be null, and `module.this.delimiter` will be `-` (hyphen).
+#
+
+module "this" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0" # requires Terraform >= 0.13.0
+
+  enabled             = var.enabled
+  namespace           = var.namespace
+  tenant              = var.tenant
+  environment         = var.environment
+  stage               = var.stage
+  name                = var.name
+  delimiter           = var.delimiter
+  attributes          = var.attributes
+  tags                = var.tags
+  additional_tag_map  = var.additional_tag_map
+  label_order         = var.label_order
+  regex_replace_chars = var.regex_replace_chars
+  id_length_limit     = var.id_length_limit
+  label_key_case      = var.label_key_case
+  label_value_case    = var.label_value_case
+  descriptor_formats  = var.descriptor_formats
+  labels_as_tags      = var.labels_as_tags
+
+  context = var.context
+}
+
+# Copy contents of cloudposse/terraform-null-label/variables.tf here
+
+variable "context" {
+  type = any
+  default = {
+    enabled             = true
+    namespace           = null
+    tenant              = null
+    environment         = null
+    stage               = null
+    name                = null
+    delimiter           = null
+    attributes          = []
+    tags                = {}
+    additional_tag_map  = {}
+    regex_replace_chars = null
+    label_order         = []
+    id_length_limit     = null
+    label_key_case      = null
+    label_value_case    = null
+    descriptor_formats  = {}
+    # Note: we have to use [] instead of null for unset lists due to
+    # https://github.com/hashicorp/terraform/issues/28137
+    # which was not fixed until Terraform 1.0.0,
+    # but we want the default to be all the labels in `label_order`
+    # and we want users to be able to prevent all tag generation
+    # by setting `labels_as_tags` to `[]`, so we need
+    # a different sentinel to indicate "default"
+    labels_as_tags = ["unset"]
+  }
+  description = <<-EOT
+    Single object for setting entire context at once.
+    See description of individual variables for details.
+    Leave string and numeric variables as `null` to use default value.
+    Individual variable settings (non-null) override settings in context object,
+    except for attributes, tags, and additional_tag_map, which are merged.
+  EOT
+
+  validation {
+    condition     = lookup(var.context, "label_key_case", null) == null ? true : contains(["lower", "title", "upper"], var.context["label_key_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+
+  validation {
+    condition     = lookup(var.context, "label_value_case", null) == null ? true : contains(["lower", "title", "upper", "none"], var.context["label_value_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+variable "enabled" {
+  type        = bool
+  default     = null
+  description = "Set to false to prevent the module from creating any resources"
+}
+
+variable "namespace" {
+  type        = string
+  default     = null
+  description = "ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique"
+}
+
+variable "tenant" {
+  type        = string
+  default     = null
+  description = "ID element _(Rarely used, not included by default)_. A customer identifier, indicating who this instance of a resource is for"
+}
+
+variable "environment" {
+  type        = string
+  default     = null
+  description = "ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT'"
+}
+
+variable "stage" {
+  type        = string
+  default     = null
+  description = "ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release'"
+}
+
+variable "name" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.
+    This is the only ID element not also included as a `tag`.
+    The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input.
+    EOT
+}
+
+variable "delimiter" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Delimiter to be used between ID elements.
+    Defaults to `-` (hyphen). Set to `""` to use no delimiter at all.
+  EOT
+}
+
+variable "attributes" {
+  type        = list(string)
+  default     = []
+  description = <<-EOT
+    ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,
+    in the order they appear in the list. New attributes are appended to the
+    end of the list. The elements of the list are joined by the `delimiter`
+    and treated as a single ID element.
+    EOT
+}
+
+variable "labels_as_tags" {
+  type        = set(string)
+  default     = ["default"]
+  description = <<-EOT
+    Set of labels (ID elements) to include as tags in the `tags` output.
+    Default is to include all labels.
+    Tags with empty values will not be included in the `tags` output.
+    Set to `[]` to suppress all generated tags.
+    **Notes:**
+      The value of the `name` tag, if included, will be the `id`, not the `name`.
+      Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be
+      changed in later chained modules. Attempts to change it will be silently ignored.
+    EOT
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+    Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).
+    Neither the tag keys nor the tag values will be modified by this module.
+    EOT
+}
+
+variable "additional_tag_map" {
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+    Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.
+    This is for some rare cases where resources want additional configuration of tags
+    and therefore take a list of maps with tag key, value, and additional configuration.
+    EOT
+}
+
+variable "label_order" {
+  type        = list(string)
+  default     = null
+  description = <<-EOT
+    The order in which the labels (ID elements) appear in the `id`.
+    Defaults to ["namespace", "environment", "stage", "name", "attributes"].
+    You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present.
+    EOT
+}
+
+variable "regex_replace_chars" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Terraform regular expression (regex) string.
+    Characters matching the regex will be removed from the ID elements.
+    If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits.
+  EOT
+}
+
+variable "id_length_limit" {
+  type        = number
+  default     = null
+  description = <<-EOT
+    Limit `id` to this many characters (minimum 6).
+    Set to `0` for unlimited length.
+    Set to `null` for keep the existing setting, which defaults to `0`.
+    Does not affect `id_full`.
+  EOT
+  validation {
+    condition     = var.id_length_limit == null ? true : var.id_length_limit >= 6 || var.id_length_limit == 0
+    error_message = "The id_length_limit must be >= 6 if supplied (not null), or 0 for unlimited length."
+  }
+}
+
+variable "label_key_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Controls the letter case of the `tags` keys (label names) for tags generated by this module.
+    Does not affect keys of tags passed in via the `tags` input.
+    Possible values: `lower`, `title`, `upper`.
+    Default value: `title`.
+  EOT
+
+  validation {
+    condition     = var.label_key_case == null ? true : contains(["lower", "title", "upper"], var.label_key_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+}
+
+variable "label_value_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Controls the letter case of ID elements (labels) as included in `id`,
+    set as tag values, and output by this module individually.
+    Does not affect values of tags passed in via the `tags` input.
+    Possible values: `lower`, `title`, `upper` and `none` (no transformation).
+    Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.
+    Default value: `lower`.
+  EOT
+
+  validation {
+    condition     = var.label_value_case == null ? true : contains(["lower", "title", "upper", "none"], var.label_value_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+variable "descriptor_formats" {
+  type        = any
+  default     = {}
+  description = <<-EOT
+    Describe additional descriptors to be output in the `descriptors` output map.
+    Map of maps. Keys are names of descriptors. Values are maps of the form
+    `{
+       format = string
+       labels = list(string)
+    }`
+    (Type is `any` so the map values can later be enhanced to provide additional options.)
+    `format` is a Terraform format string to be passed to the `format()` function.
+    `labels` is a list of labels, in order, to pass to `format()` function.
+    Label values will be normalized before being passed to `format()` so they will be
+    identical to how they appear in `id`.
+    Default is `{}` (`descriptors` output will be empty).
+    EOT
+}
+
+#### End of copy of cloudposse/terraform-null-label/variables.tf

--- a/modules/aurora-mysql-resources/modules/mysql-user/default.auto.tfvars
+++ b/modules/aurora-mysql-resources/modules/mysql-user/default.auto.tfvars
@@ -1,0 +1,1 @@
+enabled = false

--- a/modules/aurora-mysql-resources/modules/mysql-user/main.tf
+++ b/modules/aurora-mysql-resources/modules/mysql-user/main.tf
@@ -1,0 +1,128 @@
+locals {
+  enabled = module.this.enabled
+
+  db_user         = length(var.db_user) > 0 ? var.db_user : var.service_name
+  db_password     = length(var.db_password) > 0 ? var.db_password : join("", random_password.db_password.*.result)
+  db_password_key = format("/%s/%s/%s", var.ssm_path_prefix, var.service_name, "db_password")
+
+  create_db_user       = local.enabled && var.service_name != local.db_user
+  save_password_in_ssm = local.enabled && var.save_password_in_ssm
+
+  db_user_ssm = local.create_db_user ? {
+    name        = format("/%s/%s/%s", var.ssm_path_prefix, var.service_name, "db_user")
+    value       = local.db_user
+    description = "MySQL Username for ${var.service_name} service"
+    type        = "String"
+    overwrite   = true
+  } : null
+  db_password_ssm = local.save_password_in_ssm ? {
+    name        = local.db_password_key
+    value       = local.db_password
+    description = "MySQL Password for DB user ${local.db_user}"
+    type        = "SecureString"
+    overwrite   = true
+  } : null
+
+  # In order to avoid:
+  # "local.parameter_write will be known only after apply"
+  # We must define exactly what the list should include
+  parameter_write = (local.create_db_user && local.save_password_in_ssm) ? [local.db_user_ssm, local.db_password_ssm] : (((local.create_db_user) ? [local.db_user_ssm] : ((local.save_password_in_ssm) ? [local.db_password_ssm] : [])))
+
+  # You cannot grant "ALL" to an RDS user because "ALL" includes privileges that
+  # Master does not have (because this is a managed database).
+  # See the full list of available options at https://docs.amazonaws.cn/en_us/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Security.html
+  # This is all the privileges an application should need.
+  # Privileges not listed are not available.
+  # Privileges commented out are dangerous or cannot be limited to 1 database and should not be needed by an app
+  all_rds_app_grants = [
+    "ALTER",
+    "ALTER ROUTINE",
+    "CREATE",
+    "CREATE ROUTINE",
+    "CREATE TEMPORARY TABLES",
+    # "CREATE USER",
+    "CREATE VIEW",
+    "DELETE",
+    "DROP",
+    "EVENT",
+    "EXECUTE",
+    # "GRANT OPTION",
+    "INDEX",
+    "INSERT",
+    "LOAD FROM S3",
+    "LOCK TABLES",
+    # "PROCESS",
+    "REFERENCES",
+    # "RELOAD",
+    # "REPLICATION CLIENT",
+    # "REPLICATION SLAVE",
+    "SELECT",
+    # "SHOW DATABASES",
+    "SHOW VIEW",
+    "TRIGGER",
+    "UPDATE"
+  ]
+  all_rds_other_grants = [
+    "CREATE USER",
+    "GRANT OPTION",
+    "PROCESS",
+    "RELOAD",
+    "REPLICATION CLIENT",
+    "REPLICATION SLAVE",
+    "SHOW DATABASES",
+  ]
+  all_grants = distinct(concat(local.all_rds_app_grants, local.all_rds_other_grants))
+}
+
+resource "random_password" "db_password" {
+  count   = local.enabled && length(var.db_password) == 0 ? 1 : 0
+  length  = 33
+  special = false
+
+  keepers = {
+    db_user = local.db_user
+  }
+}
+
+resource "mysql_user" "default" {
+  count              = local.enabled ? 1 : 0
+  user               = local.db_user
+  host               = "%"
+  plaintext_password = local.db_password
+  #  depends_on         = [var.instance_ids]
+}
+
+# Grant the user full access to this specific database
+resource "mysql_grant" "default" {
+  count    = local.enabled ? length(var.grants) : 0
+  user     = join("", mysql_user.default.*.user)
+  host     = join("", mysql_user.default.*.host)
+  database = split(".", var.grants[count.index].db)[0]
+  # We would like to use
+  # table = try(split(".", var.grants[count.index].db)[1], "*")
+  # but when we create the database, no tables exist, and we cannot
+  # limit a grant to a non-existent table.
+  table = "*"
+
+  privileges = flatten([for grant in var.grants[count.index].grant : (
+    grant == "ALL_APP" ? local.all_rds_app_grants : grant == "ALL" ? local.all_grants : [grant]
+  )])
+
+  depends_on = [mysql_user.default]
+  # Apparently this is needed. See https://github.com/terraform-providers/terraform-provider-mysql/issues/55#issuecomment-615463296
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+module "parameter_store_write" {
+  source  = "cloudposse/ssm-parameter-store/aws"
+  version = "0.10.0"
+
+  # kms_arn will only be used for SecureString parameters
+  kms_arn = var.kms_key_id # not necessarily ARN — alias works too
+
+  parameter_write = local.parameter_write
+
+  context = module.this.context
+}

--- a/modules/aurora-mysql-resources/modules/mysql-user/outputs.tf
+++ b/modules/aurora-mysql-resources/modules/mysql-user/outputs.tf
@@ -1,0 +1,14 @@
+output "notice" {
+  value       = local.save_password_in_ssm ? "Password for user ${local.db_user} is stored in SSM under ${local.db_password_key}" : null
+  description = "Note to user"
+}
+
+output "password_ssm_key" {
+  value       = local.save_password_in_ssm ? local.db_password_key : null
+  description = "SSM key under which user password is stored"
+}
+
+output "db_user" {
+  value       = local.db_user
+  description = "DB user name"
+}

--- a/modules/aurora-mysql-resources/modules/mysql-user/variables.tf
+++ b/modules/aurora-mysql-resources/modules/mysql-user/variables.tf
@@ -1,0 +1,49 @@
+variable "service_name" {
+  type        = string
+  description = "Name of service owning the database (used in SSM key)"
+}
+
+variable "db_user" {
+  type        = string
+  description = "MySQL admin user name (default is service name)"
+  default     = ""
+}
+
+variable "db_password" {
+  type        = string
+  description = "MySQL password for the admin user (generated if not provided)"
+  default     = ""
+}
+
+variable "grants" {
+  type = list(object({
+    grant : list(string)
+    db : string
+  }))
+  description = <<-EOT
+    List of { grant: "[<grant>, <grant>, ...]", db: "db" }.
+    Normal grants plus `ALL_APP` for all RDS allowed grants that an app should need
+    (can be limited to a single database). `ALL` is not the normal MySQL `ALL` but
+    is all the grants RDS allows.
+    EOT
+  default     = [{ grant : ["ALL_APP"], db : "*" }]
+}
+
+variable "ssm_path_prefix" {
+  type        = string
+  default     = "rds"
+  description = "SSM path prefix"
+}
+
+variable "save_password_in_ssm" {
+  type        = bool
+  default     = true
+  description = "If true, DB user's password will be stored in SSM"
+}
+
+variable "kms_key_id" {
+  type        = string
+  default     = "alias/aws/rds"
+  description = "KMS key ID, ARN, or alias to use for encrypting MySQL database"
+}
+

--- a/modules/aurora-mysql-resources/modules/mysql-user/versions.tf
+++ b/modules/aurora-mysql-resources/modules/mysql-user/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.0.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+    mysql = {
+      source  = "terraform-providers/mysql"
+      version = ">= 1.9"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 2.2"
+    }
+  }
+}

--- a/modules/aurora-mysql-resources/outputs.tf
+++ b/modules/aurora-mysql-resources/outputs.tf
@@ -1,0 +1,10 @@
+output "additional_users" {
+  value       = { for k, v in var.additional_users : k => module.additional_users[k] }
+  description = "Additional DB users created"
+}
+
+output "additional_grants" {
+  value       = keys(module.additional_grants)
+  description = "Additional DB users created"
+}
+

--- a/modules/aurora-mysql-resources/providers.tf
+++ b/modules/aurora-mysql-resources/providers.tf
@@ -1,0 +1,35 @@
+provider "aws" {
+  region = var.region
+
+  profile = module.iam_roles.profiles_enabled ? coalesce(var.import_profile_name, module.iam_roles.terraform_profile_name) : null
+
+  dynamic "assume_role" {
+    for_each = module.iam_roles.profiles_enabled ? [] : ["role"]
+    content {
+      role_arn = coalesce(var.import_role_arn, module.iam_roles.terraform_role_arn)
+    }
+  }
+}
+
+module "iam_roles" {
+  source  = "../account-map/modules/iam-roles"
+  context = module.this.context
+}
+
+variable "import_profile_name" {
+  type        = string
+  default     = null
+  description = "AWS Profile name to use when importing a resource"
+}
+
+variable "import_role_arn" {
+  type        = string
+  default     = null
+  description = "IAM Role ARN to use when importing a resource"
+}
+
+provider "mysql" {
+  endpoint = module.aurora_mysql.outputs.aurora_mysql_endpoint
+  username = local.mysql_admin_user
+  password = local.mysql_admin_password
+}

--- a/modules/aurora-mysql-resources/remote-state.tf
+++ b/modules/aurora-mysql-resources/remote-state.tf
@@ -1,0 +1,8 @@
+module "aurora_mysql" {
+  source  = "cloudposse/stack-config/yaml//modules/remote-state"
+  version = "0.22.4"
+
+  component = var.aurora_mysql_component_name
+
+  context = module.this.context
+}

--- a/modules/aurora-mysql-resources/variables.tf
+++ b/modules/aurora-mysql-resources/variables.tf
@@ -1,0 +1,77 @@
+variable "region" {
+  type        = string
+  description = "AWS Region"
+}
+
+variable "aurora_mysql_component_name" {
+  type        = string
+  description = "Aurora MySQL component name to read the remote state from"
+}
+
+variable "ssm_path_prefix" {
+  type        = string
+  default     = "rds"
+  description = "SSM path prefix"
+}
+
+variable "ssm_password_source" {
+  type        = string
+  default     = ""
+  description = "If set, DB user passwords will be retrieved from SSM using the key `format(var.ssm_password_source, local.db_username)`"
+}
+
+variable "mysql_admin_password" {
+  type        = string
+  description = "MySQL password for the admin user"
+  default     = ""
+}
+
+variable "mysql_db_name" {
+  type        = string
+  description = "Database name (default is not to create a database"
+  default     = ""
+}
+
+variable "mysql_cluster_enabled" {
+  type        = string
+  default     = true
+  description = "Set to `false` to prevent the module from creating any resources"
+}
+
+variable "additional_databases" {
+  type    = set(string)
+  default = []
+}
+
+variable "additional_users" {
+  # map key is service name
+  type = map(object({
+    db_user : string
+    db_password : string
+    grants : list(object({
+      grant : list(string)
+      db : string
+    }))
+  }))
+  default     = {}
+  description = <<-EOT
+    Create additional database user for a service, specifying username, grants, and optional password.
+    If no password is specified, one will be generated. Username and password will be stored in
+    SSM parameter store under the service's key.
+    EOT
+}
+
+variable "additional_grants" {
+  # map key is user name
+  type = map(list(object({
+    grant : list(string)
+    db : string
+  })))
+  default     = {}
+  description = <<-EOT
+    Create additional database user with specified grants.
+    If `var.ssm_password_source` is set, passwords will be retrieved from SSM parameter store,
+    otherwise, passwords will be generated and stored in SSM parameter store under the service's key.
+    EOT
+}
+

--- a/modules/aurora-mysql-resources/versions.tf
+++ b/modules/aurora-mysql-resources/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.0.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+    mysql = {
+      source  = "terraform-providers/mysql"
+      version = ">= 1.9"
+    }
+  }
+}

--- a/modules/aurora-mysql/README.md
+++ b/modules/aurora-mysql/README.md
@@ -1,0 +1,197 @@
+# Component: `aurora-mysql`
+
+This component is responsible for provisioning Aurora MySQL RDS clusters. 
+It seeds relevant database information (hostnames, username, password, etc.) into AWS SSM Parameter Store.
+
+## Usage
+
+**Stack Level**: Regional
+
+Here's an example for how to use this component.
+
+`stacks/catalog/aurora-mysql/defaults.yaml` file (base component for all Aurora MySQL clusters with default settings):
+
+```yaml
+components:
+  terraform:
+    aurora-mysql/defaults:
+      metadata:
+        type: abstract
+      vars:
+        enabled: false
+        name: rds
+        mysql_deletion_protection: false
+        mysql_storage_encrypted: true
+        aurora_mysql_engine: "aurora-mysql"
+        allowed_cidr_blocks:
+          # all otto
+          - 10.128.0.0/22
+          # all corp
+          - 10.128.16.0/22
+        eks_component_names:
+          - eks/eks
+        # https://docs.aws.amazon.com/AmazonRDS/latest/AuroraMySQLReleaseNotes/AuroraMySQL.Updates.3020.html
+        # aws rds describe-db-engine-versions --engine aurora-mysql --query 'DBEngineVersions[].EngineVersion'
+        aurora_mysql_engine_version: "8.0.mysql_aurora.3.02.0"
+        # engine and cluster family are notoriously hard to find.
+        # If you know the engine version (example here is "8.0.mysql_aurora.3.02.0"), use Engine and DBParameterGroupFamily from:
+        #    aws rds describe-db-engine-versions --engine aurora-mysql --query "DBEngineVersions[]" | \
+        #    jq '.[] | select(.EngineVersion == "8.0.mysql_aurora.3.02.0") |
+        #       { Engine: .Engine, EngineVersion: .EngineVersion, DBParameterGroupFamily: .DBParameterGroupFamily }'
+        #
+        #    Returns:
+        #    {
+        #       "Engine": "aurora-mysql",
+        #       "EngineVersion": "8.0.mysql_aurora.3.02.0",
+        #       "DBParameterGroupFamily": "aurora-mysql8.0"
+        #     }
+        aurora_mysql_cluster_family: "aurora-mysql8.0"
+        mysql_name: shared
+        # 1 writer, 1 reader
+        mysql_cluster_size: 2
+        mysql_admin_user: "" # generate random username
+        mysql_admin_password: "" # generate random password
+        mysql_db_name: "" # generate random db name
+        # https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Concepts.DBInstanceClass.html
+        mysql_instance_type: "db.t3.medium"
+        mysql_skip_final_snapshot: false
+```
+
+Example (not actual)
+`stacks/uw2-dev.yaml` file (override the default settings for the cluster in the `dev` account):
+
+```yaml
+import:
+  - catalog/aurora-mysql/defaults
+
+components:
+  terraform:
+    aurora-mysql/dev:
+      metadata:
+        component: aurora-mysql
+        inherits:
+          - aurora-mysql/defaults
+      vars:
+        instance_type: db.r5.large
+        cluster_size: 1
+        cluster_name: main
+        database_name: main
+```
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
+| <a name="requirement_mysql"></a> [mysql](#requirement\_mysql) | >= 1.9 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.2 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 2.2 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_aurora_mysql"></a> [aurora\_mysql](#module\_aurora\_mysql) | cloudposse/rds-cluster/aws | 1.3.1 |
+| <a name="module_cluster"></a> [cluster](#module\_cluster) | cloudposse/label/null | 0.25.0 |
+| <a name="module_dns-delegated"></a> [dns-delegated](#module\_dns-delegated) | cloudposse/stack-config/yaml//modules/remote-state | 0.22.4 |
+| <a name="module_eks"></a> [eks](#module\_eks) | cloudposse/stack-config/yaml//modules/remote-state | 0.22.4 |
+| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
+| <a name="module_kms_key_rds"></a> [kms\_key\_rds](#module\_kms\_key\_rds) | cloudposse/kms-key/aws | 0.12.1 |
+| <a name="module_parameter_store_write"></a> [parameter\_store\_write](#module\_parameter\_store\_write) | cloudposse/ssm-parameter-store/aws | 0.10.0 |
+| <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | cloudposse/stack-config/yaml//modules/remote-state | 0.22.4 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [random_password.mysql_admin_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
+| [random_pet.mysql_admin_user](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
+| [random_pet.mysql_db_name](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.kms_key_rds](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
+| [aws_ssm_parameter.password](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br>This is for some rare cases where resources want additional configuration of tags<br>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
+| <a name="input_allowed_cidr_blocks"></a> [allowed\_cidr\_blocks](#input\_allowed\_cidr\_blocks) | List of CIDR blocks to be allowed to connect to the RDS cluster | `list(string)` | `[]` | no |
+| <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br>in the order they appear in the list. New attributes are appended to the<br>end of the list. The elements of the list are joined by the `delimiter`<br>and treated as a single ID element. | `list(string)` | `[]` | no |
+| <a name="input_aurora_mysql_cluster_family"></a> [aurora\_mysql\_cluster\_family](#input\_aurora\_mysql\_cluster\_family) | DBParameterGroupFamily (e.g. `aurora5.6`, `aurora-mysql5.7` for Aurora MySQL databases). See https://stackoverflow.com/a/55819394 for help finding the right one to use. | `string` | n/a | yes |
+| <a name="input_aurora_mysql_cluster_parameters"></a> [aurora\_mysql\_cluster\_parameters](#input\_aurora\_mysql\_cluster\_parameters) | List of DB cluster parameters to apply | <pre>list(object({<br>    apply_method = string<br>    name         = string<br>    value        = string<br>  }))</pre> | `[]` | no |
+| <a name="input_aurora_mysql_engine"></a> [aurora\_mysql\_engine](#input\_aurora\_mysql\_engine) | Engine for Aurora database: `aurora` for MySQL 5.6, `aurora-mysql` for MySQL 5.7 | `string` | n/a | yes |
+| <a name="input_aurora_mysql_engine_version"></a> [aurora\_mysql\_engine\_version](#input\_aurora\_mysql\_engine\_version) | Engine Version for Aurora database. | `string` | `""` | no |
+| <a name="input_aurora_mysql_instance_parameters"></a> [aurora\_mysql\_instance\_parameters](#input\_aurora\_mysql\_instance\_parameters) | List of DB instance parameters to apply | <pre>list(object({<br>    apply_method = string<br>    name         = string<br>    value        = string<br>  }))</pre> | `[]` | no |
+| <a name="input_auto_minor_version_upgrade"></a> [auto\_minor\_version\_upgrade](#input\_auto\_minor\_version\_upgrade) | Automatically update the cluster when a new minor version is released | `bool` | `false` | no |
+| <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "descriptor_formats": {},<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "labels_as_tags": [<br>    "unset"<br>  ],<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {},<br>  "tenant": null<br>}</pre> | no |
+| <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between ID elements.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
+| <a name="input_descriptor_formats"></a> [descriptor\_formats](#input\_descriptor\_formats) | Describe additional descriptors to be output in the `descriptors` output map.<br>Map of maps. Keys are names of descriptors. Values are maps of the form<br>`{<br>   format = string<br>   labels = list(string)<br>}`<br>(Type is `any` so the map values can later be enhanced to provide additional options.)<br>`format` is a Terraform format string to be passed to the `format()` function.<br>`labels` is a list of labels, in order, to pass to `format()` function.<br>Label values will be normalized before being passed to `format()` so they will be<br>identical to how they appear in `id`.<br>Default is `{}` (`descriptors` output will be empty). | `any` | `{}` | no |
+| <a name="input_eks_component_name"></a> [eks\_component\_name](#input\_eks\_component\_name) | The name of the eks component | `string` | `"eks/eks"` | no |
+| <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
+| <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for keep the existing setting, which defaults to `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
+| <a name="input_import_profile_name"></a> [import\_profile\_name](#input\_import\_profile\_name) | AWS Profile name to use when importing a resource | `string` | `null` | no |
+| <a name="input_import_role_arn"></a> [import\_role\_arn](#input\_import\_role\_arn) | IAM Role ARN to use when importing a resource | `string` | `null` | no |
+| <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | Controls the letter case of the `tags` keys (label names) for tags generated by this module.<br>Does not affect keys of tags passed in via the `tags` input.<br>Possible values: `lower`, `title`, `upper`.<br>Default value: `title`. | `string` | `null` | no |
+| <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The order in which the labels (ID elements) appear in the `id`.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present. | `list(string)` | `null` | no |
+| <a name="input_label_value_case"></a> [label\_value\_case](#input\_label\_value\_case) | Controls the letter case of ID elements (labels) as included in `id`,<br>set as tag values, and output by this module individually.<br>Does not affect values of tags passed in via the `tags` input.<br>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br>Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.<br>Default value: `lower`. | `string` | `null` | no |
+| <a name="input_labels_as_tags"></a> [labels\_as\_tags](#input\_labels\_as\_tags) | Set of labels (ID elements) to include as tags in the `tags` output.<br>Default is to include all labels.<br>Tags with empty values will not be included in the `tags` output.<br>Set to `[]` to suppress all generated tags.<br>**Notes:**<br>  The value of the `name` tag, if included, will be the `id`, not the `name`.<br>  Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be<br>  changed in later chained modules. Attempts to change it will be silently ignored. | `set(string)` | <pre>[<br>  "default"<br>]</pre> | no |
+| <a name="input_mysql_admin_password"></a> [mysql\_admin\_password](#input\_mysql\_admin\_password) | MySQL password for the admin user | `string` | `""` | no |
+| <a name="input_mysql_admin_user"></a> [mysql\_admin\_user](#input\_mysql\_admin\_user) | MySQL admin user name | `string` | `""` | no |
+| <a name="input_mysql_backup_retention_period"></a> [mysql\_backup\_retention\_period](#input\_mysql\_backup\_retention\_period) | Number of days for which to retain backups | `number` | `3` | no |
+| <a name="input_mysql_backup_window"></a> [mysql\_backup\_window](#input\_mysql\_backup\_window) | Daily time range during which the backups happen | `string` | `"07:00-09:00"` | no |
+| <a name="input_mysql_cluster_enabled"></a> [mysql\_cluster\_enabled](#input\_mysql\_cluster\_enabled) | Set to `false` to prevent the module from creating any resources | `string` | `true` | no |
+| <a name="input_mysql_cluster_size"></a> [mysql\_cluster\_size](#input\_mysql\_cluster\_size) | MySQL cluster size | `string` | `2` | no |
+| <a name="input_mysql_db_name"></a> [mysql\_db\_name](#input\_mysql\_db\_name) | Database name (default is not to create a database | `string` | `""` | no |
+| <a name="input_mysql_deletion_protection"></a> [mysql\_deletion\_protection](#input\_mysql\_deletion\_protection) | Set to `true` to protect the database from deletion | `string` | `true` | no |
+| <a name="input_mysql_enabled_cloudwatch_logs_exports"></a> [mysql\_enabled\_cloudwatch\_logs\_exports](#input\_mysql\_enabled\_cloudwatch\_logs\_exports) | List of log types to export to cloudwatch. The following log types are supported: audit, error, general, slowquery | `list(string)` | <pre>[<br>  "audit",<br>  "error",<br>  "general",<br>  "slowquery"<br>]</pre> | no |
+| <a name="input_mysql_instance_type"></a> [mysql\_instance\_type](#input\_mysql\_instance\_type) | EC2 instance type for RDS MySQL cluster | `string` | `"db.t3.medium"` | no |
+| <a name="input_mysql_maintenance_window"></a> [mysql\_maintenance\_window](#input\_mysql\_maintenance\_window) | Weekly time range during which system maintenance can occur, in UTC | `string` | `"sat:10:00-sat:10:30"` | no |
+| <a name="input_mysql_name"></a> [mysql\_name](#input\_mysql\_name) | MySQL solution name (part of cluster identifier) | `string` | `""` | no |
+| <a name="input_mysql_skip_final_snapshot"></a> [mysql\_skip\_final\_snapshot](#input\_mysql\_skip\_final\_snapshot) | Determines whether a final DB snapshot is created before the DB cluster is deleted | `string` | `false` | no |
+| <a name="input_mysql_storage_encrypted"></a> [mysql\_storage\_encrypted](#input\_mysql\_storage\_encrypted) | Set to `true` to keep the database contents encrypted | `string` | `true` | no |
+| <a name="input_name"></a> [name](#input\_name) | ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.<br>This is the only ID element not also included as a `tag`.<br>The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input. | `string` | `null` | no |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique | `string` | `null` | no |
+| <a name="input_performance_insights_enabled"></a> [performance\_insights\_enabled](#input\_performance\_insights\_enabled) | Set `true` to enable Performance Insights | `bool` | `false` | no |
+| <a name="input_publicly_accessible"></a> [publicly\_accessible](#input\_publicly\_accessible) | n/a | `bool` | `false` | no |
+| <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br>Characters matching the regex will be removed from the ID elements.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
+| <a name="input_region"></a> [region](#input\_region) | AWS Region | `string` | n/a | yes |
+| <a name="input_ssm_password_source"></a> [ssm\_password\_source](#input\_ssm\_password\_source) | If set, DB Admin user password will be retrieved from SSM using the key `format(var.ssm_password_source, local.db_username)` | `string` | `""` | no |
+| <a name="input_ssm_path_prefix"></a> [ssm\_path\_prefix](#input\_ssm\_path\_prefix) | SSM path prefix | `string` | `"rds"` | no |
+| <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
+| <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_aurora_mysql_cluster_name"></a> [aurora\_mysql\_cluster\_name](#output\_aurora\_mysql\_cluster\_name) | RDS Aurora-MySQL: Cluster Identifier |
+| <a name="output_aurora_mysql_endpoint"></a> [aurora\_mysql\_endpoint](#output\_aurora\_mysql\_endpoint) | RDS Aurora-MySQL: Endpoint |
+| <a name="output_aurora_mysql_master_hostname"></a> [aurora\_mysql\_master\_hostname](#output\_aurora\_mysql\_master\_hostname) | RDS Aurora-MySQL: DB Master hostname |
+| <a name="output_aurora_mysql_master_password"></a> [aurora\_mysql\_master\_password](#output\_aurora\_mysql\_master\_password) | Location of admin password |
+| <a name="output_aurora_mysql_master_password_ssm_key"></a> [aurora\_mysql\_master\_password\_ssm\_key](#output\_aurora\_mysql\_master\_password\_ssm\_key) | SSM key for admin password |
+| <a name="output_aurora_mysql_master_username"></a> [aurora\_mysql\_master\_username](#output\_aurora\_mysql\_master\_username) | RDS Aurora-MySQL: Username for the master DB user |
+| <a name="output_aurora_mysql_reader_endpoint"></a> [aurora\_mysql\_reader\_endpoint](#output\_aurora\_mysql\_reader\_endpoint) | RDS Aurora-MySQL: Reader Endpoint |
+| <a name="output_aurora_mysql_replicas_hostname"></a> [aurora\_mysql\_replicas\_hostname](#output\_aurora\_mysql\_replicas\_hostname) | RDS Aurora-MySQL: Replicas hostname |
+| <a name="output_cluster_domain"></a> [cluster\_domain](#output\_cluster\_domain) | AWS DNS name under which DB instances are provisioned |
+| <a name="output_kms_key_arn"></a> [kms\_key\_arn](#output\_kms\_key\_arn) | KMS key ARN for Aurora MySQL |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+
+## References
+* [cloudposse/terraform-aws-components](https://github.com/cloudposse/terraform-aws-components/tree/master/modules/aurora-mysql) - Cloud Posse's upstream component
+
+
+[<img src="https://cloudposse.com/logo-300x69.svg" height="32" align="right"/>](https://cpco.io/component)

--- a/modules/aurora-mysql/cluster-regional.tf
+++ b/modules/aurora-mysql/cluster-regional.tf
@@ -1,0 +1,48 @@
+module "aurora_mysql" {
+  source  = "cloudposse/rds-cluster/aws"
+  version = "1.3.1"
+
+  enabled    = local.mysql_enabled
+  attributes = [var.mysql_name]
+
+  engine              = var.aurora_mysql_engine
+  engine_version      = var.aurora_mysql_engine_version
+  cluster_family      = var.aurora_mysql_cluster_family
+  cluster_parameters  = var.aurora_mysql_cluster_parameters
+  cluster_size        = var.mysql_cluster_size
+  cluster_type        = "regional"
+  instance_parameters = var.aurora_mysql_instance_parameters
+  instance_type       = var.mysql_instance_type
+
+  db_name        = local.mysql_db_name
+  db_port        = 3306
+  admin_password = local.mysql_admin_password
+  admin_user     = local.mysql_admin_user
+
+  vpc_id              = local.vpc_id
+  publicly_accessible = var.publicly_accessible
+  subnets             = var.publicly_accessible ? local.public_subnet_ids : local.private_subnet_ids
+  allowed_cidr_blocks = var.publicly_accessible ? coalescelist(var.allowed_cidr_blocks, ["0.0.0.0/0"]) : var.allowed_cidr_blocks
+  security_groups     = [local.eks_cluster_managed_security_group_id]
+
+  zone_id          = local.zone_id
+  cluster_dns_name = "master.${local.cluster_subdomain}"
+  reader_dns_name  = "readers.${local.cluster_subdomain}"
+
+  auto_minor_version_upgrade      = var.auto_minor_version_upgrade
+  deletion_protection             = var.mysql_deletion_protection
+  enabled_cloudwatch_logs_exports = var.mysql_enabled_cloudwatch_logs_exports
+  copy_tags_to_snapshot           = true
+  skip_final_snapshot             = var.mysql_skip_final_snapshot
+
+  backup_window      = var.mysql_backup_window
+  maintenance_window = var.mysql_maintenance_window
+  retention_period   = var.mysql_backup_retention_period
+
+  storage_encrypted               = var.mysql_storage_encrypted
+  kms_key_arn                     = var.mysql_storage_encrypted ? module.kms_key_rds.key_arn : null
+  performance_insights_enabled    = var.performance_insights_enabled
+  performance_insights_kms_key_id = var.performance_insights_enabled ? module.kms_key_rds.key_arn : null
+
+  context = module.this.context
+}

--- a/modules/aurora-mysql/context.tf
+++ b/modules/aurora-mysql/context.tf
@@ -1,0 +1,279 @@
+#
+# ONLY EDIT THIS FILE IN github.com/cloudposse/terraform-null-label
+# All other instances of this file should be a copy of that one
+#
+#
+# Copy this file from https://github.com/cloudposse/terraform-null-label/blob/master/exports/context.tf
+# and then place it in your Terraform module to automatically get
+# Cloud Posse's standard configuration inputs suitable for passing
+# to Cloud Posse modules.
+#
+# curl -sL https://raw.githubusercontent.com/cloudposse/terraform-null-label/master/exports/context.tf -o context.tf
+#
+# Modules should access the whole context as `module.this.context`
+# to get the input variables with nulls for defaults,
+# for example `context = module.this.context`,
+# and access individual variables as `module.this.<var>`,
+# with final values filled in.
+#
+# For example, when using defaults, `module.this.context.delimiter`
+# will be null, and `module.this.delimiter` will be `-` (hyphen).
+#
+
+module "this" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0" # requires Terraform >= 0.13.0
+
+  enabled             = var.enabled
+  namespace           = var.namespace
+  tenant              = var.tenant
+  environment         = var.environment
+  stage               = var.stage
+  name                = var.name
+  delimiter           = var.delimiter
+  attributes          = var.attributes
+  tags                = var.tags
+  additional_tag_map  = var.additional_tag_map
+  label_order         = var.label_order
+  regex_replace_chars = var.regex_replace_chars
+  id_length_limit     = var.id_length_limit
+  label_key_case      = var.label_key_case
+  label_value_case    = var.label_value_case
+  descriptor_formats  = var.descriptor_formats
+  labels_as_tags      = var.labels_as_tags
+
+  context = var.context
+}
+
+# Copy contents of cloudposse/terraform-null-label/variables.tf here
+
+variable "context" {
+  type = any
+  default = {
+    enabled             = true
+    namespace           = null
+    tenant              = null
+    environment         = null
+    stage               = null
+    name                = null
+    delimiter           = null
+    attributes          = []
+    tags                = {}
+    additional_tag_map  = {}
+    regex_replace_chars = null
+    label_order         = []
+    id_length_limit     = null
+    label_key_case      = null
+    label_value_case    = null
+    descriptor_formats  = {}
+    # Note: we have to use [] instead of null for unset lists due to
+    # https://github.com/hashicorp/terraform/issues/28137
+    # which was not fixed until Terraform 1.0.0,
+    # but we want the default to be all the labels in `label_order`
+    # and we want users to be able to prevent all tag generation
+    # by setting `labels_as_tags` to `[]`, so we need
+    # a different sentinel to indicate "default"
+    labels_as_tags = ["unset"]
+  }
+  description = <<-EOT
+    Single object for setting entire context at once.
+    See description of individual variables for details.
+    Leave string and numeric variables as `null` to use default value.
+    Individual variable settings (non-null) override settings in context object,
+    except for attributes, tags, and additional_tag_map, which are merged.
+  EOT
+
+  validation {
+    condition     = lookup(var.context, "label_key_case", null) == null ? true : contains(["lower", "title", "upper"], var.context["label_key_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+
+  validation {
+    condition     = lookup(var.context, "label_value_case", null) == null ? true : contains(["lower", "title", "upper", "none"], var.context["label_value_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+variable "enabled" {
+  type        = bool
+  default     = null
+  description = "Set to false to prevent the module from creating any resources"
+}
+
+variable "namespace" {
+  type        = string
+  default     = null
+  description = "ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique"
+}
+
+variable "tenant" {
+  type        = string
+  default     = null
+  description = "ID element _(Rarely used, not included by default)_. A customer identifier, indicating who this instance of a resource is for"
+}
+
+variable "environment" {
+  type        = string
+  default     = null
+  description = "ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT'"
+}
+
+variable "stage" {
+  type        = string
+  default     = null
+  description = "ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release'"
+}
+
+variable "name" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.
+    This is the only ID element not also included as a `tag`.
+    The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input.
+    EOT
+}
+
+variable "delimiter" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Delimiter to be used between ID elements.
+    Defaults to `-` (hyphen). Set to `""` to use no delimiter at all.
+  EOT
+}
+
+variable "attributes" {
+  type        = list(string)
+  default     = []
+  description = <<-EOT
+    ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,
+    in the order they appear in the list. New attributes are appended to the
+    end of the list. The elements of the list are joined by the `delimiter`
+    and treated as a single ID element.
+    EOT
+}
+
+variable "labels_as_tags" {
+  type        = set(string)
+  default     = ["default"]
+  description = <<-EOT
+    Set of labels (ID elements) to include as tags in the `tags` output.
+    Default is to include all labels.
+    Tags with empty values will not be included in the `tags` output.
+    Set to `[]` to suppress all generated tags.
+    **Notes:**
+      The value of the `name` tag, if included, will be the `id`, not the `name`.
+      Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be
+      changed in later chained modules. Attempts to change it will be silently ignored.
+    EOT
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+    Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).
+    Neither the tag keys nor the tag values will be modified by this module.
+    EOT
+}
+
+variable "additional_tag_map" {
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+    Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.
+    This is for some rare cases where resources want additional configuration of tags
+    and therefore take a list of maps with tag key, value, and additional configuration.
+    EOT
+}
+
+variable "label_order" {
+  type        = list(string)
+  default     = null
+  description = <<-EOT
+    The order in which the labels (ID elements) appear in the `id`.
+    Defaults to ["namespace", "environment", "stage", "name", "attributes"].
+    You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present.
+    EOT
+}
+
+variable "regex_replace_chars" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Terraform regular expression (regex) string.
+    Characters matching the regex will be removed from the ID elements.
+    If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits.
+  EOT
+}
+
+variable "id_length_limit" {
+  type        = number
+  default     = null
+  description = <<-EOT
+    Limit `id` to this many characters (minimum 6).
+    Set to `0` for unlimited length.
+    Set to `null` for keep the existing setting, which defaults to `0`.
+    Does not affect `id_full`.
+  EOT
+  validation {
+    condition     = var.id_length_limit == null ? true : var.id_length_limit >= 6 || var.id_length_limit == 0
+    error_message = "The id_length_limit must be >= 6 if supplied (not null), or 0 for unlimited length."
+  }
+}
+
+variable "label_key_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Controls the letter case of the `tags` keys (label names) for tags generated by this module.
+    Does not affect keys of tags passed in via the `tags` input.
+    Possible values: `lower`, `title`, `upper`.
+    Default value: `title`.
+  EOT
+
+  validation {
+    condition     = var.label_key_case == null ? true : contains(["lower", "title", "upper"], var.label_key_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+}
+
+variable "label_value_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Controls the letter case of ID elements (labels) as included in `id`,
+    set as tag values, and output by this module individually.
+    Does not affect values of tags passed in via the `tags` input.
+    Possible values: `lower`, `title`, `upper` and `none` (no transformation).
+    Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.
+    Default value: `lower`.
+  EOT
+
+  validation {
+    condition     = var.label_value_case == null ? true : contains(["lower", "title", "upper", "none"], var.label_value_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+variable "descriptor_formats" {
+  type        = any
+  default     = {}
+  description = <<-EOT
+    Describe additional descriptors to be output in the `descriptors` output map.
+    Map of maps. Keys are names of descriptors. Values are maps of the form
+    `{
+       format = string
+       labels = list(string)
+    }`
+    (Type is `any` so the map values can later be enhanced to provide additional options.)
+    `format` is a Terraform format string to be passed to the `format()` function.
+    `labels` is a list of labels, in order, to pass to `format()` function.
+    Label values will be normalized before being passed to `format()` so they will be
+    identical to how they appear in `id`.
+    Default is `{}` (`descriptors` output will be empty).
+    EOT
+}
+
+#### End of copy of cloudposse/terraform-null-label/variables.tf

--- a/modules/aurora-mysql/default.auto.tfvars
+++ b/modules/aurora-mysql/default.auto.tfvars
@@ -1,0 +1,1 @@
+enabled = false

--- a/modules/aurora-mysql/kms.tf
+++ b/modules/aurora-mysql/kms.tf
@@ -1,0 +1,77 @@
+module "kms_key_rds" {
+  source  = "cloudposse/kms-key/aws"
+  version = "0.12.1"
+
+  enabled = local.mysql_enabled
+
+  description             = "KMS key for Aurora MySQL"
+  deletion_window_in_days = 10
+  enable_key_rotation     = true
+  policy                  = join("", data.aws_iam_policy_document.kms_key_rds.*.json)
+
+  context = module.cluster.context
+}
+
+data "aws_caller_identity" "current" {
+  count = local.enabled ? 1 : 0
+}
+
+data "aws_partition" "current" {
+  count = local.enabled ? 1 : 0
+}
+
+# https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default-allow-administrators
+# https://aws.amazon.com/premiumsupport/knowledge-center/update-key-policy-future/
+data "aws_iam_policy_document" "kms_key_rds" {
+  count = local.enabled ? 1 : 0
+
+  statement {
+    sid    = "Enable the account that owns the KMS key to manage it via IAM"
+    effect = "Allow"
+
+    actions = [
+      "kms:*"
+    ]
+
+    resources = [
+      "*"
+    ]
+
+    principals {
+      type = "AWS"
+
+      identifiers = [
+        format("arn:${join("", data.aws_partition.current.*.partition)}:iam::%s:root", join("", data.aws_caller_identity.current.*.account_id))
+      ]
+    }
+  }
+
+  # https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html
+  # https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html
+  # https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_aws-services-that-work-with-iam.html
+  # https://docs.aws.amazon.com/efs/latest/ug/using-service-linked-roles.html
+  statement {
+    sid    = "Allow RDS to encrypt and decrypt with the KMS key"
+    effect = "Allow"
+
+    actions = [
+      "kms:Encrypt*",
+      "kms:Decrypt*",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:Describe*"
+    ]
+
+    resources = [
+      "*"
+    ]
+
+    principals {
+      type = "Service"
+
+      identifiers = [
+        "rds.amazonaws.com"
+      ]
+    }
+  }
+}

--- a/modules/aurora-mysql/main.tf
+++ b/modules/aurora-mysql/main.tf
@@ -1,0 +1,64 @@
+locals {
+  enabled = module.this.enabled
+
+  vpc_outputs                           = module.vpc.outputs
+  dns_delegated_outputs                 = module.dns-delegated.outputs
+  eks_outputs                           = module.eks.outputs
+  vpc_id                                = local.vpc_outputs.vpc_id
+  public_subnet_ids                     = local.vpc_outputs.public_subnet_ids
+  private_subnet_ids                    = local.vpc_outputs.private_subnet_ids
+  zone_id                               = local.dns_delegated_outputs.default_dns_zone_id
+  eks_cluster_managed_security_group_id = local.eks_outputs.eks_cluster_managed_security_group_id
+
+  cluster_domain = local.mysql_enabled ? trimprefix(module.aurora_mysql.endpoint, "${module.aurora_mysql.cluster_identifier}.cluster-") : null
+
+
+  mysql_enabled        = var.mysql_cluster_enabled && local.enabled
+  mysql_admin_user     = length(var.mysql_admin_user) > 0 ? var.mysql_admin_user : join("", random_pet.mysql_admin_user.*.id)
+  fetch_admin_password = local.enabled && length(var.ssm_password_source) > 0
+  mysql_admin_password = local.fetch_admin_password ? data.aws_ssm_parameter.password[0].value : (
+    length(var.mysql_admin_password) > 0 ? var.mysql_admin_password : join("", random_password.mysql_admin_password.*.result)
+  )
+  mysql_admin_password_key = format("/%s/admin/%s/%s", var.ssm_path_prefix, "aurora-mysql", "password")
+
+  mysql_db_name = length(var.mysql_db_name) > 0 ? var.mysql_db_name : join("", random_pet.mysql_db_name.*.id)
+
+  cluster_subdomain = var.mysql_name == "" ? module.this.name : "${var.mysql_name}.${module.this.name}"
+
+  ssm_path_prefix        = format("/%s/%s", var.ssm_path_prefix, module.cluster.id)
+  ssm_cluster_key_prefix = format("%s/%s", local.ssm_path_prefix, "cluster")
+}
+
+module "cluster" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0"
+
+  attributes = [var.mysql_name]
+
+  context = module.this.context
+}
+
+resource "random_pet" "mysql_admin_user" {
+  count     = local.mysql_enabled && length(var.mysql_admin_user) == 0 ? 1 : 0
+  length    = 2
+  separator = "_"
+}
+
+resource "random_password" "mysql_admin_password" {
+  count   = local.mysql_enabled && length(var.mysql_admin_password) == 0 && local.fetch_admin_password == false ? 1 : 0
+  length  = 33
+  special = false
+}
+
+resource "random_pet" "mysql_db_name" {
+  count = local.mysql_enabled && length(var.mysql_db_name) == 0 ? 1 : 0
+
+  separator = "_"
+
+  keepers = {
+    cluster_name = var.mysql_name
+    db_name      = var.mysql_db_name
+  }
+}
+
+

--- a/modules/aurora-mysql/outputs.tf
+++ b/modules/aurora-mysql/outputs.tf
@@ -1,0 +1,51 @@
+output "cluster_domain" {
+  value       = local.cluster_domain
+  description = "AWS DNS name under which DB instances are provisioned"
+}
+
+output "aurora_mysql_master_username" {
+  value       = local.mysql_enabled ? module.aurora_mysql.master_username : null
+  description = "RDS Aurora-MySQL: Username for the master DB user"
+  sensitive   = true
+}
+
+output "aurora_mysql_master_password" {
+  value       = local.mysql_enabled ? "Password for admin user ${module.aurora_mysql.master_username} is stored in SSM at ${local.mysql_admin_password_key}" : null
+  description = "Location of admin password"
+  sensitive   = true
+}
+
+output "aurora_mysql_master_password_ssm_key" {
+  value       = local.mysql_enabled ? local.mysql_admin_password_key : null
+  description = "SSM key for admin password"
+}
+
+output "aurora_mysql_master_hostname" {
+  value       = local.mysql_enabled ? module.aurora_mysql.master_host : null
+  description = "RDS Aurora-MySQL: DB Master hostname"
+}
+
+output "aurora_mysql_replicas_hostname" {
+  value       = local.mysql_enabled ? module.aurora_mysql.replicas_host : null
+  description = "RDS Aurora-MySQL: Replicas hostname"
+}
+
+output "aurora_mysql_cluster_name" {
+  value       = local.mysql_enabled ? module.aurora_mysql.cluster_identifier : null
+  description = "RDS Aurora-MySQL: Cluster Identifier"
+}
+
+output "aurora_mysql_endpoint" {
+  value       = local.mysql_enabled ? module.aurora_mysql.endpoint : null
+  description = "RDS Aurora-MySQL: Endpoint"
+}
+
+output "aurora_mysql_reader_endpoint" {
+  value       = local.mysql_enabled ? module.aurora_mysql.reader_endpoint : null
+  description = "RDS Aurora-MySQL: Reader Endpoint"
+}
+
+output "kms_key_arn" {
+  value       = module.kms_key_rds.key_arn
+  description = "KMS key ARN for Aurora MySQL"
+}

--- a/modules/aurora-mysql/providers.tf
+++ b/modules/aurora-mysql/providers.tf
@@ -1,0 +1,35 @@
+provider "aws" {
+  region = var.region
+
+  profile = module.iam_roles.profiles_enabled ? coalesce(var.import_profile_name, module.iam_roles.terraform_profile_name) : null
+
+  dynamic "assume_role" {
+    for_each = module.iam_roles.profiles_enabled ? [] : ["role"]
+    content {
+      role_arn = coalesce(var.import_role_arn, module.iam_roles.terraform_role_arn)
+    }
+  }
+}
+
+module "iam_roles" {
+  source  = "../account-map/modules/iam-roles"
+  context = module.this.context
+}
+
+variable "import_profile_name" {
+  type        = string
+  default     = null
+  description = "AWS Profile name to use when importing a resource"
+}
+
+variable "import_role_arn" {
+  type        = string
+  default     = null
+  description = "IAM Role ARN to use when importing a resource"
+}
+
+provider "mysql" {
+  endpoint = time_sleep.mysql_cluster_propagation[0].triggers["endpoint"]
+  username = time_sleep.mysql_cluster_propagation[0].triggers["username"]
+  password = local.mysql_admin_password
+}

--- a/modules/aurora-mysql/remote-state.tf
+++ b/modules/aurora-mysql/remote-state.tf
@@ -1,0 +1,28 @@
+module "dns-delegated" {
+  source  = "cloudposse/stack-config/yaml//modules/remote-state"
+  version = "0.22.4"
+
+  component   = "dns-delegated"
+  environment = "gbl"
+
+  context = module.this.context
+}
+
+module "eks" {
+  source  = "cloudposse/stack-config/yaml//modules/remote-state"
+  version = "0.22.4"
+
+  component = var.eks_component_name
+
+  context = module.this.context
+}
+
+module "vpc" {
+  source  = "cloudposse/stack-config/yaml//modules/remote-state"
+  version = "0.22.4"
+
+  component = "vpc"
+
+  context = module.this.context
+}
+

--- a/modules/aurora-mysql/ssm.tf
+++ b/modules/aurora-mysql/ssm.tf
@@ -1,0 +1,70 @@
+data "aws_ssm_parameter" "password" {
+  count = local.fetch_admin_password ? 1 : 0
+
+  name = format(var.ssm_password_source, local.mysql_admin_user)
+
+  with_decryption = true
+}
+
+module "parameter_store_write" {
+  source  = "cloudposse/ssm-parameter-store/aws"
+  version = "0.10.0"
+
+  # kms_arn will only be used for SecureString parameters
+  kms_arn = module.kms_key_rds.key_arn
+
+  parameter_write = [
+    {
+      name        = format("%s/%s/%s", local.ssm_cluster_key_prefix, "aurora-mysql", "cluster_domain")
+      value       = local.cluster_domain
+      description = "AWS DNS name under which DB instances are provisioned"
+      type        = "String"
+      overwrite   = true
+    },
+    {
+      name        = format("%s/admin/%s/%s", local.ssm_cluster_key_prefix, "aurora-mysql", "user")
+      value       = local.mysql_admin_user
+      description = "Aurora MySQL DB admin user"
+      type        = "String"
+      overwrite   = true
+    },
+    {
+      name        = local.mysql_admin_password_key
+      value       = local.mysql_admin_password
+      description = "Aurora MySQL DB admin password"
+      type        = "SecureString"
+      overwrite   = true
+    },
+    {
+      name        = format("%s/%s/%s", local.ssm_cluster_key_prefix, "aurora-mysql", "db_host")
+      value       = module.aurora_mysql.master_host
+      description = "Aurora MySQL DB Master hostname"
+      type        = "String"
+      overwrite   = true
+    },
+    {
+      name        = format("%s/%s/%s", local.ssm_cluster_key_prefix, "aurora-mysql", "db_port")
+      value       = "3306"
+      description = "Aurora MySQL DB Master TCP port"
+      type        = "String"
+      overwrite   = true
+    },
+    {
+      name        = format("%s/%s/%s", local.ssm_cluster_key_prefix, "aurora-mysql", "replicas_hostname")
+      value       = module.aurora_mysql.replicas_host
+      description = "Aurora MySQL DB Replicas hostname"
+      type        = "String"
+      overwrite   = true
+    },
+    {
+      name        = format("%s/%s/%s", local.ssm_cluster_key_prefix, "aurora-mysql", "cluster_name")
+      value       = module.aurora_mysql.cluster_identifier
+      description = "Aurora MySQL DB Cluster Identifier"
+      type        = "String"
+      overwrite   = true
+    }
+  ]
+
+  context = module.this.context
+}
+

--- a/modules/aurora-mysql/variables.tf
+++ b/modules/aurora-mysql/variables.tf
@@ -1,0 +1,166 @@
+variable "region" {
+  type        = string
+  description = "AWS Region"
+}
+
+variable "ssm_path_prefix" {
+  type        = string
+  default     = "rds"
+  description = "SSM path prefix"
+}
+
+variable "ssm_password_source" {
+  type        = string
+  default     = ""
+  description = "If set, DB Admin user password will be retrieved from SSM using the key `format(var.ssm_password_source, local.db_username)`"
+}
+
+variable "allowed_cidr_blocks" {
+  type        = list(string)
+  default     = []
+  description = "List of CIDR blocks to be allowed to connect to the RDS cluster"
+}
+
+variable "mysql_name" {
+  type        = string
+  description = "MySQL solution name (part of cluster identifier)"
+  default     = ""
+}
+
+variable "mysql_db_name" {
+  type        = string
+  description = "Database name (default is not to create a database"
+  default     = ""
+}
+
+variable "mysql_admin_user" {
+  type        = string
+  description = "MySQL admin user name"
+  default     = ""
+}
+
+variable "mysql_admin_password" {
+  type        = string
+  description = "MySQL password for the admin user"
+  default     = ""
+}
+
+# https://aws.amazon.com/rds/RDS/pricing
+variable "mysql_instance_type" {
+  type        = string
+  default     = "db.t3.medium"
+  description = "EC2 instance type for RDS MySQL cluster"
+}
+
+variable "aurora_mysql_engine" {
+  type        = string
+  description = "Engine for Aurora database: `aurora` for MySQL 5.6, `aurora-mysql` for MySQL 5.7"
+}
+
+variable "aurora_mysql_engine_version" {
+  type        = string
+  description = "Engine Version for Aurora database."
+  default     = ""
+}
+
+variable "aurora_mysql_cluster_family" {
+  type        = string
+  description = "DBParameterGroupFamily (e.g. `aurora5.6`, `aurora-mysql5.7` for Aurora MySQL databases). See https://stackoverflow.com/a/55819394 for help finding the right one to use."
+}
+
+variable "aurora_mysql_cluster_parameters" {
+  type = list(object({
+    apply_method = string
+    name         = string
+    value        = string
+  }))
+  default     = []
+  description = "List of DB cluster parameters to apply"
+}
+
+variable "aurora_mysql_instance_parameters" {
+  type = list(object({
+    apply_method = string
+    name         = string
+    value        = string
+  }))
+  default     = []
+  description = "List of DB instance parameters to apply"
+}
+
+variable "mysql_cluster_size" {
+  type        = string
+  default     = 2
+  description = "MySQL cluster size"
+}
+
+variable "mysql_cluster_enabled" {
+  type        = string
+  default     = true
+  description = "Set to `false` to prevent the module from creating any resources"
+}
+
+variable "mysql_storage_encrypted" {
+  type        = string
+  default     = true
+  description = "Set to `true` to keep the database contents encrypted"
+}
+
+variable "mysql_deletion_protection" {
+  type        = string
+  default     = true
+  description = "Set to `true` to protect the database from deletion"
+}
+
+variable "mysql_skip_final_snapshot" {
+  type        = string
+  default     = false
+  description = "Determines whether a final DB snapshot is created before the DB cluster is deleted"
+}
+
+variable "mysql_enabled_cloudwatch_logs_exports" {
+  type        = list(string)
+  description = "List of log types to export to cloudwatch. The following log types are supported: audit, error, general, slowquery"
+  default     = ["audit", "error", "general", "slowquery"]
+}
+
+variable "performance_insights_enabled" {
+  type        = bool
+  description = "Set `true` to enable Performance Insights"
+  default     = false
+}
+
+variable "mysql_backup_retention_period" {
+  type        = number
+  default     = 3
+  description = "Number of days for which to retain backups"
+}
+
+variable "mysql_backup_window" {
+  type        = string
+  default     = "07:00-09:00"
+  description = "Daily time range during which the backups happen"
+}
+
+variable "mysql_maintenance_window" {
+  type        = string
+  default     = "sat:10:00-sat:10:30"
+  description = "Weekly time range during which system maintenance can occur, in UTC"
+}
+
+variable "auto_minor_version_upgrade" {
+  type        = bool
+  default     = false
+  description = "Automatically update the cluster when a new minor version is released"
+}
+
+variable "publicly_accessible" {
+  type    = bool
+  default = false
+}
+
+variable "eks_component_name" {
+  type        = string
+  description = "The name of the eks component"
+  default     = "eks/eks"
+}

--- a/modules/aurora-mysql/versions.tf
+++ b/modules/aurora-mysql/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.0.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+    mysql = {
+      source  = "terraform-providers/mysql"
+      version = ">= 1.9"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 2.2"
+    }
+  }
+}


### PR DESCRIPTION
## what
- Added both `aurora-mysql` and `aurora-mysql-resources`

## why
- These components are not yet upstream
- Created these components from the outdated single component, `aurora-mysql`

## references
- [Slack context](https://cloudposse.slack.com/archives/CA4TC65HS/p1660338132983349)