### PR TITLE
docs: eks/actions-runner-controller webhook scaleUpTrigger config

### DIFF
--- a/modules/eks/actions-runner-controller/README.md
+++ b/modules/eks/actions-runner-controller/README.md
@@ -238,11 +238,12 @@ the logs of the `actions-runner-controller-github-webhook-server` pod.
 
 ### Configuring Scaling
 
-The default scaleUpTrigger duration is 30 minutes. The time should be adjusted with `webhook_startup_timeout`
-to best fit your maximum job duration. If this time is too short, it can interrupt work since the autoscaler
-will assume any activity from the webhook has been resolved. Think of this as a way to tidy up jobs that might
-not finish cleanly or could be stuck. No particular time will fit all scenarios so you should expect to
-adjust this once you have a workload to test with.
+The default [`scaleUpTrigger`](https://github.com/actions/actions-runner-controller/blob/master/docs/automatically-scaling-runners.md#webhook-driven-scaling) duration is 30 minutes. The time should be adjusted with `webhook_startup_timeout`
+to best fit your maximum job duration. You should ensure the duration allows for
+backlog clearance. Project maintainers suggest "30m," but it depends on job lengths and maxReplicas.
+Use "30m" for low-backlog pools, and "2h30m" for high-backlog pools, like package building.
+Previously, "2m" was recommended, but it's insufficient. Update deployments to "30m" or consult with
+customers.
 
 You can read more about
 [scaling runners](https://github.com/actions/actions-runner-controller/blob/master/docs/automatically-scaling-runners.md)

--- a/modules/eks/actions-runner-controller/README.md
+++ b/modules/eks/actions-runner-controller/README.md
@@ -74,7 +74,7 @@ components:
                 cpu: 100m
                 memory: 128Mi
             webhook_driven_scaling_enabled: true
-            webhook_startup_timeout: "2m"
+            webhook_startup_timeout: "30m"
             pull_driven_scaling_enabled: false
             # Labels are not case-sensitive to GitHub, but *are* case-sensitive
             # to the webhook based autoscaler, which requires exact matches
@@ -122,7 +122,7 @@ components:
           #      cpu: 100m
           #      memory: 128Mi
           #  webhook_driven_scaling_enabled: true
-          #  webhook_startup_timeout: "2m"
+          #  webhook_startup_timeout: "30m"
           #  pull_driven_scaling_enabled: false
           #  # Labels are not case-sensitive to GitHub, but *are* case-sensitive
           #  # to the webhook based autoscaler, which requires exact matches
@@ -236,6 +236,17 @@ After the webhook is created, select "edit" for the webhook and go to the "Recen
 (of a "ping" event) with a green check mark. If not, verify all the settings and consult
 the logs of the `actions-runner-controller-github-webhook-server` pod.
 
+### Configuring Scaling
+
+The default scaleUpTrigger duration is 30 minutes. The time should be adjusted with `webhook_startup_timeout`
+to best fit your maximum job duration. If this time is too short, it can interrupt work since the autoscaler
+will assume any activity from the webhook has been resolved. Think of this as a way to tidy up jobs that might
+not finish cleanly or could be stuck. No particular time will fit all scenarios so you should expect to
+adjust this once you have a workload to test with.
+
+You can read more about
+[scaling runners](https://github.com/actions/actions-runner-controller/blob/master/docs/automatically-scaling-runners.md)
+in the docs.
 
 ### Updating CRDs
 


### PR DESCRIPTION
## what
* update example config to use 30m for webhook_startup_timeout
* add docs on configuration for webhook scaleUpTriggers

## why
* runners will scale back down at the end of duration and could interrupt work
* while 30m is a recommended default, long durations may be necessary

## references
* [scaling runners](https://github.com/actions/actions-runner-controller/blob/master/docs/automatically-scaling-runners.md)

