### PR TITLE
feat: add lambda monitors to datadog-monitor

### DIFF
--- a/modules/datadog-monitor/catalog/monitors/lambda-log-forwarder.yaml
+++ b/modules/datadog-monitor/catalog/monitors/lambda-log-forwarder.yaml
@@ -1,0 +1,39 @@
+# The official Datadog API documentation with available query parameters & alert types:
+# https://docs.datadoghq.com/api/v1/monitors/#create-a-monitor
+
+datadog-lambda-forwarder-config-modification:
+  name: "(Lambda) ${ stage } - Datadog Lambda Forwarder Config Changed"
+  type: event-v2 alert
+  query: |
+    events("source:amazon_lambda functionname:${tenant}-${environment}-${ stage }-datadog-lambda-forwarder-logs").rollup("count").last("15m") >= 1
+  message: |
+    Configuration has been changed for the datadog lambda forwarder in
+    ({{tenant.name}}-{{environment.name}}-{{stage.name}})
+    by {{ event.tags.username }}.
+    Event title: {{ event.title }}
+    Lambda function name: {{ event.tags.functionname }}
+    Event ID: {{ event.id }}
+
+  escalation_message: ""
+  tags:
+    managed-by: Terraform
+  notify_no_data: false
+  notify_audit: true
+  require_full_window: true
+  enable_logs_sample: false
+  force_delete: true
+  include_tags: true
+  locked: false
+  renotify_interval: 60
+  timeout_h: 1
+  evaluation_delay: 60
+  new_host_delay: 300
+  no_data_timeframe: 10
+  threshold_windows: { }
+  thresholds:
+    critical: 1
+    #warning:
+    #unknown:
+    #ok:
+    #critical_recovery:
+    #warning_recovery:

--- a/modules/datadog-monitor/catalog/monitors/lambda.yaml
+++ b/modules/datadog-monitor/catalog/monitors/lambda.yaml
@@ -1,0 +1,22 @@
+# The official Datadog API documentation with available query parameters & alert types:
+# https://docs.datadoghq.com/api/v1/monitors/#create-a-monitor
+
+lambda-errors:
+  name: AWS Lambda [{{functionname.name}}] has errors
+  type: query alert
+  query: sum(last_5m):sum:aws.lambda.errors{*} by {stage,tenant,environment,functionname}.as_count() > 0
+  message: |
+    Lambda {{functionname.name}} in
+    ({{tenant.name}}-{{environment.name}}-{{stage.name}})
+    has {{value}} errors over the last 5 minutes.
+  tags: []
+  options:
+    thresholds:
+      critical: 0
+    notify_audit: false
+    require_full_window: false
+    notify_no_data: false
+    renotify_interval: 0
+    include_tags: true
+    evaluation_delay: 900
+    new_group_delay: 60

--- a/modules/datadog-monitor/catalog/monitors/lambda.yaml
+++ b/modules/datadog-monitor/catalog/monitors/lambda.yaml
@@ -10,13 +10,13 @@ lambda-errors:
     ({{tenant.name}}-{{environment.name}}-{{stage.name}})
     has {{value}} errors over the last 5 minutes.
   tags: []
-  options:
-    thresholds:
-      critical: 0
-    notify_audit: false
-    require_full_window: false
-    notify_no_data: false
-    renotify_interval: 0
-    include_tags: true
-    evaluation_delay: 900
-    new_group_delay: 60
+  threshold_windows: { }
+  thresholds:
+    critical: 0
+  notify_audit: false
+  require_full_window: false
+  notify_no_data: false
+  renotify_interval: 0
+  include_tags: true
+  evaluation_delay: 900
+  new_group_delay: 60


### PR DESCRIPTION
## what
* add lambda error monitor
* add datadog lambda log forwarder config monitor

## why
* Observability

