### PR TITLE
`eks/alb-controller-ingress-group`: Corrected Tags to pull LB Data Resource

### DIFF
--- a/modules/eks/alb-controller-ingress-group/default.auto.tfvars
+++ b/modules/eks/alb-controller-ingress-group/default.auto.tfvars
@@ -1,3 +1,0 @@
-# This file is included by default in terraform plans
-
-enabled = false

--- a/modules/eks/alb-controller-ingress-group/main.tf
+++ b/modules/eks/alb-controller-ingress-group/main.tf
@@ -171,7 +171,7 @@ data "aws_lb" "default" {
 
   tags = {
     "ingress.k8s.aws/resource" = "LoadBalancer"
-    "ingress.k8s.aws/stack"    = var.name
+    "ingress.k8s.aws/stack"    = local.ingress_controller_group_name
     "elbv2.k8s.aws/cluster"    = module.eks.outputs.eks_cluster_id
   }
 


### PR DESCRIPTION
## what
- corrected tag reference for pull lb data resource

## why
- the tags that are used to pull the ALB that's created should be filtering using the same group_name that is given when the LB is created

## references
- n/a

