### PR TITLE
alb-ingress-group tag filter update

### DIFF
--- a/modules/eks/alb-controller-ingress-group/main.tf
+++ b/modules/eks/alb-controller-ingress-group/main.tf
@@ -171,7 +171,7 @@ data "aws_lb" "default" {
 
   tags = {
     "ingress.k8s.aws/resource" = "LoadBalancer"
-    "ingress.k8s.aws/stack"    = var.name
+    "ingress.k8s.aws/stack"    = coalesce(var.alb_group_name, var.name)
     "elbv2.k8s.aws/cluster"    = module.eks.outputs.eks_cluster_id
   }
 


### PR DESCRIPTION
## what
* update alb-ingress group tag filter

## why
* a group name is the stack tag value, which should be filtered for
