### PR TITLE
fix: Use `vpc` without tenant

### DIFF
--- a/modules/vpc/remote-state.tf
+++ b/modules/vpc/remote-state.tf
@@ -7,7 +7,7 @@ module "vpc_flow_logs_bucket" {
   component   = "vpc-flow-logs-bucket"
   environment = var.vpc_flow_logs_bucket_environment_name
   stage       = var.vpc_flow_logs_bucket_stage_name
-  tenant      = coalesce(var.vpc_flow_logs_bucket_tenant_name, module.this.tenant)
+  tenant      = try(coalesce(var.vpc_flow_logs_bucket_tenant_name, module.this.tenant), null)
 
   context = module.this.context
 }


### PR DESCRIPTION
## why

```bash
│ Error: Error in function call
│ 
│   on remote-state.tf line 10, in module "vpc_flow_logs_bucket":
│   10:   tenant      = coalesce(var.vpc_flow_logs_bucket_tenant_name, module.this.tenant)
│     ├────────────────
│     │ while calling coalesce(vals...)
│     │ module.this.tenant is ""
│     │ var.vpc_flow_logs_bucket_tenant_name is null
│ 
│ Call to function "coalesce" failed: no non-null, non-empty-string
│ arguments.
```

## references
* Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
* Use `closes #123`, if this PR closes a GitHub issue `#123`

