### PR TITLE
chore(spacelift): update with dependency resource

### DIFF
--- a/modules/spacelift/README.md
+++ b/modules/spacelift/README.md
@@ -346,7 +346,7 @@ cat stacks.txt | while read stack; do echo $stack && echo spacectl stack set-cur
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
-| <a name="module_spacelift"></a> [spacelift](#module\_spacelift) | cloudposse/cloud-infrastructure-automation/spacelift | 0.51.3 |
+| <a name="module_spacelift"></a> [spacelift](#module\_spacelift) | cloudposse/cloud-infrastructure-automation/spacelift | 0.55.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 
 ## Resources
@@ -408,6 +408,7 @@ cat stacks.txt | while read stack; do echo $stack && echo spacectl stack set-cur
 | <a name="input_spacelift_api_endpoint"></a> [spacelift\_api\_endpoint](#input\_spacelift\_api\_endpoint) | The Spacelift API endpoint URL (e.g. https://example.app.spacelift.io) | `string` | n/a | yes |
 | <a name="input_spacelift_component_path"></a> [spacelift\_component\_path](#input\_spacelift\_component\_path) | The Spacelift Component Path | `string` | `"components/terraform"` | no |
 | <a name="input_spacelift_run_enabled"></a> [spacelift\_run\_enabled](#input\_spacelift\_run\_enabled) | Enable/disable creation of the `spacelift_run` resource | `bool` | `false` | no |
+| <a name="input_spacelift_stack_dependency_enabled"></a> [spacelift\_stack\_dependency\_enabled](#input\_spacelift\_stack\_dependency\_enabled) | If enabled, the `spacelift_stack_dependency` Spacelift resource will be used to create dependencies between stacks instead of using the `depends-on` labels. The `depends-on` labels will be removed from the stacks and the trigger policies for dependencies will be detached | `bool` | `false` | no |
 | <a name="input_stack_config_path_template"></a> [stack\_config\_path\_template](#input\_stack\_config\_path\_template) | Stack config path template | `string` | `"stacks/%s.yaml"` | no |
 | <a name="input_stack_destructor_enabled"></a> [stack\_destructor\_enabled](#input\_stack\_destructor\_enabled) | Flag to enable/disable the stack destructor to destroy the resources of a stack before deleting the stack itself | `bool` | `false` | no |
 | <a name="input_stacks_space_id"></a> [stacks\_space\_id](#input\_stacks\_space\_id) | Override the space ID for all stacks (unless the stack config has `dedicated_space` set to true). Otherwise, it will default to the admin stack's space. | `string` | `null` | no |

--- a/modules/spacelift/main.tf
+++ b/modules/spacelift/main.tf
@@ -1,6 +1,6 @@
 module "spacelift" {
   source  = "cloudposse/cloud-infrastructure-automation/spacelift"
-  version = "0.51.3"
+  version = "0.55.0"
 
   context_filters = var.context_filters
   tag_filters     = var.tag_filters
@@ -23,9 +23,10 @@ module "spacelift" {
   terraform_version     = var.terraform_version
   terraform_version_map = var.terraform_version_map
 
-  imports_processing_enabled        = false
-  stack_deps_processing_enabled     = false
-  component_deps_processing_enabled = true
+  imports_processing_enabled         = false
+  stack_deps_processing_enabled      = false
+  component_deps_processing_enabled  = true
+  spacelift_stack_dependency_enabled = var.spacelift_stack_dependency_enabled
 
   policies_available       = var.policies_available
   policies_enabled         = var.policies_enabled

--- a/modules/spacelift/variables.tf
+++ b/modules/spacelift/variables.tf
@@ -220,3 +220,9 @@ variable "stacks_space_id" {
   description = "Override the space ID for all stacks (unless the stack config has `dedicated_space` set to true). Otherwise, it will default to the admin stack's space."
   default     = null
 }
+
+variable "spacelift_stack_dependency_enabled" {
+  type        = bool
+  description = "If enabled, the `spacelift_stack_dependency` Spacelift resource will be used to create dependencies between stacks instead of using the `depends-on` labels. The `depends-on` labels will be removed from the stacks and the trigger policies for dependencies will be detached"
+  default     = false
+}


### PR DESCRIPTION
## what
* update spacelift component to 0.55.0

## why
* support feature flag for spacelift_stack_dependency resource

## references
* [spacelift module 0.55.0](https://github.com/cloudposse/terraform-spacelift-cloud-infrastructure-automation/releases/tag/0.55.0)

