### PR TITLE
Sync karpenter chart values with the schema

### DIFF
--- a/modules/eks/karpenter/main.tf
+++ b/modules/eks/karpenter/main.tf
@@ -109,11 +109,13 @@ module "karpenter" {
     }),
     # karpenter-specific values
     yamlencode({
-      aws = {
-        defaultInstanceProfile = one(aws_iam_instance_profile.default[*].name)
+      settings = {
+        aws = {
+          defaultInstanceProfile = one(aws_iam_instance_profile.default[*].name)
+          clusterName            = local.eks_cluster_id
+          clusterEndpoint        = local.eks_cluster_endpoint
+        }
       }
-      clusterName     = local.eks_cluster_id
-      clusterEndpoint = local.eks_cluster_endpoint
     }),
     # additional values
     yamlencode(var.chart_values)


### PR DESCRIPTION
## what
Based on https://github.com/aws/karpenter/blob/92b3d4a0b029cae6a9d6536517ba42d70c3ebf8c/charts/karpenter/values.yaml#L129-L142 all these should go under settings.aws

## why
Ensure compatibility with the new charts

## references
Based on https://github.com/aws/karpenter/blob/92b3d4a0b029cae6a9d6536517ba42d70c3ebf8c/charts/karpenter/values.yaml

