### PR TITLE
`spacelift-worker-pool` README update and AMI limits

### DIFF
--- a/modules/spacelift-worker-pool/README.md
+++ b/modules/spacelift-worker-pool/README.md
@@ -36,10 +36,15 @@ components:
       vars:
         enabled: true
         name: "spacelift-worker-pool"
-        ec2_instance_type: m6i.large
-        ecr_account_name: corp
+        cpu_utilization_high_threshold_percent: 60
+        cpu_utilization_low_threshold_percent: 20
         ecr_repo_name: infrastructure
+        # ecr_tenant_name: core # optional
+        instance_type: m6i.large
+        max_size: 6
+        min_size: 1
         spacelift_api_endpoint: https://<GITHUBORG>.app.spacelift.io
+        wait_for_capacity_timeout: 5m
 ```
 
 ## Configuration

--- a/modules/spacelift-worker-pool/data.tf
+++ b/modules/spacelift-worker-pool/data.tf
@@ -19,7 +19,7 @@ data "aws_ami" "spacelift" {
 
   filter {
     name   = "name"
-    values = ["spacelift-*"]
+    values = ["spacelift-*-x86_64*"]
   }
 
   filter {


### PR DESCRIPTION
## what
* Limited the AMI to `x86_64`. This might not be required so can remove this from the PR, if necessary.
* Updated the README to include other required vars

## why
* The AMI search would retrieve arm64 and fail to deploy

## references
