### PR TITLE
`eks/actions-runner-controller`: use coalesce

### DIFF
--- a/modules/eks/actions-runner-controller/main.tf
+++ b/modules/eks/actions-runner-controller/main.tf
@@ -216,7 +216,7 @@ module "actions_runner" {
       min_replicas                   = each.value.min_replicas
       max_replicas                   = each.value.max_replicas
       webhook_driven_scaling_enabled = each.value.webhook_driven_scaling_enabled
-      webhook_startup_timeout        = try(each.value.webhook_startup_timeout, "${each.value.scale_down_delay_seconds}s") # if webhook_startup_timeout isnt defined, use scale_down_delay_seconds
+      webhook_startup_timeout        = coalesce(each.value.webhook_startup_timeout, "${each.value.scale_down_delay_seconds}s") # if webhook_startup_timeout isnt defined, use scale_down_delay_seconds
       pull_driven_scaling_enabled    = each.value.pull_driven_scaling_enabled
       pvc_enabled                    = each.value.pvc_enabled
     }),


### PR DESCRIPTION
## what
* use coalesce instead of try, as we need a value passed in here