### PR TITLE
`datadog-monitors`: Team Grouping

### DIFF
--- a/modules/datadog-monitor/catalog/monitors/aurora.yaml
+++ b/modules/datadog-monitor/catalog/monitors/aurora.yaml
@@ -5,7 +5,7 @@ aurora-replica-lag:
   name: "(RDS) ${tenant} ${stage} - Aurora Replica Lag Detected"
   type: metric alert
   query: |
-    min(last_15m):min:aws.rds.aurora_replica_lag{stage:${ stage }} by {dbinstanceidentifier,stage,tenant,environment} > 1000
+    min(last_15m):min:aws.rds.aurora_replica_lag{stage:${ stage }} by {dbinstanceidentifier,stage,tenant,environment,team} > 1000
   message: |
     ({{tenant.name}}-{{environment.name}}-{{stage.name}})
     {{#is_warning}}

--- a/modules/datadog-monitor/catalog/monitors/ec2.yaml
+++ b/modules/datadog-monitor/catalog/monitors/ec2.yaml
@@ -5,7 +5,7 @@ ec2-failed-status-check:
   name: "(EC2) ${tenant} ${ stage } - Failed Status Check"
   type: metric alert
   query: |
-    avg(last_10m):avg:aws.ec2.status_check_failed{stage:${ stage }} by {instance_id,stage,tenant,environment} > 0
+    avg(last_10m):avg:aws.ec2.status_check_failed{stage:${ stage }} by {instance_id,stage,tenant,environment,team} > 0
   message: |
     ({{tenant.name}}-{{environment.name}}-{{stage.name}}) {{instance_id}} failed a status check
   escalation_message: ""

--- a/modules/datadog-monitor/catalog/monitors/efs.yaml
+++ b/modules/datadog-monitor/catalog/monitors/efs.yaml
@@ -5,7 +5,7 @@ efs-throughput-utilization-check:
   name: "(EFS) ${tenant} ${ stage } - % Throughput Utilization"
   type: metric alert
   query: |
-    avg(last_1h):(sum:aws.efs.metered_iobytes{stage:${ stage }} by {filesystemid} * 100 / 1048576) / (sum:aws.efs.permitted_throughput{stage:${ stage }} by {filesystemid,stage,tenant,environment} / 1048576) > 75
+    avg(last_1h):(sum:aws.efs.metered_iobytes{stage:${ stage }} by {filesystemid} * 100 / 1048576) / (sum:aws.efs.permitted_throughput{stage:${ stage }} by {filesystemid,stage,tenant,environment,team} / 1048576) > 75
   message: |
     ({{tenant.name}}-{{environment.name}}-{{stage.name}}) {{filesystemid}} Throughput Utilization is too high
   escalation_message: ""
@@ -39,7 +39,7 @@ efs-burst-balance:
   name: "(EFS) ${tenant} ${ stage } - Burst Balance Low (< 100 GB)"
   type: metric alert
   query: |
-    min(last_1h):avg:aws.efs.burst_credit_balance{stage:${ stage }} by {filesystemid,stage,tenant,environment} < 100000000000
+    min(last_1h):avg:aws.efs.burst_credit_balance{stage:${ stage }} by {filesystemid,stage,tenant,environment,team} < 100000000000
   message: |
     ({{tenant.name}}-{{environment.name}}-{{stage.name}}) {{filesystemid}} EFS Burst Balance for {{filesystemid}} dipped below 100 GB.
   escalation_message: ""
@@ -71,7 +71,7 @@ efs-io-percent-limit:
   name: "(EFS) ${tenant} ${ stage } - I/O limit has been reached (> 90%)"
   type: metric alert
   query: |
-    max(last_1h):avg:aws.efs.percent_iolimit{stage:${ stage }} by {filesystemid,stage,tenant,environment} > 90
+    max(last_1h):avg:aws.efs.percent_iolimit{stage:${ stage }} by {filesystemid,stage,tenant,environment,team} > 90
   message: |
     ({{tenant.name}}-{{environment.name}}-{{stage.name}}) {{filesystemid}} EFS I/O limit has been reached for fs {{filesystemid}}.
   escalation_message: ""
@@ -102,7 +102,7 @@ efs-client-connection-anomaly:
   name: "(EFS) ${tenant} ${ stage } - Client Connection Anomaly"
   type: metric alert
   query: |
-    avg(last_4h):anomalies(avg:aws.efs.client_connections{stage:${ stage }} by {aws_account,filesystemid,name,stage,tenant,environment}.as_count(), 'basic', 2, direction='both', alert_window='last_15m', interval=60, count_default_zero='true') >= 1
+    avg(last_4h):anomalies(avg:aws.efs.client_connections{stage:${ stage }} by {aws_account,filesystemid,name,stage,tenant,environment,team}.as_count(), 'basic', 2, direction='both', alert_window='last_15m', interval=60, count_default_zero='true') >= 1
   message: |
     ({{tenant.name}}-{{environment.name}}-{{stage.name}}) [{{name}}] EFS Client Connection Anomoly for filesystem {{filesystemid}}.
   escalation_message: ""

--- a/modules/datadog-monitor/catalog/monitors/elb.yaml
+++ b/modules/datadog-monitor/catalog/monitors/elb.yaml
@@ -2,7 +2,7 @@ elb-lb-httpcode-5xx-notify:
   name: "(ELB) ${tenant} ${ stage } HTTP 5XX client error detected"
   type: query alert
   query: |
-    avg(last_15m):max:aws.elb.httpcode_elb_5xx{${context_dd_tags}} by {env,host,stage,tenant,environment} > 50
+    avg(last_15m):max:aws.elb.httpcode_elb_5xx{${context_dd_tags}} by {env,host,stage,tenant,environment,team} > 50
   message: |
     ({{tenant.name}}-{{environment.name}}-{{stage.name}}) lb:[ {{host}} ]
     {{#is_warning}}

--- a/modules/datadog-monitor/catalog/monitors/host.yaml
+++ b/modules/datadog-monitor/catalog/monitors/host.yaml
@@ -4,7 +4,7 @@
 host-io-wait-times:
   name: "(Host) ${tenant} ${ stage } - I/O Wait Times"
   type: metric alert
-  query: "avg(last_10m):avg:system.cpu.iowait{stage:${ stage }} by {host,stage,tenant,environment} > 50"
+  query: "avg(last_10m):avg:system.cpu.iowait{stage:${ stage }} by {host,stage,tenant,environment,team} > 50"
   message: |-
     The I/O wait time for ({{host.name}} {{host.ip}}) is very high
   escalation_message: ""
@@ -30,7 +30,7 @@ host-io-wait-times:
 host-disk-use:
   name: "(Host) ${tenant} ${ stage } - Host Disk Usage"
   type: metric alert
-  query: "avg(last_30m):(avg:system.disk.total{stage:${ stage }} by {host,stage,tenant,environment} - avg:system.disk.free{stage:${ stage }} by {host}) / avg:system.disk.total{stage:${ stage }} by {host} * 100 > 90"
+  query: "avg(last_30m):(avg:system.disk.total{stage:${ stage }} by {host,stage,tenant,environment,team} - avg:system.disk.free{stage:${ stage }} by {host}) / avg:system.disk.total{stage:${ stage }} by {host} * 100 > 90"
   message: |-
     Disk Usage has been above threshold over 30 minutes on ({{host.name}} {{host.ip}})
   escalation_message: ""
@@ -60,7 +60,7 @@ host-disk-use:
 host-high-mem-use:
   name: "(Host) ${tenant} ${ stage } - Memory Utilization"
   type: query alert
-  query: "avg(last_15m):avg:system.mem.pct_usable{stage:${ stage }} by {host,stage,tenant,environment} < 0.1"
+  query: "avg(last_15m):avg:system.mem.pct_usable{stage:${ stage }} by {host,stage,tenant,environment,team} < 0.1"
   message: |-
     Running out of free memory on ({{host.name}} {{host.ip}})
   escalation_message: ""
@@ -90,7 +90,7 @@ host-high-mem-use:
 host-high-load-avg:
   name: "(Host) ${tenant} ${ stage } - High System Load Average"
   type: metric alert
-  query: "avg(last_30m):avg:system.load.norm.5{stage:${ stage }} by {host,stage,tenant,environment} > 0.8"
+  query: "avg(last_30m):avg:system.load.norm.5{stage:${ stage }} by {host,stage,tenant,environment,team} > 0.8"
   message: |-
     ({{tenant.name}}-{{environment.name}}-{{stage.name}}) Load average is high on ({{host.name}} {{host.ip}})
   escalation_message: ""

--- a/modules/datadog-monitor/catalog/monitors/k8s.yaml
+++ b/modules/datadog-monitor/catalog/monitors/k8s.yaml
@@ -5,7 +5,7 @@ k8s-deployment-replica-pod-down:
   name: "(k8s) ${tenant} ${ stage } - Deployment Replica Pod is down"
   type: query alert
   query: |
-    avg(last_15m):avg:kubernetes_state.deployment.replicas_desired{stage:${ stage }} by {cluster_name,deployment,stage,tenant,environment} - avg:kubernetes_state.deployment.replicas_ready{stage:${ stage }} by {cluster_name,deployment,stage,tenant,environment} >= 2
+    avg(last_15m):avg:kubernetes_state.deployment.replicas_desired{stage:${ stage }} by {cluster_name,deployment,stage,tenant,environment,team} - avg:kubernetes_state.deployment.replicas_ready{stage:${ stage }} by {cluster_name,deployment,stage,tenant,environment,team} >= 2
   message: |
     ({{tenant.name}}-{{environment.name}}-{{stage.name}}) [{{cluster_name.name}}] More than one Deployments Replica's pods are down on {{deployment.name}}
   escalation_message: ""
@@ -31,7 +31,7 @@ k8s-pod-restarting:
   name: "(k8s) ${tenant} ${ stage } - Pods are restarting multiple times"
   type: query alert
   query: |
-    change(sum(last_5m),last_5m):exclude_null(avg:kubernetes.containers.restarts{stage:${ stage }} by {cluster_name,kube_namespace,pod_name,stage,tenant,environment}) > 5
+    change(sum(last_5m),last_5m):exclude_null(avg:kubernetes.containers.restarts{stage:${ stage }} by {cluster_name,kube_namespace,pod_name,stage,tenant,environment,team}) > 5
   message: |
     ({{tenant.name}}-{{environment.name}}-{{stage.name}}) [{{cluster_name.name}}] pod {{pod_name.name}} is restarting multiple times on {{kube_namespace.name}}
   escalation_message: ""
@@ -58,7 +58,7 @@ k8s-statefulset-replica-down:
   name: "(k8s) ${tenant} ${ stage } - StatefulSet Replica Pod is down"
   type: query alert
   query: |
-    max(last_15m):sum:kubernetes_state.statefulset.replicas_desired{stage:${ stage }} by {cluster_name,kube_namespace,statefulset,stage,tenant,environment} - sum:kubernetes_state.statefulset.replicas_ready{stage:${ stage }} by {cluster_name,kube_namespace,statefulset,stage,tenant,environment} >= 2
+    max(last_15m):sum:kubernetes_state.statefulset.replicas_desired{stage:${ stage }} by {cluster_name,kube_namespace,statefulset,stage,tenant,environment,team} - sum:kubernetes_state.statefulset.replicas_ready{stage:${ stage }} by {cluster_name,kube_namespace,statefulset,stage,tenant,environment,team} >= 2
   message: |
     ({{tenant.name}}-{{environment.name}}-{{stage.name}}) [{{cluster_name.name}} {{statefulset.name}}] More than one StatefulSet Replica's pods are down on {{kube_namespace.name}}
   escalation_message: ""
@@ -86,7 +86,7 @@ k8s-daemonset-pod-down:
   name: "(k8s) ${tenant} ${ stage } - DaemonSet Pod is down"
   type: query alert
   query: |
-    max(last_15m):sum:kubernetes_state.daemonset.desired{stage:${ stage }} by {cluster_name,kube_namespace,daemonset,stage,tenant,environment} - sum:kubernetes_state.daemonset.ready{stage:${ stage }} by {cluster_name,kube_namespace,daemonset,stage,tenant,environment} >= 1
+    max(last_15m):sum:kubernetes_state.daemonset.desired{stage:${ stage }} by {cluster_name,kube_namespace,daemonset,stage,tenant,environment,team} - sum:kubernetes_state.daemonset.ready{stage:${ stage }} by {cluster_name,kube_namespace,daemonset,stage,tenant,environment,team} >= 1
   message: |
     ({{tenant.name}}-{{environment.name}}-{{stage.name}}) [{{cluster_name.name}} {{daemonset.name}}] One or more DaemonSet pods are down on {{kube_namespace.name}}
   escalation_message: ""
@@ -112,7 +112,7 @@ k8s-crashloopBackOff:
   name: "(k8s) ${tenant} ${ stage } - CrashloopBackOff detected"
   type: query alert
   query: |
-    max(last_10m):max:kubernetes_state.container.status_report.count.waiting{stage:${ stage },reason:crashloopbackoff} by {cluster_name,kube_namespace,pod_name,stage,tenant,environment} >= 1
+    max(last_10m):max:kubernetes_state.container.status_report.count.waiting{stage:${ stage },reason:crashloopbackoff} by {cluster_name,kube_namespace,pod_name,stage,tenant,environment,team} >= 1
   message: |
     ({{tenant.name}}-{{environment.name}}-{{stage.name}}) [{{cluster_name.name}}] pod {{pod_name.name}} is CrashloopBackOff on {{kube_namespace.name}}
   escalation_message: ""
@@ -138,7 +138,7 @@ k8s-multiple-pods-failing:
   name: "(k8s) ${tenant} ${ stage } - Multiple Pods are failing"
   type: query alert
   query: |
-    change(avg(last_5m),last_5m):sum:kubernetes_state.pod.status_phase{stage:${ stage },phase:failed} by {cluster_name,kube_namespace,stage,tenant,environment} > 10
+    change(avg(last_5m),last_5m):sum:kubernetes_state.pod.status_phase{stage:${ stage },phase:failed} by {cluster_name,kube_namespace,stage,tenant,environment,team} > 10
   message: |
     ({{tenant.name}}-{{environment.name}}-{{stage.name}}) [{{cluster_name.name}}] More than ten pods are failing on {{kube_namespace.name}}
   escalation_message: ""
@@ -165,7 +165,7 @@ k8s-unavailable-deployment-replica:
   name: "(k8s) ${tenant} ${ stage } - Unavailable Deployment Replica(s) detected"
   type: metric alert
   query: |
-    max(last_10m):max:kubernetes_state.deployment.replicas_unavailable{stage:${ stage }} by {cluster_name,kube_namespace,stage,tenant,environment} > 0
+    max(last_10m):max:kubernetes_state.deployment.replicas_unavailable{stage:${ stage }} by {cluster_name,kube_namespace,stage,tenant,environment,team} > 0
   message: |
     ({{tenant.name}}-{{environment.name}}-{{stage.name}}) [{{cluster_name.name}}] Detected unavailable Deployment replicas for longer than 10 minutes on {{kube_namespace.name}}
   escalation_message: ""
@@ -196,7 +196,7 @@ k8s-unavailable-statefulset-replica:
   name: "(k8s) ${tenant} ${ stage } - Unavailable Statefulset Replica(s) detected"
   type: metric alert
   query: |
-    max(last_10m):max:kubernetes_state.statefulset.replicas_unavailable{stage:${ stage }} by {cluster_name,kube_namespace,stage,tenant,environment} > 0
+    max(last_10m):max:kubernetes_state.statefulset.replicas_unavailable{stage:${ stage }} by {cluster_name,kube_namespace,stage,tenant,environment,team} > 0
   message: |
     ({{tenant.name}}-{{environment.name}}-{{stage.name}}) [{{cluster_name.name}}] Detected unavailable Statefulset replicas for longer than 10 minutes on {{kube_namespace.name}}
   escalation_message: ""
@@ -227,7 +227,7 @@ k8s-node-status-unschedulable:
   name: "(k8s) ${tenant} ${ stage } - Detected Unschedulable Node(s)"
   type: query alert
   query: |
-    max(last_15m):sum:kubernetes_state.node.status{stage:${ stage },status:schedulable} by {cluster_name} * 100 / sum:kubernetes_state.node.status{stage:${ stage }} by {cluster_name,stage,tenant,environment} < 80
+    max(last_15m):sum:kubernetes_state.node.status{stage:${ stage },status:schedulable} by {cluster_name} * 100 / sum:kubernetes_state.node.status{stage:${ stage }} by {cluster_name,stage,tenant,environment,team} < 80
   message: |
     ({{tenant.name}}-{{environment.name}}-{{stage.name}}) [{{cluster_name.name}}] More than 20% of nodes are unschedulable on the cluster. \n Keep in mind that this might be expected based on your infrastructure.
   escalation_message: ""
@@ -258,7 +258,7 @@ k8s-imagepullbackoff:
   name: "(k8s) ${tenant} ${ stage } - ImagePullBackOff detected"
   type: "query alert"
   query: |
-    max(last_10m):max:kubernetes_state.container.status_report.count.waiting{reason:imagepullbackoff,stage:${ stage }} by {kube_cluster_name,kube_namespace,pod_name,stage,tenant,environment} >= 1
+    max(last_10m):max:kubernetes_state.container.status_report.count.waiting{reason:imagepullbackoff,stage:${ stage }} by {kube_cluster_name,kube_namespace,pod_name,stage,tenant,environment,team} >= 1
   message: |
     ({{tenant.name}}-{{environment.name}}-{{stage.name}}) [{{cluster_name.name}}] Pod {{pod_name.name}} is ImagePullBackOff on namespace {{kube_namespace.name}}
   escalation_message: ""
@@ -289,7 +289,7 @@ k8s-high-cpu-usage:
   name: "(k8s) ${tenant} ${ stage } - High CPU Usage Detected"
   type: metric alert
   query: |
-    avg(last_10m):avg:system.cpu.system{stage:${ stage }} by {host,stage,tenant,environment} > 90
+    avg(last_10m):avg:system.cpu.system{stage:${ stage }} by {host,stage,tenant,environment,team} > 90
   message: |
     ({{tenant.name}}-{{environment.name}}-{{stage.name}}) [{{cluster_name.name}} {{host.cluster_name}}] High CPU usage for the last 10 minutes on {{host.name}}
   escalation_message: ""
@@ -320,7 +320,7 @@ k8s-high-disk-usage:
   name: "(k8s) ${tenant} ${ stage } - High Disk Usage Detected"
   type: metric alert
   query: |
-    min(last_5m):min:system.disk.used{stage:${ stage }} by {host,cluster_name,stage,tenant,environment} / avg:system.disk.total{stage:${ stage }} by {host,cluster_name,stage,tenant,environment} * 100 > 90
+    min(last_5m):min:system.disk.used{stage:${ stage }} by {host,cluster_name,stage,tenant,environment,team} / avg:system.disk.total{stage:${ stage }} by {host,cluster_name,stage,tenant,environment,team} * 100 > 90
   message: |
     ({{tenant.name}}-{{environment.name}}-{{stage.name}}) [{{cluster_name.name}}] High disk usage detected on {{host.name}}
   escalation_message: ""
@@ -351,7 +351,7 @@ k8s-high-memory-usage:
   name: "(k8s) ${tenant} ${ stage } - High Memory Usage Detected"
   type: metric alert
   query: |
-    avg(last_10m):avg:kubernetes.memory.usage_pct{stage:${ stage }} by {cluster_name,stage,tenant,environment} > 90
+    avg(last_10m):avg:kubernetes.memory.usage_pct{stage:${ stage }} by {cluster_name,stage,tenant,environment,team} > 90
   message: |
     ({{tenant.name}}-{{environment.name}}-{{stage.name}}) [{{cluster_name.name}}] High memory usage detected on {{host.name}}
     {{#is_warning}}
@@ -388,7 +388,7 @@ k8s-high-filesystem-usage:
   name: "(k8s) ${tenant} ${ stage } - High Filesystem Usage Detected"
   type: metric alert
   query: |
-    avg(last_10m):avg:kubernetes.filesystem.usage_pct{stage:${ stage }} by {cluster_name,stage,tenant,environment} > 90
+    avg(last_10m):avg:kubernetes.filesystem.usage_pct{stage:${ stage }} by {cluster_name,stage,tenant,environment,team} > 90
   message: |
     ({{tenant.name}}-{{environment.name}}-{{stage.name}}) [{{cluster_name.name}}]
     {{#is_warning}}
@@ -425,7 +425,7 @@ k8s-network-tx-errors:
   name: "(k8s) ${tenant} ${ stage } - High Network TX (send) Errors"
   type: metric alert
   query: |
-    avg(last_10m):avg:kubernetes.network.tx_errors{stage:${ stage }} by {cluster_name,stage,tenant,environment} > 100
+    avg(last_10m):avg:kubernetes.network.tx_errors{stage:${ stage }} by {cluster_name,stage,tenant,environment,team} > 100
   message: |
     ({{tenant.name}}-{{environment.name}}-{{stage.name}}) [{{cluster_name.name}}]
     {{#is_warning}}
@@ -462,7 +462,7 @@ k8s-network-rx-errors:
   name: "(k8s) ${tenant} ${ stage } - High Network RX (receive) Errors"
   type: metric alert
   query: |
-    avg(last_10m):avg:kubernetes.network.rx_errors{stage:${ stage }} by {cluster_name,stage,tenant,environment} > 100
+    avg(last_10m):avg:kubernetes.network.rx_errors{stage:${ stage }} by {cluster_name,stage,tenant,environment,team} > 100
   message: |
     ({{tenant.name}}-{{environment.name}}-{{stage.name}}) [{{cluster_name.name}}]
     {{#is_warning}}
@@ -499,7 +499,7 @@ k8s-increased-pod-crash:
   name: "(k8s) ${tenant} ${ stage } - Increased Pod Crashes"
   type: query alert
   query: |
-    avg(last_5m):avg:kubernetes_state.container.restarts{stage:${ stage }} by {cluster_name,kube_namespace,pod,stage,tenant,environment} - hour_before(avg:kubernetes_state.container.restarts{stage:${ stage }} by {cluster_name,kube_namespace,pod,stage,tenant,environment}) > 3
+    avg(last_5m):avg:kubernetes_state.container.restarts{stage:${ stage }} by {cluster_name,kube_namespace,pod,stage,tenant,environment,team} - hour_before(avg:kubernetes_state.container.restarts{stage:${ stage }} by {cluster_name,kube_namespace,pod,stage,tenant,environment,team}) > 3
   message: |-
     ({{tenant.name}}-{{environment.name}}-{{stage.name}}) [{{cluster_name.name}} {{kube_namespace.name}} {{pod.name}}] has crashed repeatedly over the last hour
   escalation_message: ""
@@ -530,7 +530,7 @@ k8s-pending-pods:
   name: "(k8s) ${tenant} ${ stage } - Pending Pods"
   type: metric alert
   query: |
-    min(last_30m):sum:kubernetes_state.pod.status_phase{stage:${ stage },phase:running} by {cluster_name,stage,tenant,environment} - sum:kubernetes_state.pod.status_phase{stage:${ stage },phase:running} by {cluster_name,stage,tenant,environment} + sum:kubernetes_state.pod.status_phase{stage:${ stage },phase:pending} by {cluster_name,stage,tenant,environment}.fill(zero) >= 1
+    min(last_30m):sum:kubernetes_state.pod.status_phase{stage:${ stage },phase:running} by {cluster_name,stage,tenant,environment,team} - sum:kubernetes_state.pod.status_phase{stage:${ stage },phase:running} by {cluster_name,stage,tenant,environment,team} + sum:kubernetes_state.pod.status_phase{stage:${ stage },phase:pending} by {cluster_name,stage,tenant,environment,team}.fill(zero) >= 1
   message: |-
     ({{tenant.name}}-{{environment.name}}-{{stage.name}}) [{{cluster_name.name}}] There has been at least 1 pod Pending for 30 minutes.
     There are currently ({{value}}) pods Pending.

--- a/modules/datadog-monitor/catalog/monitors/rabbitmq.yaml
+++ b/modules/datadog-monitor/catalog/monitors/rabbitmq.yaml
@@ -2,7 +2,7 @@ rabbitmq-messages-unacknowledged-rate-too-high:
   name: "[RabbitMQ] ${tenant} ${ stage } - Messages unacknowledged rate is higher than usual on: {{broker.name}}"
   type: "query alert"
   query: |
-    avg(last_4h):anomalies(avg:aws.amazonmq.message_unacknowledged_count{stage:${ stage }} by {broker,queue,stage,tenant,environment}, 'agile', 2, direction='above', alert_window='last_15m', interval=60, count_default_zero='true', seasonality='hourly') >= 1
+    avg(last_4h):anomalies(avg:aws.amazonmq.message_unacknowledged_count{stage:${ stage }} by {broker,queue,stage,tenant,environment,team}, 'agile', 2, direction='above', alert_window='last_15m', interval=60, count_default_zero='true', seasonality='hourly') >= 1
   message: |
     ({{tenant.name}}-{{environment.name}}-{{stage.name}})
     The rate at which messages are being delivered without receiving acknowledgement is higher than usual.
@@ -38,7 +38,7 @@ rabbitmq-memory-utilization:
   name: "[RabbitMQ] ${tenant} ${ stage } - Memory Utilization: {{broker.name}}"
   type: "query alert"
   query: |
-    avg(last_10m):avg:aws.amazonmq.rabbit_mqmem_used{stage:${ stage }} by {broker,node,stage,tenant,environment} / avg:aws.amazonmq.rabbit_mqmem_limit{stage:${ stage }} by {broker,node,stage,tenant,environment} > 0.50
+    avg(last_10m):avg:aws.amazonmq.rabbit_mqmem_used{stage:${ stage }} by {broker,node,stage,tenant,environment,team} / avg:aws.amazonmq.rabbit_mqmem_limit{stage:${ stage }} by {broker,node,stage,tenant,environment,team} > 0.50
   message: |
     ({{tenant.name}}-{{environment.name}}-{{stage.name}})
     Memory Percentage of a node in Rabbit MQ Cluster is high
@@ -72,7 +72,7 @@ rabbitmq-disk-utilization:
   name: "[RabbitMQ] ${tenant} ${ stage } - Disk Utilization: {{broker.name}}"
   type: "query alert"
   query: |
-    avg(last_10m):avg:aws.amazonmq.rabbit_mqdisk_free{stage:${ stage }} by {broker,node,stage,tenant,environment} < 100000000000
+    avg(last_10m):avg:aws.amazonmq.rabbit_mqdisk_free{stage:${ stage }} by {broker,node,stage,tenant,environment,team} < 100000000000
   message: |
     ({{tenant.name}}-{{environment.name}}-{{stage.name}})
     Free Disk Space of a node in Rabbit MQ Cluster is Less than 100 GB

--- a/modules/datadog-monitor/catalog/monitors/rds.yaml
+++ b/modules/datadog-monitor/catalog/monitors/rds.yaml
@@ -5,7 +5,7 @@ rds-cpuutilization:
   name: "(RDS) ${tenant} ${ stage } - CPU Utilization above 90%"
   type: metric alert
   query: |
-    avg(last_15m):avg:aws.rds.cpuutilization{stage:${ stage }} by {dbinstanceidentifier,stage,tenant,environment} > 90
+    avg(last_15m):avg:aws.rds.cpuutilization{stage:${ stage }} by {dbinstanceidentifier,stage,tenant,environment,team} > 90
   message: |
     ({{tenant.name}}-{{environment.name}}-{{stage.name}})
     {{#is_warning}}
@@ -42,7 +42,7 @@ rds-disk-queue-depth:
   name: "(RDS) ${tenant} ${ stage } - Disk queue depth above 64"
   type: metric alert
   query: |
-    avg(last_15m):avg:aws.rds.disk_queue_depth{stage:${ stage }} by {dbinstanceidentifier,stage,tenant,environment} > 64
+    avg(last_15m):avg:aws.rds.disk_queue_depth{stage:${ stage }} by {dbinstanceidentifier,stage,tenant,environment,team} > 64
   message: |
     ({{tenant.name}}-{{environment.name}}-{{stage.name}})
     {{#is_warning}}
@@ -116,7 +116,7 @@ rds-swap-usage:
   name: "(RDS) ${tenant} ${ stage } - Swap usage above 256 MB"
   type: metric alert
   query: |
-    avg(last_15m):avg:aws.rds.swap_usage{stage:${ stage }} by {dbinstanceidentifier,stage,tenant,environment} > 256000000
+    avg(last_15m):avg:aws.rds.swap_usage{stage:${ stage }} by {dbinstanceidentifier,stage,tenant,environment,team} > 256000000
   message: |
     ({{tenant.name}}-{{environment.name}}-{{stage.name}})
     {{#is_warning}}


### PR DESCRIPTION
## what
* grouping by team helps ensure the team tag is sent to Opsgenie

## why
* ensures most data is fed to a valid team tag instead of `@opsgenie-`

