### PR TITLE
Add `iam-policy` to `ecs-service`

### DIFF
--- a/modules/ecs-service/main.tf
+++ b/modules/ecs-service/main.tf
@@ -215,7 +215,7 @@ module "ecs_alb_service_task" {
   wait_for_steady_state              = lookup(var.task, "wait_for_steady_state", true)
   circuit_breaker_deployment_enabled = lookup(var.task, "circuit_breaker_deployment_enabled", true)
   circuit_breaker_rollback_enabled   = lookup(var.task, "circuit_breaker_rollback_enabled  ", true)
-  task_policy_arns                   = var.task_policy_arns
+  task_policy_arns                   = var.iam_policy_enabled ? concat(var.task_policy_arns, formatlist(aws_iam_policy.default[0].arn)) : var.task_policy_arns
   ecs_service_enabled                = lookup(var.task, "ecs_service_enabled", true)
   bind_mount_volumes                 = lookup(var.task, "bind_mount_volumes", [])
   task_role_arn                      = lookup(var.task, "task_role_arn", [])


### PR DESCRIPTION
## what
Add an option to attach the `iam-policy` resource to `ecs-service`

## why
This policy is already created, but is missing its attachment. We should attach this to the resource when enabled

## references
https://cloudposse.slack.com/archives/CA4TC65HS/p1683729972134479

