### PR TITLE
Upgrade S3 Bucket module to support recent changes made by AWS team regarding ACL

### DIFF
--- a/modules/s3-bucket/README.md
+++ b/modules/s3-bucket/README.md
@@ -97,7 +97,7 @@ components:
 | <a name="module_account_map"></a> [account\_map](#module\_account\_map) | cloudposse/stack-config/yaml//modules/remote-state | 1.4.1 |
 | <a name="module_bucket_policy"></a> [bucket\_policy](#module\_bucket\_policy) | cloudposse/iam-policy/aws | 0.4.0 |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
-| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | cloudposse/s3-bucket/aws | 3.0.0 |
+| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | cloudposse/s3-bucket/aws | 3.1.1 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 
 ## Resources

--- a/modules/s3-bucket/main.tf
+++ b/modules/s3-bucket/main.tf
@@ -37,7 +37,7 @@ module "bucket_policy" {
 
 module "s3_bucket" {
   source  = "cloudposse/s3-bucket/aws"
-  version = "3.0.0"
+  version = "3.1.1"
 
   bucket_name = var.bucket_name
 


### PR DESCRIPTION
## what
* Upgraded S3 Bucket module version

## why
* Upgrade S3 Bucket module to support recent changes made by AWS team regarding ACL

## references
* https://github.com/cloudposse/terraform-aws-s3-bucket/pull/178
