### PR TITLE
VPC, DNS, CloudTrail, testing

### DIFF
--- a/.github/workflows/bats.yml
+++ b/.github/workflows/bats.yml
@@ -1,0 +1,54 @@
+name: bats
+
+on:
+  pull_request_target:
+    types: [labeled, opened, synchronize, unlabeled]
+
+jobs:
+  bats:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.state == 'open'
+    container: cloudposse/test-harness:latest
+    env:
+      MAKE_INCLUDES: Makefile
+      TF_PLUGIN_CACHE_DIR: /tmp
+      BATS_TESTS: input-descriptions lint output-descriptions module-pinning provider-pinning
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
+        # Check out the PR commit, not the merge commit
+        # Use `ref` instead of `sha` to enable pushing back to `ref`
+        ref: ${{ github.event.pull_request.head.ref }}
+
+    - name: Run tests on modified modules
+      id: get-modified-files
+      shell: bash -x -e -o pipefail {0}
+      env:
+        BASE_REF: ${{ github.base_ref }}
+        HEAD_REF: ${{ github.head_ref }}
+      run: |
+        MODIFIED_MODULES=($(git diff --name-only origin/${BASE_REF} origin/${HEAD_REF} |
+          xargs -n 1 dirname | sort | uniq | grep ^modules/)))
+        if [ -z "$MODIFIED_MODULES" ]; then
+            echo "No modules changed in this PR. Skipping tests."
+            exit 0
+        else
+            echo "Running checks on the following modules:"
+            printf -- "- %s\n" "${MODIFIED_MODULES[@]#modules/}"
+        fi
+        pass=true
+        for dir in "${MODIFIED_MODULES[@]}"; do 
+          (
+            status=pass
+            cd $dir
+            printf "\n\nTesting in $dir\n"
+            for test in $BATS_TESTS; do 
+              bats -t /test/terraform/${test}.bats || status=fail
+            done
+            [[ status == "pass" ]]
+          ) || pass=false
+        done
+        [[ pass == "true" ]]

--- a/modules/cloudtrail-bucket/README.md
+++ b/modules/cloudtrail-bucket/README.md
@@ -28,7 +28,7 @@ components:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9.0 |
 
 ## Providers
 

--- a/modules/cloudtrail-bucket/default.auto.tfvars
+++ b/modules/cloudtrail-bucket/default.auto.tfvars
@@ -1,3 +1,0 @@
-# This file is included by default in terraform plans
-
-enabled = false

--- a/modules/cloudtrail-bucket/versions.tf
+++ b/modules/cloudtrail-bucket/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = ">= 4.9.0"
     }
   }
 }

--- a/modules/cloudtrail/README.md
+++ b/modules/cloudtrail/README.md
@@ -33,20 +33,20 @@ components:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.9.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_cloudtrail"></a> [cloudtrail](#module\_cloudtrail) | cloudposse/cloudtrail/aws | 0.21.0 |
-| <a name="module_cloudtrail_bucket"></a> [cloudtrail\_bucket](#module\_cloudtrail\_bucket) | cloudposse/stack-config/yaml//modules/remote-state | 0.22.1 |
+| <a name="module_cloudtrail_bucket"></a> [cloudtrail\_bucket](#module\_cloudtrail\_bucket) | cloudposse/stack-config/yaml//modules/remote-state | 1.1.0 |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
 | <a name="module_kms_key_cloudtrail"></a> [kms\_key\_cloudtrail](#module\_kms\_key\_cloudtrail) | cloudposse/kms-key/aws | 0.12.1 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |

--- a/modules/cloudtrail/default.auto.tfvars
+++ b/modules/cloudtrail/default.auto.tfvars
@@ -1,3 +1,0 @@
-# This file is included by default in terraform plans
-
-enabled = false

--- a/modules/cloudtrail/remote-state.tf
+++ b/modules/cloudtrail/remote-state.tf
@@ -1,6 +1,6 @@
 module "cloudtrail_bucket" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "0.22.1"
+  version = "1.1.0"
 
   component   = "cloudtrail-bucket"
   environment = var.cloudtrail_bucket_environment_name

--- a/modules/cloudtrail/versions.tf
+++ b/modules/cloudtrail/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = ">= 4.9.0"
     }
   }
 }

--- a/modules/dns-delegated/README.md
+++ b/modules/dns-delegated/README.md
@@ -24,6 +24,16 @@ components:
           zone_name: example.net
         request_acm_certificate: true
         dns_private_zone_enabled: false
