### PR TITLE
aws-sso: upgrade to 0.7.1 and adjust policies

### DIFF
--- a/modules/aws-sso/main.tf
+++ b/modules/aws-sso/main.tf
@@ -1,6 +1,6 @@
 module "permission_sets" {
   source  = "cloudposse/sso/aws//modules/permission-sets"
-  version = "0.6.2"
+  version = "0.7.1"
 
   permission_sets = concat(
     local.administrator_access_permission_set,
@@ -18,7 +18,7 @@ module "permission_sets" {
 
 module "sso_account_assignments" {
   source  = "cloudposse/sso/aws//modules/account-assignments"
-  version = "0.6.2"
+  version = "0.7.1"
 
   account_assignments = local.account_assignments
   context             = module.this.context
@@ -26,7 +26,7 @@ module "sso_account_assignments" {
 
 module "sso_account_assignments_root" {
   source  = "cloudposse/sso/aws//modules/account-assignments"
-  version = "0.6.2"
+  version = "0.7.1"
 
   providers = {
     aws = aws.root

--- a/modules/aws-sso/policy-AdminstratorAccess.tf
+++ b/modules/aws-sso/policy-AdminstratorAccess.tf
@@ -7,5 +7,6 @@ locals {
     tags               = {},
     inline_policy      = ""
     policy_attachments = ["arn:${local.aws_partition}:iam::aws:policy/AdministratorAccess"]
+    customer_managed_policy_attachments = []
   }]
 }

--- a/modules/aws-sso/policy-BillingAdministratorAccess.tf
+++ b/modules/aws-sso/policy-BillingAdministratorAccess.tf
@@ -10,5 +10,6 @@ locals {
       "arn:${local.aws_partition}:iam::aws:policy/job-function/Billing",
       "arn:${local.aws_partition}:iam::aws:policy/AWSSupportAccess",
     ]
+    customer_managed_policy_attachments = []
   }]
 }

--- a/modules/aws-sso/policy-BillingReadOnlyAccess.tf
+++ b/modules/aws-sso/policy-BillingReadOnlyAccess.tf
@@ -10,5 +10,6 @@ locals {
       "arn:${local.aws_partition}:iam::aws:policy/AWSBillingReadOnlyAccess",
       "arn:${local.aws_partition}:iam::aws:policy/AWSSupportAccess",
     ]
+    customer_managed_policy_attachments = []
   }]
 }

--- a/modules/aws-sso/policy-DNSAdministratorAccess.tf
+++ b/modules/aws-sso/policy-DNSAdministratorAccess.tf
@@ -34,5 +34,6 @@ locals {
     tags               = {},
     inline_policy      = data.aws_iam_policy_document.dns_administrator_access.json,
     policy_attachments = ["arn:${local.aws_partition}:iam::aws:policy/AWSSupportAccess"]
+    customer_managed_policy_attachments = []
   }]
 }

--- a/modules/aws-sso/policy-Identity-role-RoleAccess.tf
+++ b/modules/aws-sso/policy-Identity-role-RoleAccess.tf
@@ -61,5 +61,6 @@ locals {
     tags               = {},
     inline_policy      = data.aws_iam_policy_document.assume_identity_role[role].json
     policy_attachments = ["arn:${local.aws_partition}:iam::aws:policy/job-function/ViewOnlyAccess"]
+    customer_managed_policy_attachments = []
   }]
 }

--- a/modules/aws-sso/policy-PoweruserAccess.tf
+++ b/modules/aws-sso/policy-PoweruserAccess.tf
@@ -10,5 +10,6 @@ locals {
       "arn:${local.aws_partition}:iam::aws:policy/PowerUserAccess",
       "arn:${local.aws_partition}:iam::aws:policy/AWSSupportAccess",
     ]
+    customer_managed_policy_attachments = []
   }]
 }

--- a/modules/aws-sso/policy-ReadOnlyAccess.tf
+++ b/modules/aws-sso/policy-ReadOnlyAccess.tf
@@ -10,5 +10,6 @@ locals {
       "arn:${local.aws_partition}:iam::aws:policy/ReadOnlyAccess",
       "arn:${local.aws_partition}:iam::aws:policy/AWSSupportAccess",
     ]
+    customer_managed_policy_attachments = []
   }]
 }

--- a/modules/aws-sso/policy-TerraformUpdateAccess.tf
+++ b/modules/aws-sso/policy-TerraformUpdateAccess.tf
@@ -26,5 +26,6 @@ locals {
     tags               = {},
     inline_policy      = data.aws_iam_policy_document.TerraformUpdateAccess.json,
     policy_attachments = []
+    customer_managed_policy_attachments = []
   }]
 }


### PR DESCRIPTION
## what

* Upgrade the aws-sso module to use the 0.7.1 sso module

NOTE: I did not test this locally. I ran this within a project and am applying the changes it required for the update. More couple be needed here or an entirely different format.

## why

* `aws-sso` was outdated by a full minor version

## references
