### PR TITLE
Format Identity Team Access Permission Set Name

### DIFF
--- a/modules/aws-sso/README.md
+++ b/modules/aws-sso/README.md
@@ -47,7 +47,7 @@ The `account_assignments` setting configures access to permission sets for users
 The `identity_roles_accessible` element provides a list of role names corresponding to roles created in the `iam-primary-roles` component. For each names role, a corresponding permission set will be created which allows the user to assume that role. The permission set name is generated in Terraform from the role name using this statement:
 
 ```
-format("Identity%sTeamAccess", title(role))
+format("Identity%sTeamAccess", replace(title(role), "-", ""))
 ```
 
 #### Example

--- a/modules/aws-sso/policy-Identity-role-TeamAccess.tf
+++ b/modules/aws-sso/policy-Identity-role-TeamAccess.tf
@@ -54,8 +54,8 @@ data "aws_iam_policy_document" "assume_aws_team" {
 
 locals {
   identity_access_permission_sets = [for role in var.aws_teams_accessible : {
-    name                                = format("Identity%sTeamAccess", title(role)),
-    description                         = format("Allow user to assume the %s Team role in the Identity account, which allows access to other accounts", title(role))
+    name                                = format("Identity%sTeamAccess", replace(title(role), "-", "")),
+    description                         = format("Allow user to assume the %s Team role in the Identity account, which allows access to other accounts", replace(title(role), "-", ""))
     relay_state                         = "",
     session_duration                    = "",
     tags                                = {},


### PR DESCRIPTION
## what
- format permission set roles with hyphens

## why
- pretty Permission Set naming. We want `devops-super` to format to `IdentityDevopsSuperTeamAccess`

## references
https://github.com/cloudposse/refarch-scaffold/pull/127

