### PR TITLE
Improve platform and external-dns for release engineering

### DIFF
--- a/modules/eks/external-dns/README.md
+++ b/modules/eks/external-dns/README.md
@@ -66,6 +66,7 @@ components:
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_dns_gbl_delegated"></a> [dns\_gbl\_delegated](#module\_dns\_gbl\_delegated) | cloudposse/stack-config/yaml//modules/remote-state | 1.4.1 |
+| <a name="module_dns_gbl_primary"></a> [dns\_gbl\_primary](#module\_dns\_gbl\_primary) | cloudposse/stack-config/yaml//modules/remote-state | 1.4.1 |
 | <a name="module_eks"></a> [eks](#module\_eks) | cloudposse/stack-config/yaml//modules/remote-state | 1.4.1 |
 | <a name="module_external_dns"></a> [external\_dns](#module\_external\_dns) | cloudposse/helm-release/aws | 0.7.0 |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../../account-map/modules/iam-roles | n/a |
@@ -97,6 +98,7 @@ components:
 | <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between ID elements.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
 | <a name="input_descriptor_formats"></a> [descriptor\_formats](#input\_descriptor\_formats) | Describe additional descriptors to be output in the `descriptors` output map.<br>Map of maps. Keys are names of descriptors. Values are maps of the form<br>`{<br>   format = string<br>   labels = list(string)<br>}`<br>(Type is `any` so the map values can later be enhanced to provide additional options.)<br>`format` is a Terraform format string to be passed to the `format()` function.<br>`labels` is a list of labels, in order, to pass to `format()` function.<br>Label values will be normalized before being passed to `format()` so they will be<br>identical to how they appear in `id`.<br>Default is `{}` (`descriptors` output will be empty). | `any` | `{}` | no |
 | <a name="input_dns_gbl_delegated_environment_name"></a> [dns\_gbl\_delegated\_environment\_name](#input\_dns\_gbl\_delegated\_environment\_name) | The name of the environment where global `dns_delegated` is provisioned | `string` | `"gbl"` | no |
+| <a name="input_dns_gbl_primary_environment_name"></a> [dns\_gbl\_primary\_environment\_name](#input\_dns\_gbl\_primary\_environment\_name) | The name of the environment where global `dns_primary` is provisioned | `string` | `"gbl"` | no |
 | <a name="input_eks_component_name"></a> [eks\_component\_name](#input\_eks\_component\_name) | The name of the eks component | `string` | `"eks/cluster"` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |

--- a/modules/eks/external-dns/main.tf
+++ b/modules/eks/external-dns/main.tf
@@ -8,7 +8,8 @@ locals {
   txt_owner       = var.txt_prefix != "" ? format(module.this.tenant != null ? "%[1]s-%[2]s-%[3]s-%[4]s" : "%[1]s-%[2]s-%[4]s", var.txt_prefix, module.this.environment, module.this.tenant, module.this.stage) : ""
   txt_prefix      = var.txt_prefix != "" ? format("%s-", local.txt_owner) : ""
   zone_ids = compact(concat(
-    values(module.dns_gbl_delegated.outputs.zones)[*].zone_id
+    values(module.dns_gbl_delegated.outputs.zones)[*].zone_id,
+    values(module.dns_gbl_primary.outputs.zones)[*].zone_id
   ))
 }
 

--- a/modules/eks/external-dns/remote-state.tf
+++ b/modules/eks/external-dns/remote-state.tf
@@ -20,3 +20,19 @@ module "dns_gbl_delegated" {
     zones = {}
   }
 }
+
+module "dns_gbl_primary" {
+  source  = "cloudposse/stack-config/yaml//modules/remote-state"
+  version = "1.4.1"
+
+  component   = "dns-primary"
+  environment = var.dns_gbl_primary_environment_name
+
+  context = module.this.context
+
+  ignore_errors = true
+
+  defaults = {
+    zones = {}
+  }
+}

--- a/modules/eks/external-dns/variables.tf
+++ b/modules/eks/external-dns/variables.tf
@@ -126,6 +126,12 @@ variable "dns_gbl_delegated_environment_name" {
   default     = "gbl"
 }
 
+variable "dns_gbl_primary_environment_name" {
+  type        = string
+  description = "The name of the environment where global `dns_primary` is provisioned"
+  default     = "gbl"
+}
+
 variable "publish_internal_services" {
   type        = bool
   description = "Allow external-dns to publish DNS records for ClusterIP services"

--- a/modules/eks/platform/README.md
+++ b/modules/eks/platform/README.md
@@ -112,9 +112,7 @@ put it into `/platform/{eks cluster name}/default/default_alb_ingress_group`
 
 ## Outputs
 
-| Name | Description |
-|------|-------------|
-| <a name="output_test"></a> [test](#output\_test) | n/a |
+No outputs.
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 [<img src="https://cloudposse.com/logo-300x69.svg" height="32" align="right"/>](https://cpco.io/component)

--- a/modules/eks/platform/README.md
+++ b/modules/eks/platform/README.md
@@ -54,12 +54,14 @@ put it into `/platform/{eks cluster name}/default/default_alb_ingress_group`
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.0 |
+| <a name="requirement_jq"></a> [jq](#requirement\_jq) | >= 0.2.1 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.9.0 |
+| <a name="provider_jq"></a> [jq](#provider\_jq) | >= 0.2.1 |
 
 ## Modules
 
@@ -76,6 +78,7 @@ put it into `/platform/{eks cluster name}/default/default_alb_ingress_group`
 | Name | Type |
 |------|------|
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
+| [jq_query.default](https://registry.terraform.io/providers/massdriver-cloud/jq/latest/docs/data-sources/query) | data source |
 
 ## Inputs
 
@@ -99,7 +102,7 @@ put it into `/platform/{eks cluster name}/default/default_alb_ingress_group`
 | <a name="input_name"></a> [name](#input\_name) | ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.<br>This is the only ID element not also included as a `tag`.<br>The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input. | `string` | `null` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique | `string` | `null` | no |
 | <a name="input_platform_environment"></a> [platform\_environment](#input\_platform\_environment) | Platform environment | `string` | `"default"` | no |
-| <a name="input_references"></a> [references](#input\_references) | Platform mapping from remote components outputs | <pre>map(object({<br>    component = string<br>    output    = string<br>  }))</pre> | `{}` | no |
+| <a name="input_references"></a> [references](#input\_references) | Platform mapping from remote components outputs | <pre>map(object({<br>    component   = string<br>    privileged  = optional(bool)<br>    tenant      = optional(string)<br>    environment = optional(string)<br>    stage       = optional(string)<br>    output      = string<br>  }))</pre> | `{}` | no |
 | <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br>Characters matching the regex will be removed from the ID elements.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS Region | `string` | n/a | yes |
 | <a name="input_ssm_platform_path"></a> [ssm\_platform\_path](#input\_ssm\_platform\_path) | Format SSM path to store platform configs | `string` | `"/platform/%s/%s"` | no |
@@ -109,7 +112,9 @@ put it into `/platform/{eks cluster name}/default/default_alb_ingress_group`
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+|------|-------------|
+| <a name="output_test"></a> [test](#output\_test) | n/a |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 [<img src="https://cloudposse.com/logo-300x69.svg" height="32" align="right"/>](https://cpco.io/component)

--- a/modules/eks/platform/main.tf
+++ b/modules/eks/platform/main.tf
@@ -46,7 +46,7 @@ data "jq_query" "default" {
 }
 
 locals {
-  result = { for k, v in data.jq_query.default: k => jsondecode(v.result) }
+  result = { for k, v in data.jq_query.default : k => jsondecode(v.result) }
 }
 
 

--- a/modules/eks/platform/main.tf
+++ b/modules/eks/platform/main.tf
@@ -48,8 +48,3 @@ data "jq_query" "default" {
 locals {
   result = { for k, v in data.jq_query.default : k => jsondecode(v.result) }
 }
-
-
-output "test" {
-  value = local.result
-}

--- a/modules/eks/platform/main.tf
+++ b/modules/eks/platform/main.tf
@@ -17,14 +17,15 @@ module "store_write" {
   source  = "cloudposse/ssm-parameter-store/aws"
   version = "0.10.0"
 
-  parameter_write = concat([for k, v in var.references :
-    {
-      name        = format("%s/%s", format(var.ssm_platform_path, module.eks.outputs.eks_cluster_id, var.platform_environment), k)
-      value       = lookup(module.remote[k].outputs, v.output)
-      type        = "SecureString"
-      overwrite   = true
-      description = "Platform config for ${var.platform_environment} at ${module.eks.outputs.eks_cluster_id} cluster"
-    }
+  parameter_write = concat(
+    [for k, v in var.references :
+      {
+        name        = format("%s/%s", format(var.ssm_platform_path, module.eks.outputs.eks_cluster_id, var.platform_environment), k)
+        value       = local.result[k]
+        type        = "SecureString"
+        overwrite   = true
+        description = "Platform config for ${var.platform_environment} at ${module.eks.outputs.eks_cluster_id} cluster"
+      }
     ],
     [for k, v in local.metadata :
       {
@@ -36,4 +37,19 @@ module "store_write" {
       }
   ])
   context = module.this.context
+}
+
+data "jq_query" "default" {
+  for_each = var.references
+  data     = jsonencode(module.remote[each.key].outputs)
+  query    = ".${each.value.output}"
+}
+
+locals {
+  result = { for k, v in data.jq_query.default: k => jsondecode(v.result) }
+}
+
+
+output "test" {
+  value = local.result
 }

--- a/modules/eks/platform/providers.tf
+++ b/modules/eks/platform/providers.tf
@@ -27,3 +27,5 @@ variable "import_role_arn" {
   default     = null
   description = "IAM Role ARN to use when importing a resource"
 }
+
+provider "jq" {}

--- a/modules/eks/platform/remote-state.tf
+++ b/modules/eks/platform/remote-state.tf
@@ -13,7 +13,11 @@ module "remote" {
   source   = "cloudposse/stack-config/yaml//modules/remote-state"
   version  = "1.4.1"
 
-  component = each.value["component"]
+  component   = each.value["component"]
+  privileged  = coalesce(try(each.value["privileged"], null), false)
+  tenant      = coalesce(try(each.value["tenant"], null), module.this.context["tenant"], null)
+  environment = coalesce(try(each.value["environment"], null), module.this.context["environment"], null)
+  stage       = coalesce(try(each.value["stage"], null), module.this.context["stage"], null)
 
   context = module.this.context
 }

--- a/modules/eks/platform/variables.tf
+++ b/modules/eks/platform/variables.tf
@@ -7,7 +7,11 @@ variable "references" {
   description = "Platform mapping from remote components outputs"
   default     = {}
   type = map(object({
-    component = string
+    component   = string
+    privileged  = optional(bool)
+    tenant      = optional(string)
+    environment = optional(string)
+    stage       = optional(string)
     output    = string
   }))
 }

--- a/modules/eks/platform/variables.tf
+++ b/modules/eks/platform/variables.tf
@@ -12,7 +12,7 @@ variable "references" {
     tenant      = optional(string)
     environment = optional(string)
     stage       = optional(string)
-    output    = string
+    output      = string
   }))
 }
 

--- a/modules/eks/platform/versions.tf
+++ b/modules/eks/platform/versions.tf
@@ -11,7 +11,7 @@ terraform {
       version = ">= 2.0"
     }
     jq = {
-      source = "massdriver-cloud/jq"
+      source  = "massdriver-cloud/jq"
       version = ">= 0.2.1"
     }
   }

--- a/modules/eks/platform/versions.tf
+++ b/modules/eks/platform/versions.tf
@@ -10,5 +10,9 @@ terraform {
       source  = "hashicorp/helm"
       version = ">= 2.0"
     }
+    jq = {
+      source = "massdriver-cloud/jq"
+      version = ">= 0.2.1"
+    }
   }
 }


### PR DESCRIPTION
## what
* `eks/external-dns` support `dns-primary`
* `eks/platform` support json query remote components outputs
 
## why
* `vanity domain` pattern support by `eks/external-dns`
* Improve flexibility of `eks/platform`
