### PR TITLE
Fix typo in karpenter-provisioner

### DIFF
--- a/modules/eks/karpenter-provisioner/main.tf
+++ b/modules/eks/karpenter-provisioner/main.tf
@@ -32,18 +32,18 @@ resource "kubernetes_manifest" "provisioner" {
       providerRef = {
         name = each.value.name
       }
-      requirements = each.value.requirements
+      requirements  = each.value.requirements
+      consolidation = each.value.consolidation
       # Do not include keys with null values, or else Terraform will show a perpetual diff.
       # Use `try(length(),0)` to detect both empty lists and nulls.
-      }, try(length(each.value.taints), 0) == 0 ? {} : {
+    }, try(length(each.value.taints), 0) == 0 ? {} : {
       taints = each.value.taints
-      }, try(length(each.value.startup_taints), 0) == 0 ? {} : {
+    }, try(length(each.value.startup_taints), 0) == 0 ? {} : {
       startupTaints = each.value.startup_taints
-      }, each.value.ttl_seconds_after_empty == null ? {} : {
+    }, each.value.ttl_seconds_after_empty == null ? {} : {
       ttlSecondsAfterEmpty = each.value.ttl_seconds_after_empty
-      }, each.value.ttl_seconds_until_expired == null ? {} : {
+    }, each.value.ttl_seconds_until_expired == null ? {} : {
       ttlSecondsUntilExpired = each.value.ttl_seconds_until_expired
-      consolidation          = each.value.consolidation
     })
   }
 


### PR DESCRIPTION
## what
I formatted it last moment and did not notice that actually changed the object. 
Fixing that and reformatting all of it so it's more obvious.

## why
* Fixing bug

## references
https://github.com/cloudposse/terraform-aws-components/pull/536
