### PR TITLE
EC2 Client VPN Version Bump

### DIFF
--- a/modules/ec2-client-vpn/README.md
+++ b/modules/ec2-client-vpn/README.md
@@ -100,7 +100,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_ec2_client_vpn"></a> [ec2\_client\_vpn](#module\_ec2\_client\_vpn) | cloudposse/ec2-client-vpn/aws | 0.11.0 |
+| <a name="module_ec2_client_vpn"></a> [ec2\_client\_vpn](#module\_ec2\_client\_vpn) | cloudposse/ec2-client-vpn/aws | 0.14.0 |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | cloudposse/stack-config/yaml//modules/remote-state | 0.22.3 |

--- a/modules/ec2-client-vpn/main.tf
+++ b/modules/ec2-client-vpn/main.tf
@@ -31,7 +31,7 @@ locals {
 
 module "ec2_client_vpn" {
   source  = "cloudposse/ec2-client-vpn/aws"
-  version = "0.11.0"
+  version = "0.14.0"
 
   ca_common_name     = var.ca_common_name
   root_common_name   = var.root_common_name


### PR DESCRIPTION
## what
* Bump Versin of EC2 Client VPN

## why
* Bugfixes issue with TLS provider

## references
* https://github.com/cloudposse/terraform-aws-ec2-client-vpn/pull/58
* https://github.com/cloudposse/terraform-aws-ssm-tls-self-signed-cert/pull/20
