### PR TITLE
bugfixes from `datadog-agent` upstream

### DIFF
--- a/modules/datadog-agent/main.tf
+++ b/modules/datadog-agent/main.tf
@@ -15,7 +15,7 @@ locals {
 
   # combine context tags with passed in datadog_tags
   # skip name since that won't be relevant for each metric
-  datadog_tags = distinct(concat([for k, v in module.this.tags : "${lower(k)}:${v}" if lower(k) != "name"], var.datadog_tags))
+  datadog_tags = toset(distinct(concat([for k, v in module.this.tags : "${lower(k)}:${v}" if lower(k) != "name"], tolist(var.datadog_tags))))
 
   cluster_checks_enabled = local.enabled && var.cluster_checks_enabled
 

--- a/modules/datadog-agent/outputs.tf
+++ b/modules/datadog-agent/outputs.tf
@@ -1,5 +1,5 @@
 output "metadata" {
-  value       = local.enabled ? module.datadog_agent.metadata : ""
+  value       = local.enabled ? module.datadog_agent.metadata : null
   description = "Block status of the deployed release"
 }
 


### PR DESCRIPTION
## what
* output cannot be `""` as it mismatches other type if enabled
* tags must be a set, but function call requires a list

## why
* Bugfixes

## references
* #482 

