### PR TITLE
EKS terraform module variable type fix

### DIFF
--- a/modules/eks/actions-runner-controller/variables.tf
+++ b/modules/eks/actions-runner-controller/variables.tf
@@ -192,7 +192,7 @@ variable "runners" {
     pull_driven_scaling_enabled    = bool
     labels                         = list(string)
     storage                        = optional(string, null)
-    pvc_enabled                    = optional(string, false)
+    pvc_enabled                    = optional(bool, false)
     resources = object({
       limits = object({
         cpu               = string


### PR DESCRIPTION
## what

- use `bool` rather than `string` type for a variable that's designed to hold `true/false` value

## why

- using `string` makes the [if .Values.pvc_enabled](https://github.com/SpotOnInc/cloudposse-actions-runner-controller-tf-module-bugfix/blob/f224c7a4ee8b2ab4baf6929710d6668bd8fc5e8c/modules/eks/actions-runner-controller/charts/actions-runner/templates/runnerdeployment.yaml#L1) condition always true and creates persistent volumes even if they're not intended to use

