### PR TITLE
Update k8s metrics-server to latest

### DIFF
--- a/modules/eks/metrics-server/default.auto.tfvars
+++ b/modules/eks/metrics-server/default.auto.tfvars
@@ -4,7 +4,7 @@ name = "metrics-server"
 
 chart            = "metrics-server"
 chart_repository = "https://charts.bitnami.com/bitnami"
-chart_version    = "5.11.4"
+chart_version    = "6.2.6"
 
 create_namespace     = true
 kubernetes_namespace = "metrics-server"


### PR DESCRIPTION


## what
Upgrade metrics-server
Tested on k8s 1.24 via `kubectl get --raw "/apis/metrics.k8s.io/v1beta1/nodes"`

## why
* The previous one was so old that bitnami has even removed the chart.


