### PR TITLE
[eks/actions-runner-controller] Auth via GitHub App, prefer webhook auto-scaling

### DIFF
--- a/modules/eks/actions-runner-controller/provider-helm.tf
+++ b/modules/eks/actions-runner-controller/provider-helm.tf
@@ -2,6 +2,12 @@
 #
 # This file is a drop-in to provide a helm provider.
 #
+# It depends on 2 standard Cloud Posse data source modules to be already
+# defined in the same component:
+#
+#   1. module.iam_roles to provide the AWS profile or Role ARN to use to access the cluster
+#   2. module.eks to provide the EKS cluster information
+#
 # All the following variables are just about configuring the Kubernetes provider
 # to be able to modify EKS cluster. The reason there are so many options is
 # because at various times, each one of them has had problems, so we give you a choice.
@@ -100,9 +106,11 @@ locals {
     "--role-arn", local.kube_exec_auth_role_arn
   ] : []
 
-  certificate_authority_data = module.eks.outputs.eks_cluster_certificate_authority_data
-  eks_cluster_id             = module.eks.outputs.eks_cluster_id
-  eks_cluster_endpoint       = module.eks.outputs.eks_cluster_endpoint
+  # Provide dummy configuration for the case where the EKS cluster is not available.
+  certificate_authority_data = try(module.eks.outputs.eks_cluster_certificate_authority_data, "")
+  # Use coalesce+try to handle both the case where the output is missing and the case where it is empty.
+  eks_cluster_id       = coalesce(try(module.eks.outputs.eks_cluster_id, ""), "missing")
+  eks_cluster_endpoint = try(module.eks.outputs.eks_cluster_endpoint, "")
 }
 
 data "aws_eks_cluster_auth" "eks" {
@@ -114,14 +122,14 @@ provider "helm" {
   kubernetes {
     host                   = local.eks_cluster_endpoint
     cluster_ca_certificate = base64decode(local.certificate_authority_data)
-    token                  = local.kube_data_auth_enabled ? data.aws_eks_cluster_auth.eks[0].token : null
+    token                  = local.kube_data_auth_enabled ? one(data.aws_eks_cluster_auth.eks[*].token) : null
     # The Kubernetes provider will use information from KUBECONFIG if it exists, but if the default cluster
     # in KUBECONFIG is some other cluster, this will cause problems, so we override it always.
     config_path    = local.kubeconfig_file_enabled ? var.kubeconfig_file : ""
     config_context = var.kubeconfig_context
 
     dynamic "exec" {
-      for_each = local.kube_exec_auth_enabled ? ["exec"] : []
+      for_each = local.kube_exec_auth_enabled && length(local.certificate_authority_data) > 0 ? ["exec"] : []
       content {
         api_version = local.kubeconfig_exec_auth_api_version
         command     = "aws"
@@ -132,21 +140,21 @@ provider "helm" {
     }
   }
   experiments {
-    manifest = var.helm_manifest_experiment_enabled
+    manifest = var.helm_manifest_experiment_enabled && module.this.enabled
   }
 }
 
 provider "kubernetes" {
   host                   = local.eks_cluster_endpoint
   cluster_ca_certificate = base64decode(local.certificate_authority_data)
-  token                  = local.kube_data_auth_enabled ? data.aws_eks_cluster_auth.eks[0].token : null
+  token                  = local.kube_data_auth_enabled ? one(data.aws_eks_cluster_auth.eks[*].token) : null
   # The Kubernetes provider will use information from KUBECONFIG if it exists, but if the default cluster
   # in KUBECONFIG is some other cluster, this will cause problems, so we override it always.
   config_path    = local.kubeconfig_file_enabled ? var.kubeconfig_file : ""
   config_context = var.kubeconfig_context
 
   dynamic "exec" {
-    for_each = local.kube_exec_auth_enabled ? ["exec"] : []
+    for_each = local.kube_exec_auth_enabled && length(local.certificate_authority_data) > 0 ? ["exec"] : []
     content {
       api_version = local.kubeconfig_exec_auth_api_version
       command     = "aws"

--- a/modules/eks/actions-runner-controller/remote-state.tf
+++ b/modules/eks/actions-runner-controller/remote-state.tf
@@ -1,20 +1,8 @@
 module "eks" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "0.22.4"
+  version = "1.3.1"
 
   component = var.eks_component_name
-
-  context = module.this.context
-}
-
-module "account_map" {
-  source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "0.22.4"
-
-  component   = "account-map"
-  environment = var.account_map_environment_name
-  stage       = var.account_map_stage_name
-  tenant      = var.account_map_tenant_name
 
   context = module.this.context
 }

--- a/modules/eks/actions-runner-controller/versions.tf
+++ b/modules/eks/actions-runner-controller/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = ">= 4.9.0"
     }
     helm = {
       source  = "hashicorp/helm"


### PR DESCRIPTION
## what

- Support and prefer authentication via GitHub app
- Support and prefer webhook-based autoscaling


## why

- GitHub app is much more restricted, plus has higher API rate limits
- Webhook-based autoscaling is proactive without being overly expensive

