### PR TITLE
github-runners add support for runner groups

### DIFF
--- a/modules/github-runners/README.md
+++ b/modules/github-runners/README.md
@@ -13,16 +13,16 @@ components:
   terraform:
     github-runners:
       vars:
-        github_scope: company
-        instance_type: "t3.small"
-        min_size: 1
-        max_size: 10
-        default_cooldown: 300
-        scale_down_cooldown_seconds: 2700
-        wait_for_capacity_timeout: 10m
         cpu_utilization_high_threshold_percent: 5
         cpu_utilization_low_threshold_percent: 1
-        spot_maxprice: 0.02
+        default_cooldown: 300
+        github_scope: company
+        instance_type: "t3.small"
+        max_size: 10
+        min_size: 1
+        runner_group: default
+        scale_down_cooldown_seconds: 2700
+        wait_for_capacity_timeout: 10m
         mixed_instances_policy:
           instances_distribution:
             on_demand_allocation_strategy: "prioritized"

--- a/modules/github-runners/README.md
+++ b/modules/github-runners/README.md
@@ -151,6 +151,7 @@ chamber write github/runners/<github-org> registration-token ghp_secretstring
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique | `string` | `null` | no |
 | <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br>Characters matching the regex will be removed from the ID elements.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS Region | `string` | n/a | yes |
+| <a name="input_runner_group"></a> [runner\_group](#input\_runner\_group) | GitHub runner group | `string` | `"default"` | no |
 | <a name="input_runner_labels"></a> [runner\_labels](#input\_runner\_labels) | List of labels to add to the GitHub Runner (e.g. 'Amazon Linux 2'). | `list(string)` | `[]` | no |
 | <a name="input_runner_role_additional_policy_arns"></a> [runner\_role\_additional\_policy\_arns](#input\_runner\_role\_additional\_policy\_arns) | List of policy ARNs that will be attached to the runners' default role on creation in addition to the defaults | `list(string)` | `[]` | no |
 | <a name="input_runner_version"></a> [runner\_version](#input\_runner\_version) | GitHub runner release version | `string` | `"2.288.1"` | no |

--- a/modules/github-runners/main.tf
+++ b/modules/github-runners/main.tf
@@ -73,6 +73,7 @@ data "cloudinit_config" "config" {
       pre_install            = var.userdata_pre_install
       post_install           = var.userdata_post_install
       runner_version         = var.runner_version
+      runner_group           = var.runner_group
     })
   }
 }

--- a/modules/github-runners/templates/user-data.sh
+++ b/modules/github-runners/templates/user-data.sh
@@ -64,4 +64,4 @@ export USER=root
 ${post_install}
 
 ls -la /tmp
-/tmp/create-latest-svc.sh ${github_scope} "" $NODE_NAME $USER $LABELS
+/tmp/create-latest-svc.sh ${github_scope} "" $NODE_NAME $USER $LABELS ${runner_group}

--- a/modules/github-runners/variables.tf
+++ b/modules/github-runners/variables.tf
@@ -137,6 +137,12 @@ variable "runner_labels" {
   description = "List of labels to add to the GitHub Runner (e.g. 'Amazon Linux 2')."
 }
 
+variable "runner_group" {
+  type        = string
+  default     = "default"
+  description = "GitHub runner group"
+}
+
 variable "runner_role_additional_policy_arns" {
   type        = list(string)
   default     = []


### PR DESCRIPTION
## what
* Added optional support for separating runners by groups

NOTE: I don't know if the default of `default` is valid or if it is `Default`. I'll confirm this soon.

## why
* Groups are supported by GitHub and allow for Actions to target specific runners by group vs by label

## references

* https://docs.github.com/en/actions/hosting-your-own-runners/managing-access-to-self-hosted-runners-using-groups