### PR TITLE
fix: add missing account_map module needed to get audit_account_id

### DIFF
--- a/modules/cloudtrail/remote-state.tf
+++ b/modules/cloudtrail/remote-state.tf
@@ -8,3 +8,15 @@ module "cloudtrail_bucket" {
 
   context = module.this.context
 }
+
+module "account_map" {
+  source  = "cloudposse/stack-config/yaml//modules/remote-state"
+  version = "1.4.2"
+
+  component   = "account-map"
+  environment = var.account_map_environment_name
+  stage       = var.account_map_stage_name
+  privileged  = var.account_map_privileged
+
+  context = module.this.context
+}

--- a/modules/cloudtrail/variables.tf
+++ b/modules/cloudtrail/variables.tf
@@ -77,3 +77,21 @@ variable "audit_account_name" {
   default     = "core-audit"
   description = "The key used in Account Map to find the Audit account"
 }
+
+variable "account_map_environment_name" {
+  type        = string
+  description = "The name of the environment where `account_map` is provisioned"
+  default     = "gbl"
+}
+
+variable "account_map_stage_name" {
+  type        = string
+  description = "The name of the stage where `account_map` is provisioned"
+  default     = "root"
+}
+
+variable "account_map_privileged" {
+  type        = bool
+  description = "True if the caller already has access to the backend without assuming roles"
+  default     = false
+}


### PR DESCRIPTION
## what
* Fixed the missing `account_map` module in the component that is needed to get audit_account_id where the cloudtrail_bucket lives

## why
* Executing the module without the fix, we receive this error:
```
│ Error: Reference to undeclared module
│ 
│   on cloudtrail-kms-key.tf line 3, in locals:
│    3:   audit_account_id     = module.account_map.outputs.full_account_map[var.audit_account_name]
│ 
│ No module call named "account_map" is declared in the root module.```
- Searching on the module, there's no reference to this module, so we had to add it

