### PR TITLE
SSO upgrades and Support for Assume Role from Identity Users

### DIFF
--- a/modules/account-map/modules/roles-to-principals/main.tf
+++ b/modules/account-map/modules/roles-to-principals/main.tf
@@ -32,9 +32,16 @@ locals {
   )])))
 
   # Support for AWS SSO Permission Sets
-  permission_set_arn_like = distinct(compact(flatten([for acct, v in var.permission_set_map : formatlist(
-    # arn:aws:iam::550826706431:role/aws-reserved/sso.amazonaws.com/ap-southeast-1/AWSReservedSSO_IdentityAdminRoleAccess_b68e107e9495e2fc
+  permission_set_arn_like = distinct(compact(flatten([for acct, v in var.permission_set_map : concat(formatlist(
+    # arn:aws:iam::12345:role/aws-reserved/sso.amazonaws.com/ap-southeast-1/AWSReservedSSO_IdentityAdminRoleAccess_b68e107e9495e2fc
     # AWS SSO Sometimes includes `/region/`, but not always.
     format("arn:%s:iam::%s:role/aws-reserved/sso.amazonaws.com*/AWSReservedSSO_%%s_*", local.aws_partition, module.account_map.outputs.full_account_map[acct]),
-  v)])))
+  v),
+  formatlist(
+    # Support assume role from the allowed identity account SSO users
+    # arn:aws:iam::12345:role/aws-reserved/sso.amazonaws.com/ap-southeast-1/AWSReservedSSO_IdentityAdminRoleAccess_b68e107e9495e2fc
+    # AWS SSO Sometimes includes `/region/`, but not always.
+    format("arn:%s:iam::%s:role/aws-reserved/sso.amazonaws.com*/AWSReservedSSO_%%s_*", local.aws_partition, module.account_map.outputs.full_account_map[module.account_map.outputs.identity_account_account_name]),
+  v),
+  )])))
 }

--- a/modules/account-map/modules/roles-to-principals/main.tf
+++ b/modules/account-map/modules/roles-to-principals/main.tf
@@ -36,12 +36,12 @@ locals {
     # arn:aws:iam::12345:role/aws-reserved/sso.amazonaws.com/ap-southeast-1/AWSReservedSSO_IdentityAdminRoleAccess_b68e107e9495e2fc
     # AWS SSO Sometimes includes `/region/`, but not always.
     format("arn:%s:iam::%s:role/aws-reserved/sso.amazonaws.com*/AWSReservedSSO_%%s_*", local.aws_partition, module.account_map.outputs.full_account_map[acct]),
-  v),
-  formatlist(
-    # Support assume role from the allowed identity account SSO users
-    # arn:aws:iam::12345:role/aws-reserved/sso.amazonaws.com/ap-southeast-1/AWSReservedSSO_IdentityAdminRoleAccess_b68e107e9495e2fc
-    # AWS SSO Sometimes includes `/region/`, but not always.
-    format("arn:%s:iam::%s:role/aws-reserved/sso.amazonaws.com*/AWSReservedSSO_%%s_*", local.aws_partition, module.account_map.outputs.full_account_map[module.account_map.outputs.identity_account_account_name]),
-  v),
+    v),
+    formatlist(
+      # Support assume role from the allowed identity account SSO users
+      # arn:aws:iam::12345:role/aws-reserved/sso.amazonaws.com/ap-southeast-1/AWSReservedSSO_IdentityAdminRoleAccess_b68e107e9495e2fc
+      # AWS SSO Sometimes includes `/region/`, but not always.
+      format("arn:%s:iam::%s:role/aws-reserved/sso.amazonaws.com*/AWSReservedSSO_%%s_*", local.aws_partition, module.account_map.outputs.full_account_map[module.account_map.outputs.identity_account_account_name]),
+    v),
   )])))
 }

--- a/modules/aws-sso/README.md
+++ b/modules/aws-sso/README.md
@@ -47,7 +47,7 @@ The `account_assignments` setting configures access to permission sets for users
 The `identity_roles_accessible` element provides a list of role names corresponding to roles created in the `iam-primary-roles` component. For each names role, a corresponding permission set will be created which allows the user to assume that role. The permission set name is generated in Terraform from the role name using this statement:
 
 ```
-format("Identity%sRoleAccess", title(role))
+format("Identity%sTeamAccess", title(role))
 ```
 
 #### Example
@@ -92,7 +92,7 @@ components:
                 permission_sets:
                   - AdministratorAccess
                   - ReadOnlyAccess
