### PR TITLE
Missing Version Pins for Bats

### DIFF
--- a/modules/eks/idp-roles/README.md
+++ b/modules/eks/idp-roles/README.md
@@ -29,6 +29,7 @@ components:
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.0 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.14.0 |
 
 ## Providers
 

--- a/modules/eks/idp-roles/versions.tf
+++ b/modules/eks/idp-roles/versions.tf
@@ -10,5 +10,9 @@ terraform {
       source  = "hashicorp/helm"
       version = ">= 2.0"
     }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.14.0"
+    }
   }
 }

--- a/modules/elasticsearch/README.md
+++ b/modules/elasticsearch/README.md
@@ -33,13 +33,14 @@ components:
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.8 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.8 |
-| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 3.0 |
 
 ## Modules
 

--- a/modules/elasticsearch/versions.tf
+++ b/modules/elasticsearch/versions.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 3.8"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
   }
 }


### PR DESCRIPTION
## what
added missing provider version pins

## why
missing provider versions, required for bats

## references
#626 
#628, #627 
