### PR TITLE
Remove extra var from stack example

### DIFF
--- a/modules/vpc/README.md
+++ b/modules/vpc/README.md
@@ -22,7 +22,6 @@ components:
       vars:
         enabled: true
         name: vpc
-        eks_tags_enabled: true
         availability_zones:
           - "a"
           - "b"


### PR DESCRIPTION
## what

* Stack example has an old variable defined

## why

* `The root module does not declare a variable named "eks_tags_enabled" but a value was found in file "uw2-automation-vpc.terraform.tfvars.json".` 

## references
