### PR TITLE
fix(dns-primary/acm): include zone_name arg

### DIFF
--- a/modules/dns-primary/README.md
+++ b/modules/dns-primary/README.md
@@ -51,7 +51,7 @@ components:
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_acm"></a> [acm](#module\_acm) | cloudposse/acm-request-certificate/aws | 0.17.0 |
+| <a name="module_acm"></a> [acm](#module\_acm) | cloudposse/acm-request-certificate/aws | 0.16.2 |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 

--- a/modules/dns-primary/acm.tf
+++ b/modules/dns-primary/acm.tf
@@ -16,6 +16,7 @@ module "acm" {
 
   enabled = local.certificate_enabled
 
+  zone_name                         = each.value
   domain_name                       = each.value
   process_domain_validation_options = true
   ttl                               = 300

--- a/modules/dns-primary/acm.tf
+++ b/modules/dns-primary/acm.tf
@@ -11,12 +11,12 @@ locals {
 module "acm" {
   for_each = local.domains_set
 
-  source  = "cloudposse/acm-request-certificate/aws"
-  version = "0.17.0"
+  source = "cloudposse/acm-request-certificate/aws"
+  // Note: 0.17.0 is a 'preview' release, so we're using 0.16.2
+  version = "0.16.2"
 
   enabled = local.certificate_enabled
 
-  zone_name                         = each.value
   domain_name                       = each.value
   process_domain_validation_options = true
   ttl                               = 300


### PR DESCRIPTION
## what
* in dns-primary, revert version of acm module 0.17.0 -> 0.16.2 (17 is a preview)

## why
* primary zones must be specified now that names are trimmed before the dot (.)
