### PR TITLE
CPLIVE-320: Set VPC to use region-less AZs

### DIFF
--- a/modules/vpc/README.md
+++ b/modules/vpc/README.md
@@ -9,16 +9,47 @@ This component is responsible for provisioning a VPC and corresponding Subnets. 
 Here's an example snippet for how to use this component.
 
 ```yaml
+# catalog/vpc/defaults or catalog/vpc
+components:
+  terraform:
+    vpc/defaults:
+      metadata:
+        type: abstract
+        component: vpc
+      settings:
+        spacelift:
+          workspace_enabled: true
+      vars:
+        enabled: true
+        name: vpc
+        eks_tags_enabled: true
+        availability_zones:
+          - "a"
+          - "b"
+          - "c"
+        nat_gateway_enabled: true
+        nat_instance_enabled: false
+        max_subnet_count: 3
+        vpc_flow_logs_enabled: true
+        vpc_flow_logs_bucket_environment_name: <environment>
+        vpc_flow_logs_bucket_stage_name: audit
+        vpc_flow_logs_traffic_type: "ALL"
+        subnet_type_tag_key: "example.net/subnet/type"
+        assign_generated_ipv6_cidr_block: true
+```
+
+```yaml
+import:
+  - catalog/vpc
+
 components:
   terraform:
     vpc:
+      metadata:
+        component: vpc
+        inherits:
+          - vpc/defaults
       vars:
-        enabled: true
-        subnet_type_tag_key: "example.net/subnet/type"
-        vpc_flow_logs_enabled: true
-        vpc_flow_logs_bucket_environment_name: <environment>
-        vpc_flow_logs_bucket_stage_name: "audit"
-        vpc_flow_logs_traffic_type: "ALL"
         ipv4_primary_cidr_block: "10.111.0.0/18"
 ```
 
