### PR TITLE
s3-bucket: allow usage without providing a value for `tenant`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,18 +4,20 @@ repos:
     hooks:
       - id: check-yaml
         exclude: |
-            (?x)^(
-                modules/cert-manager/cert-manager-issuer/templates/.*.yaml |
-                modules/eks/actions-runner-controller/charts/actions-runner/templates/.*.yaml |
-                modules/echo-server/charts/eks/echo-server/templates/.*.yaml |
-                deprecated/github-actions-runner/runners/actions-runner/chart/templates/.*.yaml
-            )$
+          (?x)^(
+              deprecated/github-actions-runner/runners/actions-runner/chart/templates/.*.yaml |
+              modules/cert-manager/cert-manager-issuer/templates/.*.yaml |
+              modules/eks/actions-runner-controller/charts/actions-runner/templates/.*.yaml |
+              modules/eks/echo-server/charts/echo-server/templates/.*.yaml |
+              modules/idp-roles/charts/idp-roles/templates/.*.yaml |
+              modules/strongdm/charts/strongdm/templates/.*.yaml
+          )$
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.71.0
+    rev: v1.75.0
     hooks:
       - id: terraform_fmt
       - id: terraform_docs
-        args: ['--args=--lockfile=false']
+        args: ["--args=--lockfile=false"]
   - repo: local
     hooks:
       - id: rebuild-mixins-docs

--- a/modules/s3-bucket/remote-state.tf
+++ b/modules/s3-bucket/remote-state.tf
@@ -5,7 +5,7 @@ module "account_map" {
   component   = "account-map"
   environment = var.account_map_environment_name
   stage       = var.account_map_stage_name
-  tenant      = coalesce(var.account_map_tenant_name, module.this.tenant)
+  tenant      = try(coalesce(var.account_map_tenant_name, module.this.tenant), "")
 
   context = module.this.context
 }

--- a/modules/s3-bucket/remote-state.tf
+++ b/modules/s3-bucket/remote-state.tf
@@ -5,7 +5,7 @@ module "account_map" {
   component   = "account-map"
   environment = var.account_map_environment_name
   stage       = var.account_map_stage_name
-  tenant      = try(coalesce(var.account_map_tenant_name, module.this.tenant), "")
+  tenant      = var.account_map_tenant_name
 
   context = module.this.context
 }


### PR DESCRIPTION
## what
* Currently the s3-bucket module requires a value for `tenant`, either set via context or `account_map_tenant_name`. This change relaxes this requirement.

## why
* Some consumers of this module don't use tenant in resource naming

## references
* None
