### PR TITLE
fix(aws-sso): dont hardcode account name for root

### DIFF
--- a/modules/account-map/modules/iam-roles/variables.tf
+++ b/modules/account-map/modules/iam-roles/variables.tf
@@ -7,7 +7,7 @@ variable "privileged" {
 variable "global_tenant_name" {
   type        = string
   description = "The tenant name used for organization-wide resources"
-  default     = "gov"
+  default     = "core"
 }
 
 variable "global_environment_name" {

--- a/modules/aws-sso/main.tf
+++ b/modules/aws-sso/main.tf
@@ -39,7 +39,7 @@ module "sso_account_assignments_root" {
 locals {
   enabled = module.this.enabled
 
-  account_map = module.account_map.outputs.full_account_map
+  account_map  = module.account_map.outputs.full_account_map
   root_account = local.account_map[module.account_map.outputs.root_account_account_name]
 
   account_assignments_groups = flatten([

--- a/modules/aws-sso/main.tf
+++ b/modules/aws-sso/main.tf
@@ -40,6 +40,8 @@ locals {
   enabled = module.this.enabled
 
   account_map = module.account_map.outputs.full_account_map
+  root_account = local.account_map[module.account_map.outputs.root_account_account_name]
+
   account_assignments_groups = flatten([
     for account_key, account in var.account_assignments : [
       for principal_key, principal in account.groups : [
@@ -58,12 +60,12 @@ locals {
   account_assignments_groups_no_root = [
     for val in local.account_assignments_groups :
     val
-    if val.account != local.account_map["root"]
+    if val.account != local.root_account
   ]
   account_assignments_groups_only_root = [
     for val in local.account_assignments_groups :
     val
-    if val.account == local.account_map["root"]
+    if val.account == local.root_account
   ]
   account_assignments_users = flatten([
     for account_key, account in var.account_assignments : [
@@ -82,12 +84,12 @@ locals {
   account_assignments_users_no_root = [
     for val in local.account_assignments_users :
     val
-    if val.account != local.account_map["root"]
+    if val.account != local.root_account
   ]
   account_assignments_users_only_root = [
     for val in local.account_assignments_users :
     val
-    if val.account == local.account_map["root"]
+    if val.account == local.root_account
   ]
 
   account_assignments      = concat(local.account_assignments_groups_no_root, local.account_assignments_users_no_root)


### PR DESCRIPTION
## what
* remove hardcoding for root account moniker
* change default tenant from `gov` to `core` (now convention)

## why
* tenant is not included in the account prefix. In this case, changed to be 'core'
* most accounts do not use `gov` as the root tenant
