### PR TITLE
fix: eks/efs-controller iam policy updates

### DIFF
--- a/modules/eks/efs-controller/resources/iam_policy_statements.yaml
+++ b/modules/eks/efs-controller/resources/iam_policy_statements.yaml
@@ -5,14 +5,17 @@ AllowEFSDescribeOnAllResources:
   actions:
     - elasticfilesystem:DescribeAccessPoints
     - elasticfilesystem:DescribeFileSystems
+    - elasticfilesystem:DescribeMountTargets
+    - ec2:DescribeAvailabilityZones
   resources: ["*"]
   conditions: []
 
-AllowConditionalEFSCreateAccessPoint:
-  sid: "AllowConditionalEFSCreateAccessPoint"
+AllowConditionalEFSAccess:
+  sid: "AllowConditionalEFSAccess"
   effect: Allow
   actions:
     - elasticfilesystem:CreateAccessPoint
+    - elasticfilesystem:TagResource
   resources: ["*"]
   conditions:
     - test: "StringLike"


### PR DESCRIPTION
## what
* Update the iam policy for eks/efs-controller

## why
* Older permissions will not work with new versions of the controller

## references
* [official iam policy
sample](https://github.com/kubernetes-sigs/aws-efs-csi-driver/blob/master/docs/iam-policy-example.json)

