### PR TITLE
Remove (broken) root access to EKS clusters

### DIFF
--- a/modules/eks/cluster/main.tf
+++ b/modules/eks/cluster/main.tf
@@ -19,7 +19,9 @@ locals {
 
   aws_teams_auth = [for role in var.aws_teams_rbac : {
     rolearn  = module.iam_arns.principals_map[local.identity_account_name][role.aws_team]
-    username = format("%s-%s", local.identity_account_name, role.aws_team)
+    # Include session name in the username for auditing purposes.
+    # See https://aws.github.io/aws-eks-best-practices/security/docs/iam/#use-iam-roles-when-multiple-users-need-identical-access-to-the-cluster
+    username = format("%s-%s::{{SessionName}}", local.identity_account_name, role.aws_team)
     groups   = role.groups
   }]
 

--- a/modules/eks/cluster/main.tf
+++ b/modules/eks/cluster/main.tf
@@ -18,7 +18,7 @@ locals {
   })
 
   aws_teams_auth = [for role in var.aws_teams_rbac : {
-    rolearn  = module.iam_arns.principals_map[local.identity_account_name][role.aws_team]
+    rolearn = module.iam_arns.principals_map[local.identity_account_name][role.aws_team]
     # Include session name in the username for auditing purposes.
     # See https://aws.github.io/aws-eks-best-practices/security/docs/iam/#use-iam-roles-when-multiple-users-need-identical-access-to-the-cluster
     username = format("%s-%s::{{SessionName}}", local.identity_account_name, role.aws_team)

--- a/modules/eks/cluster/main.tf
+++ b/modules/eks/cluster/main.tf
@@ -15,7 +15,6 @@ locals {
     (local.identity_account_name) = var.aws_teams_rbac[*].aws_team
     }, {
     (local.this_account_name) = var.aws_team_roles_rbac[*].aws_team_role
-    root                      = ["*"]
   })
 
   aws_teams_auth = [for role in var.aws_teams_rbac : {


### PR DESCRIPTION
## what

- Remove (broken) root access to EKS clusters
- Include session name in audit trail of users accessing EKS

## why

- Test code granting access to all `root` users and roles was accidentally left in #645 and breaks when Tenants are part of account names
- There is no reason to allow `root` users to access EKS clusters, so even when this code worked it was wrong
- Audit trail can keep track of who is performing actions

## references

- https://aws.github.io/aws-eks-best-practices/security/docs/iam/#use-iam-roles-when-multiple-users-need-identical-access-to-the-cluster
