### PR TITLE
bump config yaml dependency on account component as it still depends on hashicorp template provider

### DIFF
--- a/modules/account/README.md
+++ b/modules/account/README.md
@@ -350,7 +350,7 @@ atmos terraform apply account --stack gbl-root
 | <a name="module_accounts_service_control_policies"></a> [accounts\_service\_control\_policies](#module\_accounts\_service\_control\_policies) | cloudposse/service-control-policies/aws | 0.9.2 |
 | <a name="module_organization_service_control_policies"></a> [organization\_service\_control\_policies](#module\_organization\_service\_control\_policies) | cloudposse/service-control-policies/aws | 0.9.2 |
 | <a name="module_organizational_units_service_control_policies"></a> [organizational\_units\_service\_control\_policies](#module\_organizational\_units\_service\_control\_policies) | cloudposse/service-control-policies/aws | 0.9.2 |
-| <a name="module_service_control_policy_statements_yaml_config"></a> [service\_control\_policy\_statements\_yaml\_config](#module\_service\_control\_policy\_statements\_yaml\_config) | cloudposse/config/yaml | 1.0.1 |
+| <a name="module_service_control_policy_statements_yaml_config"></a> [service\_control\_policy\_statements\_yaml\_config](#module\_service\_control\_policy\_statements\_yaml\_config) | cloudposse/config/yaml | 1.0.2 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 
 ## Resources

--- a/modules/account/main.tf
+++ b/modules/account/main.tf
@@ -80,7 +80,7 @@ locals {
 # Convert all Service Control Policy statements from YAML config to Terraform list
 module "service_control_policy_statements_yaml_config" {
   source  = "cloudposse/config/yaml"
-  version = "1.0.1"
+  version = "1.0.2"
 
   list_config_local_base_path = path.module
   list_config_paths           = var.service_control_policies_config_paths


### PR DESCRIPTION
## what
* Bump [cloudposse/config/yaml](https://github.com/cloudposse/terraform-yaml-config) module dependency from version 1.0.1 to 1.0.2

## why
* 1.0.1 still uses hashicorp/template provider, which has no M1 binary equivalent, 1.0.2 already uses the cloudposse version which has the binary

## references
* (https://github.com/cloudposse/terraform-yaml-config/releases/tag/1.0.2)

