### PR TITLE
Set spacelift-worker-pool ami explicitly to x86_64

### DIFF
--- a/modules/spacelift-worker-pool/data.tf
+++ b/modules/spacelift-worker-pool/data.tf
@@ -31,4 +31,9 @@ data "aws_ami" "spacelift" {
     name   = "virtualization-type"
     values = ["hvm"]
   }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
 }


### PR DESCRIPTION
## why
* autoscaling group for spacelift-worker-pool will fail to launch when new arm64 images return first
* arm64 ami image is being returned first at the moment in us-east-1

## what
* set spacelift-worker-pool ami statically to return only x86_64 results

## references
* #575 
* Note: this is an alternative to #573 which I read after, but I think this filter approach will be more easily be refactored into setting this as an attribute in variables.tf in the near future
