### PR TITLE
add providers to `mixins` folder

### DIFF
--- a/mixins/provider-datadog.tf
+++ b/mixins/provider-datadog.tf
@@ -1,0 +1,12 @@
+module "datadog_configuration" {
+  source  = "../datadog-configuration/modules/datadog_keys"
+  region  = var.region
+  context = module.this.context
+}
+
+provider "datadog" {
+  api_key  = module.datadog_configuration.datadog_api_key
+  app_key  = module.datadog_configuration.datadog_app_key
+  api_url  = module.datadog_configuration.datadog_api_url
+  validate = local.enabled
+}

--- a/mixins/providers-aws-superadmin.tf
+++ b/mixins/providers-aws-superadmin.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = var.region
+}

--- a/mixins/providers.tf
+++ b/mixins/providers.tf
@@ -1,0 +1,29 @@
+provider "aws" {
+  region = var.region
+
+  profile = module.iam_roles.profiles_enabled ? coalesce(var.import_profile_name, module.iam_roles.terraform_profile_name) : null
+
+  dynamic "assume_role" {
+    for_each = module.iam_roles.profiles_enabled ? [] : ["role"]
+    content {
+      role_arn = coalesce(var.import_role_arn, module.iam_roles.terraform_role_arn)
+    }
+  }
+}
+
+module "iam_roles" {
+  source  = "../account-map/modules/iam-roles"
+  context = module.this.context
+}
+
+variable "import_profile_name" {
+  type        = string
+  default     = null
+  description = "AWS Profile name to use when importing a resource"
+}
+
+variable "import_role_arn" {
+  type        = string
+  default     = null
+  description = "IAM Role ARN to use when importing a resource"
+}


### PR DESCRIPTION
## what
*  Copies some common providers to the mixins folder

## why
* Have a central place where our common providers are held.