-        identity_roles_accessible:
+        aws_teams_accessible:
         - "admin"
         - "ops"
         - "poweruser"
@@ -135,7 +135,7 @@ components:
 | Name | Type |
 |------|------|
 | [aws_iam_policy_document.TerraformUpdateAccess](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.assume_identity_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.assume_aws_team](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.dns_administrator_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 
@@ -146,15 +146,16 @@ components:
 | <a name="input_account_assignments"></a> [account\_assignments](#input\_account\_assignments) | Enables access to permission sets for users and groups in accounts, in the following structure:<pre>yaml<br><account-name>:<br>  groups:<br>    <group-name>:<br>      permission_sets:<br>        - <permission-set-name><br>  users:<br>    <user-name>:<br>      permission_sets:<br>        - <permission-set-name></pre> | <pre>map(map(map(object({<br>    permission_sets = list(string)<br>    }<br>  ))))</pre> | `{}` | no |
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br>This is for some rare cases where resources want additional configuration of tags<br>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
 | <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br>in the order they appear in the list. New attributes are appended to the<br>end of the list. The elements of the list are joined by the `delimiter`<br>and treated as a single ID element. | `list(string)` | `[]` | no |
+| <a name="input_aws_teams_accessible"></a> [aws\_teams\_accessible](#input\_aws\_teams\_accessible) | List of IAM roles (e.g. ["admin", "terraform"]) for which to create permission<br>sets that allow the user to assume that role. Named like<br>admin -> IdentityAdminTeamAccess | `set(string)` | `[]` | no |
+| <a name="input_aws_teams_stage_name"></a> [aws\_teams\_stage\_name](#input\_aws\_teams\_stage\_name) | The name of the stage where the IAM primary roles are provisioned | `string` | `"identity"` | no |
 | <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "descriptor_formats": {},<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "labels_as_tags": [<br>    "unset"<br>  ],<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {},<br>  "tenant": null<br>}</pre> | no |
 | <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between ID elements.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
 | <a name="input_descriptor_formats"></a> [descriptor\_formats](#input\_descriptor\_formats) | Describe additional descriptors to be output in the `descriptors` output map.<br>Map of maps. Keys are names of descriptors. Values are maps of the form<br>`{<br>   format = string<br>   labels = list(string)<br>}`<br>(Type is `any` so the map values can later be enhanced to provide additional options.)<br>`format` is a Terraform format string to be passed to the `format()` function.<br>`labels` is a list of labels, in order, to pass to `format()` function.<br>Label values will be normalized before being passed to `format()` so they will be<br>identical to how they appear in `id`.<br>Default is `{}` (`descriptors` output will be empty). | `any` | `{}` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | <a name="input_global_environment_name"></a> [global\_environment\_name](#input\_global\_environment\_name) | Global environment name | `string` | `"gbl"` | no |
-| <a name="input_iam_primary_roles_stage_name"></a> [iam\_primary\_roles\_stage\_name](#input\_iam\_primary\_roles\_stage\_name) | The name of the stage where the IAM primary roles are provisioned | `string` | `"identity"` | no |
+| <a name="input_global_stage_name"></a> [global\_stage\_name](#input\_global\_stage\_name) | The name of the stage where `account_map` is provisioned | `string` | `"root"` | no |
 | <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for keep the existing setting, which defaults to `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
-| <a name="input_identity_roles_accessible"></a> [identity\_roles\_accessible](#input\_identity\_roles\_accessible) | List of IAM roles (e.g. ["admin", "terraform"]) for which to create permission<br>sets that allow the user to assume that role. Named like<br>admin -> IdentityAdminRoleAccess | `set(string)` | `[]` | no |
 | <a name="input_import_role_arn"></a> [import\_role\_arn](#input\_import\_role\_arn) | IAM Role ARN to use when importing a resource | `string` | `null` | no |
 | <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | Controls the letter case of the `tags` keys (label names) for tags generated by this module.<br>Does not affect keys of tags passed in via the `tags` input.<br>Possible values: `lower`, `title`, `upper`.<br>Default value: `title`. | `string` | `null` | no |
 | <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The order in which the labels (ID elements) appear in the `id`.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present. | `list(string)` | `null` | no |
@@ -165,7 +166,6 @@ components:
 | <a name="input_privileged"></a> [privileged](#input\_privileged) | True if the default provider already has access to the backend | `bool` | `true` | no |
 | <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br>Characters matching the regex will be removed from the ID elements.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS Region | `string` | n/a | yes |
-| <a name="input_root_account_stage_name"></a> [root\_account\_stage\_name](#input\_root\_account\_stage\_name) | The name of the stage where `account_map` is provisioned | `string` | `"root"` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
 | <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |
@@ -173,7 +173,10 @@ components:
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+|------|-------------|
+| <a name="output_permission_sets"></a> [permission\_sets](#output\_permission\_sets) | Permission sets |
+| <a name="output_sso_account_assignments"></a> [sso\_account\_assignments](#output\_sso\_account\_assignments) | SSO account assignments |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## References

--- a/modules/aws-sso/README.md
+++ b/modules/aws-sso/README.md
@@ -123,10 +123,10 @@ components:
 |------|--------|---------|
 | <a name="module_account_map"></a> [account\_map](#module\_account\_map) | cloudposse/stack-config/yaml//modules/remote-state | 1.3.1 |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
-| <a name="module_permission_sets"></a> [permission\_sets](#module\_permission\_sets) | cloudposse/sso/aws//modules/permission-sets | 0.6.2 |
+| <a name="module_permission_sets"></a> [permission\_sets](#module\_permission\_sets) | cloudposse/sso/aws//modules/permission-sets | 0.7.1 |
 | <a name="module_role_prefix"></a> [role\_prefix](#module\_role\_prefix) | cloudposse/label/null | 0.25.0 |
-| <a name="module_sso_account_assignments"></a> [sso\_account\_assignments](#module\_sso\_account\_assignments) | cloudposse/sso/aws//modules/account-assignments | 0.6.2 |
-| <a name="module_sso_account_assignments_root"></a> [sso\_account\_assignments\_root](#module\_sso\_account\_assignments\_root) | cloudposse/sso/aws//modules/account-assignments | 0.6.2 |
+| <a name="module_sso_account_assignments"></a> [sso\_account\_assignments](#module\_sso\_account\_assignments) | cloudposse/sso/aws//modules/account-assignments | 0.7.1 |
+| <a name="module_sso_account_assignments_root"></a> [sso\_account\_assignments\_root](#module\_sso\_account\_assignments\_root) | cloudposse/sso/aws//modules/account-assignments | 0.7.1 |
 | <a name="module_tfstate"></a> [tfstate](#module\_tfstate) | cloudposse/stack-config/yaml//modules/remote-state | 1.3.1 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 

--- a/modules/aws-sso/main.tf
+++ b/modules/aws-sso/main.tf
@@ -1,6 +1,6 @@
 module "permission_sets" {
   source  = "cloudposse/sso/aws//modules/permission-sets"
-  version = "0.6.2"
+  version = "0.7.1"
 
   permission_sets = concat(
     local.administrator_access_permission_set,
@@ -18,7 +18,7 @@ module "permission_sets" {
 
 module "sso_account_assignments" {
   source  = "cloudposse/sso/aws//modules/account-assignments"
-  version = "0.6.2"
+  version = "0.7.1"
 
   account_assignments = local.account_assignments
   context             = module.this.context
@@ -26,7 +26,7 @@ module "sso_account_assignments" {
 
 module "sso_account_assignments_root" {
   source  = "cloudposse/sso/aws//modules/account-assignments"
-  version = "0.6.2"
+  version = "0.7.1"
 
   providers = {
     aws = aws.root

--- a/modules/aws-sso/outputs.tf
+++ b/modules/aws-sso/outputs.tf
@@ -1,0 +1,9 @@
+output "permission_sets" {
+  value       = module.permission_sets.permission_sets
+  description = "Permission sets"
+}
+
+output "sso_account_assignments" {
+  value       = module.sso_account_assignments.assignments
+  description = "SSO account assignments"
+}

--- a/modules/aws-sso/policy-AdminstratorAccess.tf
+++ b/modules/aws-sso/policy-AdminstratorAccess.tf
@@ -1,12 +1,12 @@
 locals {
   administrator_access_permission_set = [{
-    name               = "AdministratorAccess",
-    description        = "Allow Full Admininstrator access to the account",
-    relay_state        = "",
-    session_duration   = "",
-    tags               = {},
-    inline_policy      = ""
-    policy_attachments = ["arn:${local.aws_partition}:iam::aws:policy/AdministratorAccess"]
+    name                                = "AdministratorAccess",
+    description                         = "Allow Full Admininstrator access to the account",
+    relay_state                         = "",
+    session_duration                    = "",
+    tags                                = {},
+    inline_policy                       = ""
+    policy_attachments                  = ["arn:${local.aws_partition}:iam::aws:policy/AdministratorAccess"]
     customer_managed_policy_attachments = []
   }]
 }

--- a/modules/aws-sso/policy-AdminstratorAccess.tf
+++ b/modules/aws-sso/policy-AdminstratorAccess.tf
@@ -7,5 +7,6 @@ locals {
     tags               = {},
     inline_policy      = ""
     policy_attachments = ["arn:${local.aws_partition}:iam::aws:policy/AdministratorAccess"]
+    customer_managed_policy_attachments = []
   }]
 }

--- a/modules/aws-sso/policy-AdminstratorAccess.tf
+++ b/modules/aws-sso/policy-AdminstratorAccess.tf
@@ -1,7 +1,7 @@
 locals {
   administrator_access_permission_set = [{
     name                                = "AdministratorAccess",
-    description                         = "Allow Full Admininstrator access to the account",
+    description                         = "Allow Full Administrator access to the account",
     relay_state                         = "",
     session_duration                    = "",
     tags                                = {},

--- a/modules/aws-sso/policy-BillingAdministratorAccess.tf
+++ b/modules/aws-sso/policy-BillingAdministratorAccess.tf
@@ -10,5 +10,6 @@ locals {
       "arn:${local.aws_partition}:iam::aws:policy/job-function/Billing",
       "arn:${local.aws_partition}:iam::aws:policy/AWSSupportAccess",
     ]
+    customer_managed_policy_attachments = []
   }]
 }

--- a/modules/aws-sso/policy-BillingReadOnlyAccess.tf
+++ b/modules/aws-sso/policy-BillingReadOnlyAccess.tf
@@ -10,5 +10,6 @@ locals {
       "arn:${local.aws_partition}:iam::aws:policy/AWSBillingReadOnlyAccess",
       "arn:${local.aws_partition}:iam::aws:policy/AWSSupportAccess",
     ]
+    customer_managed_policy_attachments = []
   }]
 }

--- a/modules/aws-sso/policy-DNSAdministratorAccess.tf
+++ b/modules/aws-sso/policy-DNSAdministratorAccess.tf
@@ -27,13 +27,13 @@ data "aws_iam_policy_document" "dns_administrator_access" {
 
 locals {
   dns_administrator_access_permission_set = [{
-    name               = "DNSRecordAdministratorAccess",
-    description        = "Allow DNS Record Admininstrator access to the account, but not zone administration",
-    relay_state        = "https://console.aws.amazon.com/route53/",
-    session_duration   = "",
-    tags               = {},
-    inline_policy      = data.aws_iam_policy_document.dns_administrator_access.json,
-    policy_attachments = ["arn:${local.aws_partition}:iam::aws:policy/AWSSupportAccess"]
+    name                                = "DNSRecordAdministratorAccess",
+    description                         = "Allow DNS Record Admininstrator access to the account, but not zone administration",
+    relay_state                         = "https://console.aws.amazon.com/route53/",
+    session_duration                    = "",
+    tags                                = {},
+    inline_policy                       = data.aws_iam_policy_document.dns_administrator_access.json,
+    policy_attachments                  = ["arn:${local.aws_partition}:iam::aws:policy/AWSSupportAccess"]
     customer_managed_policy_attachments = []
   }]
 }

--- a/modules/aws-sso/policy-DNSAdministratorAccess.tf
+++ b/modules/aws-sso/policy-DNSAdministratorAccess.tf
@@ -34,5 +34,6 @@ locals {
     tags               = {},
     inline_policy      = data.aws_iam_policy_document.dns_administrator_access.json,
     policy_attachments = ["arn:${local.aws_partition}:iam::aws:policy/AWSSupportAccess"]
+    customer_managed_policy_attachments = []
   }]
 }

--- a/modules/aws-sso/policy-Identity-role-RoleAccess.tf
+++ b/modules/aws-sso/policy-Identity-role-RoleAccess.tf
@@ -4,7 +4,7 @@
 # plus ViewOnly access because it is difficult to navigate without any access at all.
 
 locals {
-  identity_account = module.account_map.outputs.full_account_map[var.iam_primary_roles_stage_name]
+  identity_account = module.account_map.outputs.full_account_map[var.iam_primary_roles_account_name]
 }
 
 module "role_prefix" {

--- a/modules/aws-sso/policy-Identity-role-RoleAccess.tf
+++ b/modules/aws-sso/policy-Identity-role-RoleAccess.tf
@@ -54,13 +54,13 @@ data "aws_iam_policy_document" "assume_identity_role" {
 
 locals {
   identity_access_permission_sets = [for role in var.identity_roles_accessible : {
-    name               = format("Identity%sRoleAccess", title(role)),
-    description        = "Allow user to assume %s role in Identity account, which allows access to other accounts",
-    relay_state        = "",
-    session_duration   = "",
-    tags               = {},
-    inline_policy      = data.aws_iam_policy_document.assume_identity_role[role].json
-    policy_attachments = ["arn:${local.aws_partition}:iam::aws:policy/job-function/ViewOnlyAccess"]
+    name                                = format("Identity%sRoleAccess", title(role)),
+    description                         = "Allow user to assume %s role in Identity account, which allows access to other accounts",
+    relay_state                         = "",
+    session_duration                    = "",
+    tags                                = {},
+    inline_policy                       = data.aws_iam_policy_document.assume_identity_role[role].json
+    policy_attachments                  = ["arn:${local.aws_partition}:iam::aws:policy/job-function/ViewOnlyAccess"]
     customer_managed_policy_attachments = []
   }]
 }

--- a/modules/aws-sso/policy-Identity-role-RoleAccess.tf
+++ b/modules/aws-sso/policy-Identity-role-RoleAccess.tf
@@ -61,5 +61,6 @@ locals {
     tags               = {},
     inline_policy      = data.aws_iam_policy_document.assume_identity_role[role].json
     policy_attachments = ["arn:${local.aws_partition}:iam::aws:policy/job-function/ViewOnlyAccess"]
+    customer_managed_policy_attachments = []
   }]
 }

--- a/modules/aws-sso/policy-Identity-role-RoleAccess.tf
+++ b/modules/aws-sso/policy-Identity-role-RoleAccess.tf
@@ -4,7 +4,7 @@
 # plus ViewOnly access because it is difficult to navigate without any access at all.
 
 locals {
-  identity_account = module.account_map.outputs.full_account_map[var.iam_primary_roles_account_name]
+  identity_account = module.account_map.outputs.full_account_map[module.account_map.outputs.identity_account_account_name]
 }
 
 module "role_prefix" {

--- a/modules/aws-sso/policy-Identity-role-TeamAccess.tf
+++ b/modules/aws-sso/policy-Identity-role-TeamAccess.tf
@@ -1,6 +1,6 @@
 
 # This file generates a permission set for each role specified in var.target_identity_roles
-# which is named "Identity<Role>RoleAccess" and grants access to only that role,
+# which is named "Identity<Role>TeamAccess" and grants access to only that role,
 # plus ViewOnly access because it is difficult to navigate without any access at all.
 
 locals {
@@ -11,13 +11,13 @@ module "role_prefix" {
   source  = "cloudposse/label/null"
   version = "0.25.0"
 
-  stage = var.iam_primary_roles_stage_name
+  stage = var.aws_teams_stage_name
 
   context = module.this.context
 }
 
-data "aws_iam_policy_document" "assume_identity_role" {
-  for_each = local.enabled ? var.identity_roles_accessible : []
+data "aws_iam_policy_document" "assume_aws_team" {
+  for_each = local.enabled ? var.aws_teams_accessible : []
 
   statement {
     sid = "RoleAssumeRole"
@@ -53,13 +53,13 @@ data "aws_iam_policy_document" "assume_identity_role" {
 }
 
 locals {
-  identity_access_permission_sets = [for role in var.identity_roles_accessible : {
-    name                                = format("Identity%sRoleAccess", title(role)),
-    description                         = "Allow user to assume %s role in Identity account, which allows access to other accounts",
+  identity_access_permission_sets = [for role in var.aws_teams_accessible : {
+    name                                = format("Identity%sTeamAccess", title(role)),
+    description                         = format("Allow user to assume the %s Team role in the Identity account, which allows access to other accounts", title(role))
     relay_state                         = "",
     session_duration                    = "",
     tags                                = {},
-    inline_policy                       = data.aws_iam_policy_document.assume_identity_role[role].json
+    inline_policy                       = data.aws_iam_policy_document.assume_aws_team[role].json
     policy_attachments                  = ["arn:${local.aws_partition}:iam::aws:policy/job-function/ViewOnlyAccess"]
     customer_managed_policy_attachments = []
   }]

--- a/modules/aws-sso/policy-PoweruserAccess.tf
+++ b/modules/aws-sso/policy-PoweruserAccess.tf
@@ -10,5 +10,6 @@ locals {
       "arn:${local.aws_partition}:iam::aws:policy/PowerUserAccess",
       "arn:${local.aws_partition}:iam::aws:policy/AWSSupportAccess",
     ]
+    customer_managed_policy_attachments = []
   }]
 }

--- a/modules/aws-sso/policy-ReadOnlyAccess.tf
+++ b/modules/aws-sso/policy-ReadOnlyAccess.tf
@@ -10,5 +10,6 @@ locals {
       "arn:${local.aws_partition}:iam::aws:policy/ReadOnlyAccess",
       "arn:${local.aws_partition}:iam::aws:policy/AWSSupportAccess",
     ]
+    customer_managed_policy_attachments = []
   }]
 }

--- a/modules/aws-sso/policy-TerraformUpdateAccess.tf
+++ b/modules/aws-sso/policy-TerraformUpdateAccess.tf
@@ -19,13 +19,13 @@ data "aws_iam_policy_document" "TerraformUpdateAccess" {
 
 locals {
   terraform_update_access_permission_set = [{
-    name               = "TerraformUpdateAccess",
-    description        = "Allow access to Terraform state sufficient to make changes",
-    relay_state        = "",
-    session_duration   = "PT1H", # One hour, maximum allowed for chained assumed roles
-    tags               = {},
-    inline_policy      = data.aws_iam_policy_document.TerraformUpdateAccess.json,
-    policy_attachments = []
+    name                                = "TerraformUpdateAccess",
+    description                         = "Allow access to Terraform state sufficient to make changes",
+    relay_state                         = "",
+    session_duration                    = "PT1H", # One hour, maximum allowed for chained assumed roles
+    tags                                = {},
+    inline_policy                       = data.aws_iam_policy_document.TerraformUpdateAccess.json,
+    policy_attachments                  = []
     customer_managed_policy_attachments = []
   }]
 }

--- a/modules/aws-sso/policy-TerraformUpdateAccess.tf
+++ b/modules/aws-sso/policy-TerraformUpdateAccess.tf
@@ -26,5 +26,6 @@ locals {
     tags               = {},
     inline_policy      = data.aws_iam_policy_document.TerraformUpdateAccess.json,
     policy_attachments = []
+    customer_managed_policy_attachments = []
   }]
 }

--- a/modules/aws-sso/remote-state.tf
+++ b/modules/aws-sso/remote-state.tf
@@ -4,7 +4,7 @@ module "account_map" {
 
   component   = "account-map"
   environment = var.global_environment_name
-  stage       = var.root_account_stage_name
+  stage       = var.global_stage_name
   privileged  = var.privileged
 
   context = module.this.context
@@ -16,7 +16,7 @@ module "tfstate" {
 
   component   = "tfstate-backend"
   environment = var.tfstate_environment_name
-  stage       = var.root_account_stage_name
+  stage       = var.global_stage_name
   privileged  = var.privileged
 
   context = module.this.context

--- a/modules/aws-sso/variables.tf
+++ b/modules/aws-sso/variables.tf
@@ -13,7 +13,8 @@ variable "global_environment_name" {
   description = "Global environment name"
   default     = "gbl"
 }
-variable "root_account_stage_name" {
+
+variable "global_stage_name" {
   type        = string
   description = "The name of the stage where `account_map` is provisioned"
   default     = "root"
@@ -49,18 +50,18 @@ variable "account_assignments" {
   default     = {}
 }
 
-variable "iam_primary_roles_stage_name" {
+variable "aws_teams_stage_name" {
   type        = string
   description = "The name of the stage where the IAM primary roles are provisioned"
   default     = "identity"
 }
 
-variable "identity_roles_accessible" {
+variable "aws_teams_accessible" {
   type        = set(string)
   description = <<-EOT
     List of IAM roles (e.g. ["admin", "terraform"]) for which to create permission
     sets that allow the user to assume that role. Named like
-    admin -> IdentityAdminRoleAccess
+    admin -> IdentityAdminTeamAccess
     EOT
   default     = []
 }


### PR DESCRIPTION
## what
* Upgraded `aws-sso` to use `0.7.1` modules
* Updated `account-map/modules/roles-to-principals` to support assume role from SSO users in the identity account
* Adjusted `aws-sso/policy-Identity-role-RoleAccess.tf` to use the identity account name vs the stage so it supports names like `core-identity` instead of just `identity`

## why
* `aws-sso` users could not assume role to plan/apply terraform locally
* using `core-identity` as a name broke the `aws-sso` policy since account `identity` does not exist in `full_account_map`

## references
