### PR TITLE
datadog-lambda-forwarder: if s3_buckets not set, module fails

### DIFF
--- a/modules/datadog-lambda-forwarder/README.md
+++ b/modules/datadog-lambda-forwarder/README.md
@@ -64,7 +64,7 @@ components:
 |------|--------|---------|
 | <a name="module_datadog-integration"></a> [datadog-integration](#module\_datadog-integration) | cloudposse/stack-config/yaml//modules/remote-state | 1.3.1 |
 | <a name="module_datadog_configuration"></a> [datadog\_configuration](#module\_datadog\_configuration) | ../datadog-configuration/modules/datadog_keys | n/a |
-| <a name="module_datadog_lambda_forwarder"></a> [datadog\_lambda\_forwarder](#module\_datadog\_lambda\_forwarder) | cloudposse/datadog-lambda-forwarder/aws | 1.1.0 |
+| <a name="module_datadog_lambda_forwarder"></a> [datadog\_lambda\_forwarder](#module\_datadog\_lambda\_forwarder) | cloudposse/datadog-lambda-forwarder/aws | 1.2.0 |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
 | <a name="module_log_group_prefix"></a> [log\_group\_prefix](#module\_log\_group\_prefix) | cloudposse/label/null | 0.25.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |

--- a/modules/datadog-lambda-forwarder/README.md
+++ b/modules/datadog-lambda-forwarder/README.md
@@ -129,7 +129,7 @@ components:
 | <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br>Characters matching the regex will be removed from the ID elements.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS Region | `string` | n/a | yes |
 | <a name="input_s3_bucket_kms_arns"></a> [s3\_bucket\_kms\_arns](#input\_s3\_bucket\_kms\_arns) | List of KMS key ARNs for s3 bucket encryption | `list(string)` | `[]` | no |
-| <a name="input_s3_buckets"></a> [s3\_buckets](#input\_s3\_buckets) | The names and ARNs of S3 buckets to forward logs to Datadog | `list(string)` | `null` | no |
+| <a name="input_s3_buckets"></a> [s3\_buckets](#input\_s3\_buckets) | The names and ARNs of S3 buckets to forward logs to Datadog | `list(string)` | `[]` | no |
 | <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids) | List of security group IDs to use when the Lambda Function runs in a VPC | `list(string)` | `null` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | List of subnet IDs to use when deploying the Lambda Function in a VPC | `list(string)` | `null` | no |

--- a/modules/datadog-lambda-forwarder/README.md
+++ b/modules/datadog-lambda-forwarder/README.md
@@ -129,7 +129,8 @@ components:
 | <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br>Characters matching the regex will be removed from the ID elements.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS Region | `string` | n/a | yes |
 | <a name="input_s3_bucket_kms_arns"></a> [s3\_bucket\_kms\_arns](#input\_s3\_bucket\_kms\_arns) | List of KMS key ARNs for s3 bucket encryption | `list(string)` | `[]` | no |
-| <a name="input_s3_buckets"></a> [s3\_buckets](#input\_s3\_buckets) | The names and ARNs of S3 buckets to forward logs to Datadog | `list(string)` | `[]` | no |
+| <a name="input_s3_buckets"></a> [s3\_buckets](#input\_s3\_buckets) | The names of S3 buckets to forward logs to Datadog | `list(string)` | `[]` | no |
+| <a name="input_s3_buckets_with_prefixes"></a> [s3\_buckets\_with\_prefixes](#input\_s3\_buckets\_with\_prefixes) | The names S3 buckets and prefix to forward logs to Datadog | `map(object({ bucket_name : string, bucket_prefix : string }))` | `{}` | no |
 | <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids) | List of security group IDs to use when the Lambda Function runs in a VPC | `list(string)` | `null` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | List of subnet IDs to use when deploying the Lambda Function in a VPC | `list(string)` | `null` | no |

--- a/modules/datadog-lambda-forwarder/main.tf
+++ b/modules/datadog-lambda-forwarder/main.tf
@@ -40,7 +40,7 @@ module "log_group_prefix" {
 
 module "datadog_lambda_forwarder" {
   source  = "cloudposse/datadog-lambda-forwarder/aws"
-  version = "1.1.0"
+  version = "1.2.0"
 
   cloudwatch_forwarder_log_groups = local.cloudwatch_forwarder_log_groups
   dd_api_key_kms_ciphertext_blob  = var.dd_api_key_kms_ciphertext_blob
@@ -72,6 +72,7 @@ module "datadog_lambda_forwarder" {
   lambda_runtime                        = var.lambda_runtime
   s3_bucket_kms_arns                    = var.s3_bucket_kms_arns
   s3_buckets                            = var.s3_buckets
+  s3_buckets_with_prefixes              = var.s3_buckets_with_prefixes
   security_group_ids                    = var.security_group_ids
   subnet_ids                            = var.subnet_ids
   tracing_config_mode                   = var.tracing_config_mode

--- a/modules/datadog-lambda-forwarder/variables.tf
+++ b/modules/datadog-lambda-forwarder/variables.tf
@@ -91,7 +91,7 @@ variable "kms_key_id" {
 variable "s3_buckets" {
   type        = list(string)
   description = "The names and ARNs of S3 buckets to forward logs to Datadog"
-  default     = null
+  default     = []
 }
 
 variable "s3_bucket_kms_arns" {

--- a/modules/datadog-lambda-forwarder/variables.tf
+++ b/modules/datadog-lambda-forwarder/variables.tf
@@ -90,8 +90,14 @@ variable "kms_key_id" {
 
 variable "s3_buckets" {
   type        = list(string)
-  description = "The names and ARNs of S3 buckets to forward logs to Datadog"
+  description = "The names of S3 buckets to forward logs to Datadog"
   default     = []
+}
+
+variable "s3_buckets_with_prefixes" {
+  type        = map(object({ bucket_name : string, bucket_prefix : string }))
+  description = "The names S3 buckets and prefix to forward logs to Datadog"
+  default     = {}
 }
 
 variable "s3_bucket_kms_arns" {


### PR DESCRIPTION
This module attempts to do length() on the value for s3_buckets.

We are not using s3_buckets, and it defaults to null, so length() fails.