### PR TITLE
[aws-config] Update usage info, add "help" and "teams" commands

### DIFF
--- a/rootfs/usr/local/bin/aws-config
+++ b/rootfs/usr/local/bin/aws-config
@@ -1,21 +1,47 @@
 #!/bin/bash
 
-## WORK IN PROGRESS
+## Production ready, but still being developed and subject to frequent breaking changes.
 
-## Usage:
-##   aws-config saml > rootfs/etc/aws-config/aws-config-saml
+functions+=(help)
+function help() {
+    fns=($(printf '%s\n' "${functions[@]}" | sort | uniq))
+    # usage=${fns//$'\n'/ | }
+    printf "Usage: %s  <command>\n  Where <command> is one of:\n\n" "$(basename $0)"
+    printf '    %s\n' "${fns[@]}"
+    echo
+
+  cat <<'EOF'
+
+## Examples:
+##   aws-config teams > rootfs/etc/aws-config/aws-config-teams
 ##     Generates full `aws` CLI configuration for use in Geodesic
-##     based on SAML authentication and SAML roles.
+##     to access aws-teams and aws-team-roles.
 ##
-##   aws-config switch-roles > rootfs/etc/aws-config/aws-switch-roles
-##   aws-config switch-roles billing > rootfs/etc/aws-config/aws-switch-roles-billing
-##   aws-config switch-roles billing_admin > rootfs/etc/aws-config/aws-switch-roles-billing_admin
+##   aws-config switch-roles > rootfs/etc/aws-config/aws-extend-switch-roles
+##   aws-config switch-roles billing > rootfs/etc/aws-config/aws-extend-switch-roles-billing
+##   aws-config switch-roles billing_admin > rootfs/etc/aws-config/aws-extend-switch-roles-billing_admin
 ##     Generates configuration for AWS Extend Switch Roles browser plugin
 ##     https://github.com/tilfinltd/aws-extend-switch-roles
 ##
 ##   aws-config spacelift > rootfs/etc/aws-config/aws-config-spacelift
 ##     Generates `aws` CLI/SDK configuration for Spacelift workers to use
 ##
+
+EOF
+
+}
+
+# main needs to be defined before sourcing other files
+
+function main() {
+  if printf '%s\0' "${functions[@]}" | grep -Fxqz -- "$1"; then
+	  "$@"
+  else
+    help
+    exit 99
+  fi
+}
+
 
 ## TODO: maybe pull the source files from S3 rather than file system
 account_sources=("$ATMOS_BASE_PATH/"components/terraform/account-map/account-info/*sh)
@@ -88,6 +114,15 @@ function saml() {
   _no-source-profile
 
   _saml "$@"
+}
+
+# Generate AWS config file for assuming `aws-teams` and `aws-team-roles` roles.
+# Will generate a profile for every role in every account, unless a role is specified,
+# in which case it will only generate a profile for that role in every account.
+# Usage: teams [<role-name>]
+functions+=(teams)
+function teams() {
+  saml "$@"
 }
 
 functions+=(switch-roles)
@@ -167,7 +202,6 @@ case $1 in
     ;;
 esac
 
-# Use main() from account-info script
 args=("$@")
 for namespace in "${target_namespace[@]}"; do
   source "$ATMOS_BASE_PATH/components/terraform/account-map/account-info/$namespace"*.sh


### PR DESCRIPTION
## what

Update `aws-config` command:
- Add `teams` command and suggest "aws-config-teams" file name instead of "aws-config-saml" because we want to use "aws-config-teams" for both SAML and SSO logins with Leapp handling the difference.
- Add `help` command
- Add more extensive help
- Do not rely on script generated by `account-map` for command `main()` function

## why
- Reflect latest design pattern
- Improved user experience