@@ -44,9 +75,10 @@ components:
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
 | <a name="module_subnets"></a> [subnets](#module\_subnets) | cloudposse/dynamic-subnets/aws | 2.0.4 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | cloudposse/vpc/aws | 2.0.0-rc1 |
-| <a name="module_vpc_endpoints"></a> [vpc\_endpoints](#module\_vpc\_endpoints) | cloudposse/vpc/aws//modules/vpc-endpoints | 2.0.0-rc1 |
-| <a name="module_vpc_flow_logs_bucket"></a> [vpc\_flow\_logs\_bucket](#module\_vpc\_flow\_logs\_bucket) | cloudposse/stack-config/yaml//modules/remote-state | 1.0.0 |
+| <a name="module_utils"></a> [utils](#module\_utils) | cloudposse/utils/aws | 1.1.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | cloudposse/vpc/aws | 2.0.0 |
+| <a name="module_vpc_endpoints"></a> [vpc\_endpoints](#module\_vpc\_endpoints) | cloudposse/vpc/aws//modules/vpc-endpoints | 2.0.0 |
+| <a name="module_vpc_flow_logs_bucket"></a> [vpc\_flow\_logs\_bucket](#module\_vpc\_flow\_logs\_bucket) | cloudposse/stack-config/yaml//modules/remote-state | 1.3.1 |
 
 ## Resources
 
@@ -62,13 +94,13 @@ components:
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br>This is for some rare cases where resources want additional configuration of tags<br>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
+| <a name="input_assign_generated_ipv6_cidr_block"></a> [assign\_generated\_ipv6\_cidr\_block](#input\_assign\_generated\_ipv6\_cidr\_block) | When `true`, assign AWS generated IPv6 CIDR block to the VPC.  Conflicts with `ipv6_ipam_pool_id`. | `bool` | `false` | no |
 | <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br>in the order they appear in the list. New attributes are appended to the<br>end of the list. The elements of the list are joined by the `delimiter`<br>and treated as a single ID element. | `list(string)` | `[]` | no |
 | <a name="input_availability_zone_ids"></a> [availability\_zone\_ids](#input\_availability\_zone\_ids) | List of Availability Zones IDs where subnets will be created. Overrides `availability_zones`.<br>Useful in some regions when using only some AZs and you want to use the same ones across multiple accounts. | `list(string)` | `[]` | no |
 | <a name="input_availability_zones"></a> [availability\_zones](#input\_availability\_zones) | List of Availability Zones (AZs) where subnets will be created. Ignored when `availability_zone_ids` is set.<br>The order of zones in the list ***must be stable*** or else Terraform will continually make changes.<br>If no AZs are specified, then `max_subnet_count` AZs will be selected in alphabetical order.<br>If `max_subnet_count > 0` and `length(var.availability_zones) > max_subnet_count`, the list<br>will be truncated. We recommend setting `availability_zones` and `max_subnet_count` explicitly as constant<br>(not computed) values for predictability, consistency, and stability. | `list(string)` | `[]` | no |
 | <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "descriptor_formats": {},<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "labels_as_tags": [<br>    "unset"<br>  ],<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {},<br>  "tenant": null<br>}</pre> | no |
 | <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between ID elements.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
 | <a name="input_descriptor_formats"></a> [descriptor\_formats](#input\_descriptor\_formats) | Describe additional descriptors to be output in the `descriptors` output map.<br>Map of maps. Keys are names of descriptors. Values are maps of the form<br>`{<br>   format = string<br>   labels = list(string)<br>}`<br>(Type is `any` so the map values can later be enhanced to provide additional options.)<br>`format` is a Terraform format string to be passed to the `format()` function.<br>`labels` is a list of labels, in order, to pass to `format()` function.<br>Label values will be normalized before being passed to `format()` so they will be<br>identical to how they appear in `id`.<br>Default is `{}` (`descriptors` output will be empty). | `any` | `{}` | no |
-| <a name="input_eks_tags_enabled"></a> [eks\_tags\_enabled](#input\_eks\_tags\_enabled) | Whether or not to apply EKS-releated tags to resources | `bool` | `false` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | <a name="input_gateway_vpc_endpoints"></a> [gateway\_vpc\_endpoints](#input\_gateway\_vpc\_endpoints) | A list of Gateway VPC Endpoints to provision into the VPC. Only valid values are "dynamodb" and "s3". | `set(string)` | `[]` | no |

--- a/modules/vpc/remote-state.tf
+++ b/modules/vpc/remote-state.tf
@@ -1,10 +1,8 @@
-
-
 module "vpc_flow_logs_bucket" {
   count = var.vpc_flow_logs_enabled ? 1 : 0
 
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "1.0.0"
+  version = "1.3.1"
 
   component   = "vpc-flow-logs-bucket"
   environment = var.vpc_flow_logs_bucket_environment_name

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -50,6 +50,12 @@ variable "ipv4_cidrs" {
   }
 }
 
+variable "assign_generated_ipv6_cidr_block" {
+  type        = bool
+  description = "When `true`, assign AWS generated IPv6 CIDR block to the VPC.  Conflicts with `ipv6_ipam_pool_id`."
+  default     = false
+}
+
 variable "public_subnets_enabled" {
   type        = bool
   description = <<-EOT
@@ -137,12 +143,6 @@ variable "vpc_flow_logs_bucket_tenant_name" {
 variable "nat_eip_aws_shield_protection_enabled" {
   type        = bool
   description = "Enable or disable AWS Shield Advanced protection for NAT EIPs. If set to 'true', a subscription to AWS Shield Advanced must exist in this account."
-  default     = false
-}
-
-variable "eks_tags_enabled" {
-  type        = bool
-  description = "Whether or not to apply EKS-releated tags to resources"
   default     = false
 }
 


### PR DESCRIPTION
## what
* Set VPC to use region-less AZs

## why
* Prevent having to set VPC AZs within global region defaults

## references
* CPLIVE-320