+        #  dns_soa_config configures the SOA record for the zone::
+        #    - awsdns-hostmaster.amazon.com. ; AWS default value for administrator email address
+        #    - 1 ; serial number, not used by AWS
+        #    - 7200 ; refresh time in seconds for secondary DNS servers to refreh SOA record
+        #    - 900 ; retry time in seconds for secondary DNS servers to retry failed SOA record update
+        #    - 1209600 ; expire time in seconds (1209600 is 2 weeks) for secondary DNS servers to remove SOA record if they cannot refresh it
+        #    - 60 ; nxdomain TTL, or time in seconds for secondary DNS servers to cache negative responses
+        #    See [SOA Record Documentation](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/SOA-NSrecords.html) for more information.
+        dns_soa_config: "awsdns-hostmaster.amazon.com. 1 7200 900 1209600 60"
+
 ```
 
 Private Hosted Zone `devplatform.example.net` will be created and `example.net` HZ in the dns primary account will contain a record delegating DNS to the new HZ
@@ -80,25 +90,25 @@ NOTE: With each of these workarounds, you may have an issue connecting to the se
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.0 |
-| <a name="provider_aws.primary"></a> [aws.primary](#provider\_aws.primary) | ~> 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.9.0 |
+| <a name="provider_aws.primary"></a> [aws.primary](#provider\_aws.primary) | >= 4.9.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_acm"></a> [acm](#module\_acm) | cloudposse/acm-request-certificate/aws | 0.16.0 |
+| <a name="module_acm"></a> [acm](#module\_acm) | cloudposse/acm-request-certificate/aws | 0.17.0 |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
-| <a name="module_private_ca"></a> [private\_ca](#module\_private\_ca) | cloudposse/stack-config/yaml//modules/remote-state | 0.22.3 |
+| <a name="module_private_ca"></a> [private\_ca](#module\_private\_ca) | cloudposse/stack-config/yaml//modules/remote-state | 1.1.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
-| <a name="module_utils"></a> [utils](#module\_utils) | cloudposse/utils/aws | 1.0.0 |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | cloudposse/stack-config/yaml//modules/remote-state | 0.22.3 |
+| <a name="module_utils"></a> [utils](#module\_utils) | cloudposse/utils/aws | 1.1.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | cloudposse/stack-config/yaml//modules/remote-state | 1.1.0 |
 
 ## Resources
 
@@ -130,6 +140,7 @@ NOTE: With each of these workarounds, you may have an issue connecting to the se
 | <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between ID elements.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
 | <a name="input_descriptor_formats"></a> [descriptor\_formats](#input\_descriptor\_formats) | Describe additional descriptors to be output in the `descriptors` output map.<br>Map of maps. Keys are names of descriptors. Values are maps of the form<br>`{<br>   format = string<br>   labels = list(string)<br>}`<br>(Type is `any` so the map values can later be enhanced to provide additional options.)<br>`format` is a Terraform format string to be passed to the `format()` function.<br>`labels` is a list of labels, in order, to pass to `format()` function.<br>Label values will be normalized before being passed to `format()` so they will be<br>identical to how they appear in `id`.<br>Default is `{}` (`descriptors` output will be empty). | `any` | `{}` | no |
 | <a name="input_dns_private_zone_enabled"></a> [dns\_private\_zone\_enabled](#input\_dns\_private\_zone\_enabled) | Whether to set the zone to public or private | `bool` | `false` | no |
+| <a name="input_dns_soa_config"></a> [dns\_soa\_config](#input\_dns\_soa\_config) | Root domain name DNS SOA record:<br>- awsdns-hostmaster.amazon.com. ; AWS default value for administrator email address<br>- 1 ; serial number, not used by AWS<br>- 7200 ; refresh time in seconds for secondary DNS servers to refreh SOA record<br>- 900 ; retry time in seconds for secondary DNS servers to retry failed SOA record update<br>- 1209600 ; expire time in seconds (1209600 is 2 weeks) for secondary DNS servers to remove SOA record if they cannot refresh it<br>- 60 ; nxdomain TTL, or time in seconds for secondary DNS servers to cache negative responses<br>See [SOA Record Documentation](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/SOA-NSrecords.html) for more information. | `string` | `"awsdns-hostmaster.amazon.com. 1 7200 900 1209600 60"` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for keep the existing setting, which defaults to `0`.<br>Does not affect `id_full`. | `number` | `null` | no |

--- a/modules/dns-delegated/acm.tf
+++ b/modules/dns-delegated/acm.tf
@@ -12,10 +12,10 @@ locals {
 }
 
 module "acm" {
-  source  = "cloudposse/acm-request-certificate/aws"
-  version = "0.16.0"
-
   for_each = local.zone_map
+
+  source  = "cloudposse/acm-request-certificate/aws"
+  version = "0.17.0"
 
   enabled = local.certificate_enabled
 

--- a/modules/dns-delegated/default.auto.tfvars
+++ b/modules/dns-delegated/default.auto.tfvars
@@ -1,3 +1,0 @@
-# This file is included by default in terraform plans
-
-enabled = false

--- a/modules/dns-delegated/main.tf
+++ b/modules/dns-delegated/main.tf
@@ -55,7 +55,7 @@ resource "aws_route53_zone" "private" {
 
 module "utils" {
   source  = "cloudposse/utils/aws"
-  version = "1.0.0"
+  version = "1.1.0"
 }
 
 resource "aws_route53_zone_association" "secondary" {
@@ -89,7 +89,7 @@ resource "aws_route53_record" "soa" {
   zone_id         = local.aws_route53_zone[each.key].zone_id
 
   records = [
-    format("${local.aws_route53_zone[each.key].name_servers[0]}%s awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400", local.public_enabled ? "." : "")
+    format("${local.aws_route53_zone[each.key].name_servers[0]}%s %s", local.public_enabled ? "." : "", var.dns_soa_config)
   ]
 }
 

--- a/modules/dns-delegated/remote-state.tf
+++ b/modules/dns-delegated/remote-state.tf
@@ -1,6 +1,6 @@
 module "vpc" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "0.22.3"
+  version = "1.1.0"
 
   for_each = local.private_enabled ? local.vpc_environment_names : toset([])
 
@@ -12,7 +12,7 @@ module "vpc" {
 
 module "private_ca" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "0.22.3"
+  version = "1.1.0"
 
   count = local.private_ca_enabled && local.certificate_enabled ? 1 : 0
 

--- a/modules/dns-delegated/variables.tf
+++ b/modules/dns-delegated/variables.tf
@@ -74,3 +74,19 @@ variable "certificate_authority_component_key" {
   default     = null
   description = "Use this component key e.g. `root` or `mgmt` to read from the remote state to get the certificate_authority_arn if using an authority type of SUBORDINATE"
 }
+
+variable "dns_soa_config" {
+  type        = string
+  description = <<-EOT
+    Root domain name DNS SOA record:
+    - awsdns-hostmaster.amazon.com. ; AWS default value for administrator email address
+    - 1 ; serial number, not used by AWS
+    - 7200 ; refresh time in seconds for secondary DNS servers to refreh SOA record
+    - 900 ; retry time in seconds for secondary DNS servers to retry failed SOA record update
+    - 1209600 ; expire time in seconds (1209600 is 2 weeks) for secondary DNS servers to remove SOA record if they cannot refresh it
+    - 60 ; nxdomain TTL, or time in seconds for secondary DNS servers to cache negative responses
+    See [SOA Record Documentation](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/SOA-NSrecords.html) for more information.
+   EOT
+  default     = "awsdns-hostmaster.amazon.com. 1 7200 900 1209600 60"
+}
+

--- a/modules/dns-delegated/versions.tf
+++ b/modules/dns-delegated/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.0"
+      version = ">= 4.9.0"
     }
   }
 }

--- a/modules/dns-primary/README.md
+++ b/modules/dns-primary/README.md
@@ -39,19 +39,19 @@ components:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.9.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_acm"></a> [acm](#module\_acm) | cloudposse/acm-request-certificate/aws | 0.16.0 |
+| <a name="module_acm"></a> [acm](#module\_acm) | cloudposse/acm-request-certificate/aws | 0.17.0 |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 
@@ -74,7 +74,7 @@ components:
 | <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "descriptor_formats": {},<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "labels_as_tags": [<br>    "unset"<br>  ],<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {},<br>  "tenant": null<br>}</pre> | no |
 | <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between ID elements.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
 | <a name="input_descriptor_formats"></a> [descriptor\_formats](#input\_descriptor\_formats) | Describe additional descriptors to be output in the `descriptors` output map.<br>Map of maps. Keys are names of descriptors. Values are maps of the form<br>`{<br>   format = string<br>   labels = list(string)<br>}`<br>(Type is `any` so the map values can later be enhanced to provide additional options.)<br>`format` is a Terraform format string to be passed to the `format()` function.<br>`labels` is a list of labels, in order, to pass to `format()` function.<br>Label values will be normalized before being passed to `format()` so they will be<br>identical to how they appear in `id`.<br>Default is `{}` (`descriptors` output will be empty). | `any` | `{}` | no |
-| <a name="input_dns_soa_config"></a> [dns\_soa\_config](#input\_dns\_soa\_config) | Root domain name DNS SOA record | `string` | `"awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400"` | no |
+| <a name="input_dns_soa_config"></a> [dns\_soa\_config](#input\_dns\_soa\_config) | Root domain name DNS SOA record:<br>- awsdns-hostmaster.amazon.com. ; AWS default value for administrator email address<br>- 1 ; serial number, not used by AWS<br>- 7200 ; refresh time in seconds for secondary DNS servers to refreh SOA record<br>- 900 ; retry time in seconds for secondary DNS servers to retry failed SOA record update<br>- 1209600 ; expire time in seconds (1209600 is 2 weeks) for secondary DNS servers to remove SOA record if they cannot refresh it<br>- 60 ; nxdomain TTL, or time in seconds for secondary DNS servers to cache negative responses<br>See [SOA Record Documentation](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/SOA-NSrecords.html) for more information. | `string` | `"awsdns-hostmaster.amazon.com. 1 7200 900 1209600 60"` | no |
 | <a name="input_domain_names"></a> [domain\_names](#input\_domain\_names) | Root domain name list, e.g. `["example.net"]` | `list(string)` | `null` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |

--- a/modules/dns-primary/acm.tf
+++ b/modules/dns-primary/acm.tf
@@ -11,10 +11,10 @@ locals {
 module "acm" {
   for_each = local.domains_set
 
-  enabled = local.certificate_enabled
   source  = "cloudposse/acm-request-certificate/aws"
-  version = "0.16.0"
+  version = "0.17.0"
 
+  enabled = local.certificate_enabled
 
   domain_name                       = each.value
   process_domain_validation_options = true

--- a/modules/dns-primary/default.auto.tfvars
+++ b/modules/dns-primary/default.auto.tfvars
@@ -1,3 +1,0 @@
-# This file is included by default in terraform plans
-
-enabled = false

--- a/modules/dns-primary/variables.tf
+++ b/modules/dns-primary/variables.tf
@@ -38,6 +38,15 @@ variable "alias_record_config" {
 
 variable "dns_soa_config" {
   type        = string
-  default     = "awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400"
-  description = "Root domain name DNS SOA record"
+  description = <<-EOT
+    Root domain name DNS SOA record:
+    - awsdns-hostmaster.amazon.com. ; AWS default value for administrator email address
+    - 1 ; serial number, not used by AWS
+    - 7200 ; refresh time in seconds for secondary DNS servers to refreh SOA record
+    - 900 ; retry time in seconds for secondary DNS servers to retry failed SOA record update
+    - 1209600 ; expire time in seconds (1209600 is 2 weeks) for secondary DNS servers to remove SOA record if they cannot refresh it
+    - 60 ; nxdomain TTL, or time in seconds for secondary DNS servers to cache negative responses
+    See [SOA Record Documentation](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/SOA-NSrecords.html) for more information.
+   EOT
+  default     = "awsdns-hostmaster.amazon.com. 1 7200 900 1209600 60"
 }

--- a/modules/dns-primary/versions.tf
+++ b/modules/dns-primary/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = ">= 4.9.0"
     }
   }
 }

--- a/modules/vpc/README.md
+++ b/modules/vpc/README.md
@@ -28,37 +28,34 @@ components:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.9.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_ec2_vpc_endpoint_sg_label"></a> [ec2\_vpc\_endpoint\_sg\_label](#module\_ec2\_vpc\_endpoint\_sg\_label) | cloudposse/label/null | 0.25.0 |
-| <a name="module_eks"></a> [eks](#module\_eks) | cloudposse/stack-config/yaml//modules/remote-state | 0.22.3 |
+| <a name="module_endpoint_security_groups"></a> [endpoint\_security\_groups](#module\_endpoint\_security\_groups) | cloudposse/security-group/aws | 2.0.0-rc1 |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
-| <a name="module_subnets"></a> [subnets](#module\_subnets) | cloudposse/dynamic-subnets/aws | 2.0.2 |
+| <a name="module_subnets"></a> [subnets](#module\_subnets) | cloudposse/dynamic-subnets/aws | 2.0.4 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | cloudposse/vpc/aws | 1.1.0 |
-| <a name="module_vpc_endpoints"></a> [vpc\_endpoints](#module\_vpc\_endpoints) | cloudposse/vpc/aws//modules/vpc-endpoints | 1.1.0 |
-| <a name="module_vpc_flow_logs_bucket"></a> [vpc\_flow\_logs\_bucket](#module\_vpc\_flow\_logs\_bucket) | cloudposse/stack-config/yaml//modules/remote-state | 0.22.3 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | cloudposse/vpc/aws | 2.0.0-rc1 |
+| <a name="module_vpc_endpoints"></a> [vpc\_endpoints](#module\_vpc\_endpoints) | cloudposse/vpc/aws//modules/vpc-endpoints | 2.0.0-rc1 |
+| <a name="module_vpc_flow_logs_bucket"></a> [vpc\_flow\_logs\_bucket](#module\_vpc\_flow\_logs\_bucket) | cloudposse/stack-config/yaml//modules/remote-state | 1.0.0 |
 
 ## Resources
 
 | Name | Type |
 |------|------|
 | [aws_flow_log.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/flow_log) | resource |
-| [aws_security_group.ec2_vpc_endpoint_sg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_shield_protection.nat_eip_shield_protection](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/shield_protection) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_eip.eip](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eip) | data source |
-| [aws_vpc_ipam_pool.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc_ipam_pool) | data source |
 
 ## Inputs
 
@@ -66,20 +63,21 @@ components:
 |------|-------------|------|---------|:--------:|
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br>This is for some rare cases where resources want additional configuration of tags<br>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
 | <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br>in the order they appear in the list. New attributes are appended to the<br>end of the list. The elements of the list are joined by the `delimiter`<br>and treated as a single ID element. | `list(string)` | `[]` | no |
-| <a name="input_availability_zones"></a> [availability\_zones](#input\_availability\_zones) | List of availability zones in which to provision VPC subnets | `list(string)` | `[]` | no |
+| <a name="input_availability_zone_ids"></a> [availability\_zone\_ids](#input\_availability\_zone\_ids) | List of Availability Zones IDs where subnets will be created. Overrides `availability_zones`.<br>Useful in some regions when using only some AZs and you want to use the same ones across multiple accounts. | `list(string)` | `[]` | no |
+| <a name="input_availability_zones"></a> [availability\_zones](#input\_availability\_zones) | List of Availability Zones (AZs) where subnets will be created. Ignored when `availability_zone_ids` is set.<br>The order of zones in the list ***must be stable*** or else Terraform will continually make changes.<br>If no AZs are specified, then `max_subnet_count` AZs will be selected in alphabetical order.<br>If `max_subnet_count > 0` and `length(var.availability_zones) > max_subnet_count`, the list<br>will be truncated. We recommend setting `availability_zones` and `max_subnet_count` explicitly as constant<br>(not computed) values for predictability, consistency, and stability. | `list(string)` | `[]` | no |
 | <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "descriptor_formats": {},<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "labels_as_tags": [<br>    "unset"<br>  ],<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {},<br>  "tenant": null<br>}</pre> | no |
 | <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between ID elements.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
 | <a name="input_descriptor_formats"></a> [descriptor\_formats](#input\_descriptor\_formats) | Describe additional descriptors to be output in the `descriptors` output map.<br>Map of maps. Keys are names of descriptors. Values are maps of the form<br>`{<br>   format = string<br>   labels = list(string)<br>}`<br>(Type is `any` so the map values can later be enhanced to provide additional options.)<br>`format` is a Terraform format string to be passed to the `format()` function.<br>`labels` is a list of labels, in order, to pass to `format()` function.<br>Label values will be normalized before being passed to `format()` so they will be<br>identical to how they appear in `id`.<br>Default is `{}` (`descriptors` output will be empty). | `any` | `{}` | no |
-| <a name="input_ec2_vpc_endpoint_enabled"></a> [ec2\_vpc\_endpoint\_enabled](#input\_ec2\_vpc\_endpoint\_enabled) | Enable or disable an EC2 interface VPC Endpoint in this VPC. | `bool` | `false` | no |
-| <a name="input_eks_component_names"></a> [eks\_component\_names](#input\_eks\_component\_names) | The names of the eks components | `set(string)` | <pre>[<br>  "eks/cluster"<br>]</pre> | no |
 | <a name="input_eks_tags_enabled"></a> [eks\_tags\_enabled](#input\_eks\_tags\_enabled) | Whether or not to apply EKS-releated tags to resources | `bool` | `false` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
+| <a name="input_gateway_vpc_endpoints"></a> [gateway\_vpc\_endpoints](#input\_gateway\_vpc\_endpoints) | A list of Gateway VPC Endpoints to provision into the VPC. Only valid values are "dynamodb" and "s3". | `set(string)` | `[]` | no |
 | <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for keep the existing setting, which defaults to `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
 | <a name="input_import_profile_name"></a> [import\_profile\_name](#input\_import\_profile\_name) | AWS Profile name to use when importing a resource | `string` | `null` | no |
 | <a name="input_import_role_arn"></a> [import\_role\_arn](#input\_import\_role\_arn) | IAM Role ARN to use when importing a resource | `string` | `null` | no |
+| <a name="input_interface_vpc_endpoints"></a> [interface\_vpc\_endpoints](#input\_interface\_vpc\_endpoints) | A list of Interface VPC Endpoints to provision into the VPC. | `set(string)` | `[]` | no |
+| <a name="input_ipv4_cidrs"></a> [ipv4\_cidrs](#input\_ipv4\_cidrs) | Lists of CIDRs to assign to subnets. Order of CIDRs in the lists must not change over time.<br>Lists may contain more CIDRs than needed. | <pre>list(object({<br>    private = list(string)<br>    public  = list(string)<br>  }))</pre> | `[]` | no |
 | <a name="input_ipv4_primary_cidr_block"></a> [ipv4\_primary\_cidr\_block](#input\_ipv4\_primary\_cidr\_block) | The primary IPv4 CIDR block for the VPC.<br>Either `ipv4_primary_cidr_block` or `ipv4_primary_cidr_block_association` must be set, but not both. | `string` | `null` | no |
-| <a name="input_ipv4_primary_cidr_block_association"></a> [ipv4\_primary\_cidr\_block\_association](#input\_ipv4\_primary\_cidr\_block\_association) | Configuration of the VPC's primary IPv4 CIDR block via IPAM. Conflicts with `ipv4_primary_cidr_block`.<br>One of `ipv4_primary_cidr_block` or `ipv4_primary_cidr_block_association` must be set.<br>Additional CIDR blocks can be set via `ipv4_additional_cidr_block_associations`. | <pre>object({<br>    # ipv4_ipam_pool_id   = string<br>    ipv4_netmask_length = number<br>  })</pre> | `null` | no |
 | <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | Controls the letter case of the `tags` keys (label names) for tags generated by this module.<br>Does not affect keys of tags passed in via the `tags` input.<br>Possible values: `lower`, `title`, `upper`.<br>Default value: `title`. | `string` | `null` | no |
 | <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The order in which the labels (ID elements) appear in the `id`.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present. | `list(string)` | `null` | no |
 | <a name="input_label_value_case"></a> [label\_value\_case](#input\_label\_value\_case) | Controls the letter case of ID elements (labels) as included in `id`,<br>set as tag values, and output by this module individually.<br>Does not affect values of tags passed in via the `tags` input.<br>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br>Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.<br>Default value: `lower`. | `string` | `null` | no |
@@ -89,12 +87,12 @@ components:
 | <a name="input_name"></a> [name](#input\_name) | ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.<br>This is the only ID element not also included as a `tag`.<br>The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input. | `string` | `null` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique | `string` | `null` | no |
 | <a name="input_nat_eip_aws_shield_protection_enabled"></a> [nat\_eip\_aws\_shield\_protection\_enabled](#input\_nat\_eip\_aws\_shield\_protection\_enabled) | Enable or disable AWS Shield Advanced protection for NAT EIPs. If set to 'true', a subscription to AWS Shield Advanced must exist in this account. | `bool` | `false` | no |
-| <a name="input_nat_gateway_enabled"></a> [nat\_gateway\_enabled](#input\_nat\_gateway\_enabled) | Flag to enable/disable NAT gateways | `bool` | n/a | yes |
-| <a name="input_nat_instance_enabled"></a> [nat\_instance\_enabled](#input\_nat\_instance\_enabled) | Flag to enable/disable NAT instances | `bool` | n/a | yes |
+| <a name="input_nat_gateway_enabled"></a> [nat\_gateway\_enabled](#input\_nat\_gateway\_enabled) | Flag to enable/disable NAT gateways | `bool` | `true` | no |
+| <a name="input_nat_instance_enabled"></a> [nat\_instance\_enabled](#input\_nat\_instance\_enabled) | Flag to enable/disable NAT instances | `bool` | `false` | no |
 | <a name="input_nat_instance_type"></a> [nat\_instance\_type](#input\_nat\_instance\_type) | NAT Instance type | `string` | `"t3.micro"` | no |
+| <a name="input_public_subnets_enabled"></a> [public\_subnets\_enabled](#input\_public\_subnets\_enabled) | If false, do not create public subnets.<br>Since NAT gateways and instances must be created in public subnets, these will also not be created when `false`. | `bool` | `true` | no |
 | <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br>Characters matching the regex will be removed from the ID elements.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS Region | `string` | n/a | yes |
-| <a name="input_region_availability_zones"></a> [region\_availability\_zones](#input\_region\_availability\_zones) | List of availability zones in region, to be used as default when `availability_zones` is not supplied | `list(string)` | `[]` | no |
 | <a name="input_root_account_tenant_name"></a> [root\_account\_tenant\_name](#input\_root\_account\_tenant\_name) | The tenant name for the root account | `string` | `null` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | <a name="input_subnet_type_tag_key"></a> [subnet\_type\_tag\_key](#input\_subnet\_type\_tag\_key) | Key for subnet type tag to provide information about the type of subnets, e.g. `cpco/subnet/type=private` or `cpcp/subnet/type=public` | `string` | n/a | yes |

--- a/modules/vpc/default.auto.tfvars
+++ b/modules/vpc/default.auto.tfvars
@@ -1,3 +1,0 @@
-# This file is included by default in terraform plans
-
-enabled = false

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -1,21 +1,15 @@
 locals {
   enabled = module.this.enabled
 
-  ec2_endpoint_enabled                  = local.enabled && var.ec2_vpc_endpoint_enabled
   nat_eip_aws_shield_protection_enabled = local.enabled && var.nat_eip_aws_shield_protection_enabled
   vpc_flow_logs_enabled                 = local.enabled && var.vpc_flow_logs_enabled
-  ipam_enabled                          = local.enabled && try(length(var.ipv4_primary_cidr_block), 0) == 0
 
-  # The usage of the specific kubernetes.io/cluster/* resource tags below are required
-  # for EKS and Kubernetes to discover and manage networking resources
-  # https://www.terraform.io/docs/providers/aws/guides/eks-getting-started.html#base-vpc-networking
-  tags = var.eks_tags_enabled ? { for eks in module.eks : format("kubernetes.io/cluster/%s", eks.outputs.eks_cluster_id) => "shared" } : {}
-
-  availability_zones = length(var.availability_zones) > 0 ? var.availability_zones : var.region_availability_zones
+  # The usage of specific kubernetes.io/cluster/* resource tags were required before Kubernetes 1.19,
+  # but are now deprecated. See https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html
 
   max_subnet_count = (
     var.max_subnet_count > 0 ? var.max_subnet_count : (
-      length(var.region_availability_zones) > 0 ? length(var.region_availability_zones) : length(var.availability_zones)
+      length(var.availability_zone_ids) > 0 ? length(var.availability_zone_ids) : length(var.availability_zones)
     )
   )
 
@@ -30,90 +24,109 @@ locals {
     (var.subnet_type_tag_key)         = "private",
     "kubernetes.io/role/internal-elb" = 1,
   }
-}
 
-data "aws_vpc_ipam_pool" "current" {
-  count = local.ipam_enabled ? 1 : 0
+  gateway_endpoint_map = { for v in var.gateway_vpc_endpoints : v => {
+    name            = v
+    policy          = null
+    route_table_ids = module.subnets.private_route_table_ids
+  } }
+
+  # If we use a separate security group for each endpoint interface,
+  # we will use the interface service name as the key:
+  #       security_group_ids  = [module.endpoint_security_groups[v].id]
+  # If we use a single security group for all endpoint interfaces,
+  # we will use local.interface_endpoint_security_group_key as the key.
+  interface_endpoint_security_group_key = "VPC Endpoint interfaces"
+
+  interface_endpoint_map = { for v in var.interface_vpc_endpoints : v => {
+    name                = v
+    policy              = null
+    private_dns_enabled = true # Allow applications to use normal service DNS names to access the service
+    security_group_ids  = [module.endpoint_security_groups[local.interface_endpoint_security_group_key].id]
+    subnet_ids          = module.subnets.private_subnet_ids
+  } }
 }
 
 module "vpc" {
   source  = "cloudposse/vpc/aws"
-  version = "1.1.0"
+  version = "2.0.0-rc1"
 
-  tags                    = local.tags
-  ipv4_primary_cidr_block = var.ipv4_primary_cidr_block
+  ipv4_primary_cidr_block          = var.ipv4_primary_cidr_block
+  internet_gateway_enabled         = var.public_subnets_enabled
+  assign_generated_ipv6_cidr_block = false # disable IPv6
 
-  ipv4_primary_cidr_block_association = local.ipam_enabled ? merge(
-    var.ipv4_primary_cidr_block_association,
-    {
-      ipv4_ipam_pool_id = join("", data.aws_vpc_ipam_pool.current.*.id)
-    }
-  ) : null
-
-  context = module.this.context
-}
-
-module "ec2_vpc_endpoint_sg_label" {
-  source  = "cloudposse/label/null"
-  version = "0.25.0"
-
-  enabled = local.ec2_endpoint_enabled
-
-  attributes = ["ec2-vpc-endpoint-sg"]
+  # Required for DNS resolution of VPC Endpoint interfaces, and generally harmless
+  # See https://docs.aws.amazon.com/vpc/latest/userguide/vpc-dns.html#vpc-dns-support
+  dns_hostnames_enabled = true
+  dns_support_enabled   = true
 
   context = module.this.context
 }
 
-resource "aws_security_group" "ec2_vpc_endpoint_sg" {
-  count = local.ec2_endpoint_enabled ? 1 : 0
+# We could create a security group per endpoint,
+# but until we are ready to customize them by service, it is just a waste
+# of resources. We use a single security group for all endpoints.
+# Security groups can be updated without recreating the endpoint or
+# interrupting service, so this is an easy change to make later.
+module "endpoint_security_groups" {
+  for_each = local.enabled && try(length(var.interface_vpc_endpoints), 0) > 0 ? toset([local.interface_endpoint_security_group_key]) : []
 
-  vpc_id = module.vpc.vpc_id
+  source  = "cloudposse/security-group/aws"
+  version = "2.0.0-rc1"
 
-  ingress {
-    from_port   = 443
-    protocol    = "TCP"
-    to_port     = 443
-    cidr_blocks = [module.vpc.vpc_cidr_block]
-    description = "Security Group for EC2 Interface VPC Endpoint"
+  create_before_destroy      = true
+  preserve_security_group_id = false
+  attributes                 = [each.value]
+  vpc_id                     = module.vpc.vpc_id
+
+  rules_map = {
+    ingress = [{
+      key              = "vpc_ingress"
+      type             = "ingress"
+      from_port        = 0
+      to_port          = 65535
+      protocol         = "-1" # allow ping
+      cidr_blocks      = compact(concat([module.vpc.vpc_cidr_block], module.vpc.additional_cidr_blocks))
+      ipv6_cidr_blocks = compact(concat([module.vpc.vpc_ipv6_cidr_block], module.vpc.additional_ipv6_cidr_blocks))
+      description      = "Ingress from VPC to ${each.value}"
+    }]
   }
 
-  tags = module.ec2_vpc_endpoint_sg_label.tags
+  allow_all_egress = true
+
+  context = module.this.context
 }
+
 
 module "vpc_endpoints" {
   source  = "cloudposse/vpc/aws//modules/vpc-endpoints"
-  version = "1.1.0"
+  version = "2.0.0-rc1"
 
-  enabled = local.ec2_endpoint_enabled
+  enabled = (length(var.interface_vpc_endpoints) + length(var.gateway_vpc_endpoints)) > 0
 
-  vpc_id = module.vpc.vpc_id
-  interface_vpc_endpoints = {
-    ec2 = {
-      name                = "ec2"
-      security_group_ids  = [join("", aws_security_group.ec2_vpc_endpoint_sg.*.id)]
-      subnet_ids          = module.subnets.private_subnet_ids
-      policy              = null
-      private_dns_enabled = true
-    }
-  }
+  vpc_id                  = module.vpc.vpc_id
+  gateway_vpc_endpoints   = local.gateway_endpoint_map
+  interface_vpc_endpoints = local.interface_endpoint_map
 
-  tags = module.ec2_vpc_endpoint_sg_label.tags
+  context = module.this.context
 }
 
 module "subnets" {
   source  = "cloudposse/dynamic-subnets/aws"
-  version = "2.0.2"
+  version = "2.0.4"
 
-  tags = local.tags
-
-  availability_zones              = local.availability_zones
+  availability_zones              = var.availability_zones
+  availability_zone_ids           = var.availability_zone_ids
   ipv4_cidr_block                 = [module.vpc.vpc_cidr_block]
-  igw_id                          = [module.vpc.igw_id]
+  ipv4_cidrs                      = var.ipv4_cidrs
+  ipv6_enabled                    = false
+  igw_id                          = var.public_subnets_enabled ? [module.vpc.igw_id] : []
   map_public_ip_on_launch         = var.map_public_ip_on_launch
   max_subnet_count                = local.max_subnet_count
   nat_gateway_enabled             = var.nat_gateway_enabled
   nat_instance_enabled            = var.nat_instance_enabled
   nat_instance_type               = var.nat_instance_type
+  public_subnets_enabled          = var.public_subnets_enabled
   public_subnets_additional_tags  = local.public_subnets_additional_tags
   private_subnets_additional_tags = local.private_subnets_additional_tags
   vpc_id                          = module.vpc.vpc_id

--- a/modules/vpc/outputs.tf
+++ b/modules/vpc/outputs.tf
@@ -116,5 +116,5 @@ output "interface_vpc_endpoints" {
 
 output "availability_zones" {
   description = "List of Availability Zones where subnets were created"
-  value       = local.availability_zones
+  value       = module.subnets.availability_zones
 }

--- a/modules/vpc/remote-state.tf
+++ b/modules/vpc/remote-state.tf
@@ -1,19 +1,10 @@
-module "eks" {
-  source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "0.22.3"
 
-  for_each = var.eks_tags_enabled ? var.eks_component_names : []
-
-  component = each.value
-
-  context = module.this.context
-}
 
 module "vpc_flow_logs_bucket" {
   count = var.vpc_flow_logs_enabled ? 1 : 0
 
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "0.22.3"
+  version = "1.0.0"
 
   component   = "vpc-flow-logs-bucket"
   environment = var.vpc_flow_logs_bucket_environment_name

--- a/modules/vpc/versions.tf
+++ b/modules/vpc/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = ">= 4.9.0"
     }
   }
 }


### PR DESCRIPTION
## what

- Upstream changes to 
  - cloudtrail
  - cloudtrail-bucket
  - dns-delegated
  - dns-primary
  - vpc
- Run `bats` tests on modified modules
- Remove `default.auto.tfvars` per latest standard

## why

- VPC
  - Improve support for VPC Endpoints
  - Remove support for deprecated features
- DNS
  - Change default negative TTL to 60 seconds
  - Make SOA configurable in `dns-delegated`
  - Improve SOA documentation
- CloudTrail: update `remote-state`, fix provider version pinning
- Testing: enforce relevant standards from our Open Source Terraform modules