### PR TITLE
`datadog-monitor` version updates and monitors use maps for tags

### DIFF
--- a/modules/datadog-monitor/README.md
+++ b/modules/datadog-monitor/README.md
@@ -54,7 +54,7 @@ components:
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_datadog_monitors"></a> [datadog\_monitors](#module\_datadog\_monitors) | cloudposse/platform/datadog//modules/monitors | 0.32.2 |
+| <a name="module_datadog_monitors"></a> [datadog\_monitors](#module\_datadog\_monitors) | cloudposse/platform/datadog//modules/monitors | 1.0.0 |
 | <a name="module_datadog_monitors_merge"></a> [datadog\_monitors\_merge](#module\_datadog\_monitors\_merge) | cloudposse/config/yaml//modules/deepmerge | 1.0.1 |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
 | <a name="module_local_datadog_monitors_yaml_config"></a> [local\_datadog\_monitors\_yaml\_config](#module\_local\_datadog\_monitors\_yaml\_config) | cloudposse/config/yaml | 1.0.1 |

--- a/modules/datadog-monitor/catalog/monitors/aurora.yaml
+++ b/modules/datadog-monitor/catalog/monitors/aurora.yaml
@@ -14,7 +14,8 @@ aurora-replica-lag:
     ({dbinstanceidentifier}) Replica lag has been greater than 1s for more than 15 minutes
     {{/is_alert}}
   escalation_message: ""
-  tags: [ "managed-by:Terraform" ]
+  tags:
+    managed-by: Terraform
   notify_no_data: false
   notify_audit: true
   require_full_window: false

--- a/modules/datadog-monitor/catalog/monitors/ec2.yaml
+++ b/modules/datadog-monitor/catalog/monitors/ec2.yaml
@@ -9,7 +9,8 @@ ec2-failed-status-check:
   message: |
     ({stage} {region}) {instance_id} failed a status check
   escalation_message: ""
-  tags: [ "managed-by:Terraform" ]
+  tags:
+    managed-by: Terraform
   notify_no_data: false
   notify_audit: true
   require_full_window: true

--- a/modules/datadog-monitor/catalog/monitors/efs.yaml
+++ b/modules/datadog-monitor/catalog/monitors/efs.yaml
@@ -9,7 +9,8 @@ efs-throughput-utilization-check:
   message: |
     ({stage} {region}) {filesystemid} Throughput Utilization is too high
   escalation_message: ""
-  tags: [ "managed-by:Terraform" ]
+  tags:
+    managed-by: Terraform
   notify_no_data: false
   notify_audit: true
   require_full_window: false
@@ -42,7 +43,8 @@ efs-burst-balance:
   message: |
     ({stage} {region}) {filesystemid} EFS Burst Balance for {filesystemid} dipped below 100 GB.
   escalation_message: ""
-  tags: [ "managed-by:Terraform" ]
+  tags:
+    managed-by: Terraform
   notify_no_data: false
   notify_audit: true
   require_full_window: false
@@ -73,7 +75,8 @@ efs-io-percent-limit:
   message: |
     ({stage} {region}) {filesystemid} EFS I/O limit has been reached for fs {filesystemid}.
   escalation_message: ""
-  tags: [ "managed-by:Terraform" ]
+  tags:
+    managed-by: Terraform
   notify_no_data: false
   notify_audit: true
   require_full_window: false
@@ -103,7 +106,8 @@ efs-client-connection-anomaly:
   message: |
     ({stage} {region}) [{name}] EFS Client Connection Anomoly for filesystem {filesystemid}.
   escalation_message: ""
-  tags: [ "managed-by:Terraform" ]
+  tags:
+    managed-by: Terraform
   notify_no_data: false
   notify_audit: true
   require_full_window: false

--- a/modules/datadog-monitor/catalog/monitors/elb.yaml
+++ b/modules/datadog-monitor/catalog/monitors/elb.yaml
@@ -13,7 +13,8 @@ elb-lb-httpcode-5xx-notify:
     {{/is_alert}}
     Check LB
   escalation_message: ""
-  tags: [ "managed-by:Terraform" ]
+  tags:
+    managed-by: Terraform
   notify_no_data: false
   notify_audit: true
   require_full_window: true

--- a/modules/datadog-monitor/catalog/monitors/host.yaml
+++ b/modules/datadog-monitor/catalog/monitors/host.yaml
@@ -8,7 +8,8 @@ host-io-wait-times:
   message: |-
     The I/O wait time for ({{host.name}} {{host.ip}}) is very high
   escalation_message: ""
-  tags: [ "managed-by:Terraform" ]
+  tags:
+    managed-by: Terraform
   notify_no_data: false
   notify_audit: true
   require_full_window: true
@@ -33,7 +34,8 @@ host-disk-use:
   message: |-
     Disk Usage has been above threshold over 30 minutes on ({{host.name}} {{host.ip}})
   escalation_message: ""
-  tags: [ "managed-by:Terraform" ]
+  tags:
+    managed-by: Terraform
   notify_no_data: false
   notify_audit: true
   require_full_window: true
@@ -62,7 +64,8 @@ host-high-mem-use:
   message: |-
     Running out of free memory on ({{host.name}} {{host.ip}})
   escalation_message: ""
-  tags: [ "managed-by:Terraform" ]
+  tags:
+    managed-by: Terraform
   notify_no_data: false
   notify_audit: true
   require_full_window: true
@@ -91,7 +94,8 @@ host-high-load-avg:
   message: |-
     Load average is high on ({{host.name}} {{host.ip}})
   escalation_message: ""
-  tags: [ "managed-by:Terraform" ]
+  tags:
+    managed-by: Terraform
   notify_no_data: false
   notify_audit: true
   require_full_window: true

--- a/modules/datadog-monitor/catalog/monitors/k8s.yaml
+++ b/modules/datadog-monitor/catalog/monitors/k8s.yaml
@@ -9,7 +9,8 @@ k8s-deployment-replica-pod-down:
   message: |
     ({{cluster_name.name}}) More than one Deployments Replica's pods are down on {{deployment.name}}
   escalation_message: ""
-  tags: [ "managed-by:Terraform" ]
+  tags:
+    managed-by: Terraform
   notify_no_data: false
   notify_audit: true
   require_full_window: true
@@ -34,7 +35,8 @@ k8s-pod-restarting:
   message: |
     ({{cluster_name.name}}) pod {{pod_name.name}} is restarting multiple times on {{kube_namespace.name}}
   escalation_message: ""
-  tags: [ "managed-by:Terraform" ]
+  tags:
+    managed-by: Terraform
   notify_no_data: false
   notify_audit: true
   require_full_window: true
@@ -60,7 +62,8 @@ k8s-statefulset-replica-down:
   message: |
     ({{cluster_name.name}} {{statefulset.name}}) More than one StatefulSet Replica's pods are down on {{kube_namespace.name}}
   escalation_message: ""
-  tags: [ "managed-by:Terraform" ]
+  tags:
+    managed-by: Terraform
   notify_no_data: false
   notify_audit: true
   require_full_window: false
@@ -87,7 +90,8 @@ k8s-daemonset-pod-down:
   message: |
     ({{cluster_name.name}} {{daemonset.name}}) One or more DaemonSet pods are down on {{kube_namespace.name}}
   escalation_message: ""
-  tags: [ "managed-by:Terraform" ]
+  tags:
+    managed-by: Terraform
   notify_no_data: false
   notify_audit: true
   require_full_window: false
@@ -112,7 +116,8 @@ k8s-crashloopBackOff:
   message: |
     ({{cluster_name.name}}) pod {{pod_name.name}} is CrashloopBackOff on {{kube_namespace.name}}
   escalation_message: ""
-  tags: [ "managed-by:Terraform" ]
+  tags:
+    managed-by: Terraform
   notify_no_data: false
   notify_audit: true
   require_full_window: false
@@ -137,7 +142,8 @@ k8s-multiple-pods-failing:
   message: |
     ({{cluster_name.name}}) More than ten pods are failing on {{kube_namespace.name}}
   escalation_message: ""
-  tags: [ "managed-by:Terraform" ]
+  tags:
+    managed-by: Terraform
   notify_no_data: false
   notify_audit: true
   require_full_window: true
@@ -163,7 +169,8 @@ k8s-unavailable-deployment-replica:
   message: |
     ({{cluster_name.name}}) Detected unavailable Deployment replicas for longer than 10 minutes on {{kube_namespace.name}}
   escalation_message: ""
-  tags: [ "managed-by:Terraform" ]
+  tags:
+    managed-by: Terraform
   notify_no_data: false
   notify_audit: true
   require_full_window: false
@@ -193,7 +200,8 @@ k8s-unavailable-statefulset-replica:
   message: |
     ({{cluster_name.name}}) Detected unavailable Statefulset replicas for longer than 10 minutes on {{kube_namespace.name}}
   escalation_message: ""
-  tags: [ "managed-by:Terraform" ]
+  tags:
+    managed-by: Terraform
   notify_no_data: false
   notify_audit: true
   require_full_window: false
@@ -223,7 +231,8 @@ k8s-node-status-unschedulable:
   message: |
     More than 20% of nodes are unschedulable on ({{cluster_name}} cluster). \n Keep in mind that this might be expected based on your infrastructure.
   escalation_message: ""
-  tags: [ "managed-by:Terraform" ]
+  tags:
+    managed-by: Terraform
   notify_no_data: false
   notify_audit: true
   require_full_window: false
@@ -253,7 +262,8 @@ k8s-imagepullbackoff:
   message: |
     Pod {{pod_name.name}} is ImagePullBackOff on namespace {{kube_namespace.name}}
   escalation_message: ""
-  tags: [ "managed-by:Terraform" ]
+  tags:
+    managed-by: Terraform
   notify_no_data: false
   notify_audit: true
   require_full_window: false
@@ -283,7 +293,8 @@ k8s-high-cpu-usage:
   message: |
     ({{host.cluster_name}}) High CPU usage for the last 10 minutes on {{host.name}}
   escalation_message: ""
-  tags: [ "managed-by:Terraform" ]
+  tags:
+    managed-by: Terraform
   notify_no_data: false
   notify_audit: true
   require_full_window: true
@@ -313,7 +324,8 @@ k8s-high-disk-usage:
   message: |
     ({{cluster_name.name}}) High disk usage detected on {{host.name}}
   escalation_message: ""
-  tags: [ "managed-by:Terraform" ]
+  tags:
+    managed-by: Terraform
   notify_no_data: false
   notify_audit: true
   require_full_window: true
@@ -348,7 +360,8 @@ k8s-high-memory-usage:
     {{cluster_name.name}} memory usage greater than 90% for 10 minutes
     {{/is_alert}}
   escalation_message: ""
-  tags: [ "managed-by:Terraform" ]
+  tags:
+    managed-by: Terraform
   notify_no_data: false
   notify_audit: true
   require_full_window: true
@@ -383,7 +396,8 @@ k8s-high-filesystem-usage:
     {{cluster_name.name}} filesystem usage greater than 90% for 10 minutes
     {{/is_alert}}
   escalation_message: ""
-  tags: [ "managed-by:Terraform" ]
+  tags:
+    managed-by: Terraform
   notify_no_data: false
   notify_audit: true
   require_full_window: true
@@ -418,7 +432,8 @@ k8s-network-tx-errors:
     {{cluster_name.name}} network TX (send) errors occurring 100 times per second
     {{/is_alert}}
   escalation_message: ""
-  tags: [ "managed-by:Terraform" ]
+  tags:
+    managed-by: Terraform
   notify_no_data: false
   notify_audit: true
   require_full_window: true
@@ -453,7 +468,8 @@ k8s-network-rx-errors:
     {{cluster_name.name}} network RX (receive) errors occurring 100 times per second
     {{/is_alert}}
   escalation_message: ""
-  tags: [ "managed-by:Terraform" ]
+  tags:
+    managed-by: Terraform
   notify_no_data: false
   notify_audit: true
   require_full_window: true
@@ -483,7 +499,8 @@ k8s-increased-pod-crash:
   message: |-
     ({{cluster_name.name}} {{kube_namespace.name}} {{pod.name}}) has crashed repeatedly over the last hour
   escalation_message: ""
-  tags: [ "managed-by:Terraform" ]
+  tags:
+    managed-by: Terraform
   notify_no_data: false
   notify_audit: false
   require_full_window: false
@@ -514,7 +531,8 @@ k8s-pending-pods:
     ({{cluster_name.name}}) There has been at least 1 pod Pending for 30 minutes.
     There are currently ({{value}}) pods Pending.
   escalation_message: ""
-  tags: [ "managed-by:Terraform" ]
+  tags:
+    managed-by: Terraform
   notify_no_data: false
   notify_audit: false
   require_full_window: true

--- a/modules/datadog-monitor/catalog/monitors/rabbitmq.yaml
+++ b/modules/datadog-monitor/catalog/monitors/rabbitmq.yaml
@@ -10,8 +10,8 @@ rabbitmq-messages-unacknowledged-rate-too-high:
     RabbitMQ Queue: {{queue.name}}
   escalation_message: ""
   tags:
-    - "managed-by:Terraform"
-    - "integration:rabbitmq"
+    managed-by: Terraform
+    integration: rabbitmq
   notify_no_data: false
   notify_audit: true
   require_full_window: true
@@ -44,8 +44,8 @@ rabbitmq-memory-utilization:
     Node: {{node.name}}
   escalation_message: ""
   tags:
-    - "managed-by:Terraform"
-    - "integration:rabbitmq"
+    managed-by: Terraform
+    integration: rabbitmq
   notify_no_data: false
   notify_audit: true
   require_full_window: true
@@ -77,8 +77,8 @@ rabbitmq-disk-utilization:
     Node: {{node.name}}
   escalation_message: ""
   tags:
-    - "managed-by:Terraform"
-    - "integration:rabbitmq"
+    managed-by: Terraform
+    integration: rabbitmq
   notify_no_data: false
   notify_audit: true
   require_full_window: true

--- a/modules/datadog-monitor/catalog/monitors/rds.yaml
+++ b/modules/datadog-monitor/catalog/monitors/rds.yaml
@@ -14,7 +14,8 @@ rds-cpuutilization:
     ({dbinstanceidentifier}) CPU Utilization above 90%
     {{/is_alert}}
   escalation_message: ""
-  tags: [ "managed-by:Terraform" ]
+  tags:
+    managed-by: Terraform
   notify_no_data: false
   notify_audit: true
   require_full_window: true
@@ -49,7 +50,8 @@ rds-disk-queue-depth:
     ({dbinstanceidentifier}) Disk queue depth above 64
     {{/is_alert}}
   escalation_message: ""
-  tags: [ "managed-by:Terraform" ]
+  tags:
+    managed-by: Terraform
   notify_no_data: false
   notify_audit: true
   require_full_window: true
@@ -84,7 +86,8 @@ rds-freeable-memory:
     ({dbinstanceidentifier}) Freeable memory below 256 MB
     {{/is_alert}}
   escalation_message: ""
-  tags: [ "managed-by:Terraform" ]
+  tags:
+    managed-by: Terraform
   notify_no_data: false
   notify_audit: true
   require_full_window: true
@@ -119,7 +122,8 @@ rds-swap-usage:
     ({dbinstanceidentifier}) Swap usage above 256 MB
     {{/is_alert}}
   escalation_message: ""
-  tags: [ "managed-by:Terraform" ]
+  tags:
+    managed-by: Terraform
   notify_no_data: false
   notify_audit: true
   require_full_window: true
@@ -154,7 +158,8 @@ rds-database-connections:
     ({dbinstanceidentifier}) Anomaly of a large variance in RDS connection count
     {{/is_alert}}
   escalation_message: ""
-  tags: [ "managed-by:Terraform" ]
+  tags:
+    managed-by: Terraform
   notify_no_data: false
   notify_audit: true
   require_full_window: true

--- a/modules/datadog-monitor/main.tf
+++ b/modules/datadog-monitor/main.tf
@@ -105,7 +105,7 @@ module "datadog_monitors" {
   count = local.datadog_monitors_enabled ? 1 : 0
 
   source  = "cloudposse/platform/datadog//modules/monitors"
-  version = "0.32.2"
+  version = "1.0.0"
 
   datadog_monitors = local.datadog_monitors
 


### PR DESCRIPTION
## what
* Datadog Platform Monitors expect a map for tags, it then converts it to an array in DD Format. This PR updates the default catalog to use maps not arrays
* Updating platform version

## why
* Upstream
