### PR TITLE
`datadog-monitors` allow specific monitors to be disabled during merge

### DIFF
--- a/modules/datadog-monitor/main.tf
+++ b/modules/datadog-monitor/main.tf
@@ -44,7 +44,7 @@ locals {
   datadog_monitors = {
     for k, v in module.datadog_monitors_merge :
     k => merge(v.merged, {
-      message = format("%s%s%s", var.message_prefix, v.merged.message, var.message_postfix)
+      message = format("%s%s%s", var.message_prefix, lookup(v.merged, "message", ""), var.message_postfix)
     })
   }
 
@@ -89,8 +89,8 @@ module "datadog_monitors_merge" {
 
   # for_each = { for k, v in local.datadog_monitors_yaml_config_map_configs : k => v if local.datadog_monitors_enabled }
   for_each = { for k, v in merge(
-    (local.local_datadog_monitors_enabled) ? module.local_datadog_monitors_yaml_config.map_configs : {},
-    (local.remote_datadog_monitors_enabled) ? module.remote_datadog_monitors_yaml_config.map_configs : {}
+    module.local_datadog_monitors_yaml_config.map_configs,
+    module.remote_datadog_monitors_yaml_config.map_configs
   ) : k => v if local.datadog_monitors_enabled }
 
   # Merge in order: datadog monitor, datadog monitor globals, context tags


### PR DESCRIPTION
## what
* Allows `enabled: false` on monitors to succeed in merge

## why
* bugfix introduced from upstream a while ago

error:
```
│ Error: Inconsistent conditional result types
│ 
│   on main.tf line 92, in module "datadog_monitors_merge":
│   92:     (local.local_datadog_monitors_enabled) ? module.local_datadog_monitors_yaml_config.map_configs : {},
│     ├────────────────
│     │ local.local_datadog_monitors_enabled is true
│     │ module.local_datadog_monitors_yaml_config.map_configs is object with 38 attributes
│ 
│ The true and false result expressions must have consistent types. The 'true' value includes object attribute "aurora-replica-lag", which is absent in the 'false' value.
╵
```
