### PR TITLE
github-runners: Use a softlink instead of cp in gh runner asg

### DIFF
--- a/modules/github-runners/templates/user-data.sh
+++ b/modules/github-runners/templates/user-data.sh
@@ -33,7 +33,7 @@ unzip awscliv2.zip
 # Installs to /usr/local/bin/aws
 sudo ./aws/install
 # The github runner still sees /bin/aws as the default so we overwrite the existing binary
-sudo cp /usr/local/bin/aws /bin/aws
+sudo ln -s /usr/local/bin/aws /bin/aws
 # Clean up
 rm -rf ./aws
 


### PR DESCRIPTION
## what
* Use a softlink instead of cp in gh runner asg

## why
* Avoid a shared library issue in awscli v2
* Client issue

## references
N/A
