### PR TITLE
fix(aws-sso): add missing tf update perms

### DIFF
--- a/modules/aws-sso/README.md
+++ b/modules/aws-sso/README.md
@@ -121,18 +121,20 @@ components:
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_account_map"></a> [account\_map](#module\_account\_map) | cloudposse/stack-config/yaml//modules/remote-state | 0.22.3 |
+| <a name="module_account_map"></a> [account\_map](#module\_account\_map) | cloudposse/stack-config/yaml//modules/remote-state | 1.3.1 |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
 | <a name="module_permission_sets"></a> [permission\_sets](#module\_permission\_sets) | cloudposse/sso/aws//modules/permission-sets | 0.6.2 |
 | <a name="module_role_prefix"></a> [role\_prefix](#module\_role\_prefix) | cloudposse/label/null | 0.25.0 |
 | <a name="module_sso_account_assignments"></a> [sso\_account\_assignments](#module\_sso\_account\_assignments) | cloudposse/sso/aws//modules/account-assignments | 0.6.2 |
 | <a name="module_sso_account_assignments_root"></a> [sso\_account\_assignments\_root](#module\_sso\_account\_assignments\_root) | cloudposse/sso/aws//modules/account-assignments | 0.6.2 |
+| <a name="module_tfstate"></a> [tfstate](#module\_tfstate) | cloudposse/stack-config/yaml//modules/remote-state | 1.3.1 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 
 ## Resources
 
 | Name | Type |
 |------|------|
+| [aws_iam_policy_document.TerraformUpdateAccess](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.assume_identity_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.dns_administrator_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
@@ -167,6 +169,7 @@ components:
 | <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
 | <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |
+| <a name="input_tfstate_environment_name"></a> [tfstate\_environment\_name](#input\_tfstate\_environment\_name) | Moniker for environment with tfstate-backend deployed | `string` | n/a | yes |
 
 ## Outputs
 

--- a/modules/aws-sso/README.md
+++ b/modules/aws-sso/README.md
@@ -169,7 +169,7 @@ components:
 | <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
 | <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |
-| <a name="input_tfstate_environment_name"></a> [tfstate\_environment\_name](#input\_tfstate\_environment\_name) | Moniker for environment with tfstate-backend deployed | `string` | n/a | yes |
+| <a name="input_tfstate_environment_name"></a> [tfstate\_environment\_name](#input\_tfstate\_environment\_name) | The name of the environment where `tfstate-backend` is provisioned | `string` | n/a | yes |
 
 ## Outputs
 

--- a/modules/aws-sso/README.md
+++ b/modules/aws-sso/README.md
@@ -109,13 +109,13 @@ components:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
 
 ## Modules
 

--- a/modules/aws-sso/main.tf
+++ b/modules/aws-sso/main.tf
@@ -10,6 +10,7 @@ module "permission_sets" {
     local.identity_access_permission_sets,
     local.poweruser_access_permission_set,
     local.read_only_access_permission_set,
+    local.terraform_update_access_permission_set,
   )
 
   context = module.this.context

--- a/modules/aws-sso/policy-TerraformUpdateAccess.tf
+++ b/modules/aws-sso/policy-TerraformUpdateAccess.tf
@@ -1,0 +1,30 @@
+
+data "aws_iam_policy_document" "TerraformUpdateAccess" {
+  statement {
+    sid     = "TerraformStateBackendS3Bucket"
+    effect  = "Allow"
+    actions = ["s3:ListBucket", "s3:GetObject", "s3:PutObject"]
+    resources = module.this.enabled ? [
+      module.tfstate.outputs.tfstate_backend_s3_bucket_arn,
+      "${module.tfstate.outputs.tfstate_backend_s3_bucket_arn}/*"
+    ] : []
+  }
+  statement {
+    sid       = "TerraformStateBackendDynamoDbTable"
+    effect    = "Allow"
+    actions   = ["dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:DeleteItem"]
+    resources = module.this.enabled ? [module.tfstate.outputs.tfstate_backend_dynamodb_table_arn] : []
+  }
+}
+
+locals {
+  terraform_update_access_permission_set = [{
+    name               = "TerraformUpdateAccess",
+    description        = "Allow access to Terraform state sufficient to make changes",
+    relay_state        = "",
+    session_duration   = "PT1H", # One hour, maximum allowed for chained assumed roles
+    tags               = {},
+    inline_policy      = data.aws_iam_policy_document.TerraformUpdateAccess.json,
+    policy_attachments = []
+  }]
+}

--- a/modules/aws-sso/remote-state.tf
+++ b/modules/aws-sso/remote-state.tf
@@ -1,9 +1,21 @@
 module "account_map" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "0.22.3"
+  version = "1.3.1"
 
   component   = "account-map"
   environment = var.global_environment_name
+  stage       = var.root_account_stage_name
+  privileged  = var.privileged
+
+  context = module.this.context
+}
+
+module "tfstate" {
+  source  = "cloudposse/stack-config/yaml//modules/remote-state"
+  version = "1.3.1"
+
+  component   = "tfstate-backend"
+  environment = var.tfstate_environment_name
   stage       = var.root_account_stage_name
   privileged  = var.privileged
 

--- a/modules/aws-sso/variables.tf
+++ b/modules/aws-sso/variables.tf
@@ -3,6 +3,11 @@ variable "region" {
   description = "AWS Region"
 }
 
+variable "tfstate_environment_name" {
+  type        = string
+  description = "Moniker for environment with tfstate-backend deployed"
+}
+
 variable "global_environment_name" {
   type        = string
   description = "Global environment name"

--- a/modules/aws-sso/variables.tf
+++ b/modules/aws-sso/variables.tf
@@ -5,7 +5,7 @@ variable "region" {
 
 variable "tfstate_environment_name" {
   type        = string
-  description = "Moniker for environment with tfstate-backend deployed"
+  description = "The name of the environment where `tfstate-backend` is provisioned"
 }
 
 variable "global_environment_name" {

--- a/modules/aws-sso/versions.tf
+++ b/modules/aws-sso/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = ">= 4.0"
     }
   }
 }


### PR DESCRIPTION
## what
* Changes for supporting [Refarch Scaffold](github.com/cloudposse/refarch-scaffold)
* TerraformUpdateAccess permission set added

## why
* Allow SSO users to update dynamodb/s3 for terraform backend
