### PR TITLE
Correct `cloudtrail` Account-Map Reference

### DIFF
--- a/modules/cloudtrail/README.md
+++ b/modules/cloudtrail/README.md
@@ -45,8 +45,9 @@ components:
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_account_map"></a> [account\_map](#module\_account\_map) | cloudposse/stack-config/yaml//modules/remote-state | 1.4.2 |
 | <a name="module_cloudtrail"></a> [cloudtrail](#module\_cloudtrail) | cloudposse/cloudtrail/aws | 0.21.0 |
-| <a name="module_cloudtrail_bucket"></a> [cloudtrail\_bucket](#module\_cloudtrail\_bucket) | cloudposse/stack-config/yaml//modules/remote-state | 1.4.1 |
+| <a name="module_cloudtrail_bucket"></a> [cloudtrail\_bucket](#module\_cloudtrail\_bucket) | cloudposse/stack-config/yaml//modules/remote-state | 1.4.2 |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
 | <a name="module_kms_key_cloudtrail"></a> [kms\_key\_cloudtrail](#module\_kms\_key\_cloudtrail) | cloudposse/kms-key/aws | 0.12.1 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
@@ -72,7 +73,6 @@ components:
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br>This is for some rare cases where resources want additional configuration of tags<br>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
 | <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br>in the order they appear in the list. New attributes are appended to the<br>end of the list. The elements of the list are joined by the `delimiter`<br>and treated as a single ID element. | `list(string)` | `[]` | no |
 | <a name="input_audit_access_enabled"></a> [audit\_access\_enabled](#input\_audit\_access\_enabled) | If `true`, allows the Audit account access to read Cloudtrail logs directly from S3. This is a requirement for running Athena queries in the Audit account. | `bool` | `false` | no |
-| <a name="input_audit_account_name"></a> [audit\_account\_name](#input\_audit\_account\_name) | The key used in Account Map to find the Audit account | `string` | `"core-audit"` | no |
 | <a name="input_cloudtrail_bucket_component_name"></a> [cloudtrail\_bucket\_component\_name](#input\_cloudtrail\_bucket\_component\_name) | The name of the CloudTrail bucket component | `string` | `"cloudtrail-bucket"` | no |
 | <a name="input_cloudtrail_bucket_environment_name"></a> [cloudtrail\_bucket\_environment\_name](#input\_cloudtrail\_bucket\_environment\_name) | The name of the environment where the CloudTrail bucket is provisioned | `string` | n/a | yes |
 | <a name="input_cloudtrail_bucket_stage_name"></a> [cloudtrail\_bucket\_stage\_name](#input\_cloudtrail\_bucket\_stage\_name) | The stage name where the CloudTrail bucket is provisioned | `string` | n/a | yes |

--- a/modules/cloudtrail/cloudtrail-kms-key.tf
+++ b/modules/cloudtrail/cloudtrail-kms-key.tf
@@ -1,6 +1,6 @@
 locals {
   audit_access_enabled = module.this.enabled && var.audit_access_enabled
-  audit_account_id     = module.account_map.outputs.full_account_map[var.audit_account_name]
+  audit_account_id     = module.account_map.outputs.full_account_map[module.account_map.outputs.audit_account_account_name]
 }
 
 module "kms_key_cloudtrail" {

--- a/modules/cloudtrail/remote-state.tf
+++ b/modules/cloudtrail/remote-state.tf
@@ -1,10 +1,21 @@
 module "cloudtrail_bucket" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "1.4.1"
+  version = "1.4.2"
 
   component   = var.cloudtrail_bucket_component_name
   environment = var.cloudtrail_bucket_environment_name
   stage       = var.cloudtrail_bucket_stage_name
+
+  context = module.this.context
+}
+
+module "account_map" {
+  source  = "cloudposse/stack-config/yaml//modules/remote-state"
+  version = "1.4.2"
+
+  component   = "account-map"
+  environment = module.iam_roles.global_environment_name
+  stage       = module.iam_roles.global_stage_name
 
   context = module.this.context
 }

--- a/modules/cloudtrail/variables.tf
+++ b/modules/cloudtrail/variables.tf
@@ -71,9 +71,3 @@ variable "audit_access_enabled" {
   default     = false
   description = "If `true`, allows the Audit account access to read Cloudtrail logs directly from S3. This is a requirement for running Athena queries in the Audit account."
 }
-
-variable "audit_account_name" {
-  type        = string
-  default     = "core-audit"
-  description = "The key used in Account Map to find the Audit account"
-}


### PR DESCRIPTION
## what
- Correctly pull Audit account from `account-map` for `cloudtrail`

## why
- account-map remote state was missing from the `cloudtrail` component
- Account names should be pulled from account-map, not using a variable

## references
- Resolves change requests https://github.com/cloudposse/terraform-aws-components/pull/638#discussion_r1193297727 and https://github.com/cloudposse/terraform-aws-components/pull/638#discussion_r1193298107
- Closes #672 
- [Internal Slack thread](https://cloudposse.slack.com/archives/CA4TC65HS/p1684122388801769)

