### PR TITLE
fix: distinct names for lambda monitors in datadog-monitor

### DIFF
--- a/modules/datadog-monitor/catalog/monitors/lambda.yaml
+++ b/modules/datadog-monitor/catalog/monitors/lambda.yaml
@@ -1,0 +1,22 @@
+# The official Datadog API documentation with available query parameters & alert types:
+# https://docs.datadoghq.com/api/v1/monitors/#create-a-monitor
+
+lambda-errors:
+  name: AWS Lambda ${ tenant }-${ environment }-${ stage } has errors
+  type: query alert
+  query: sum(last_5m):sum:aws.lambda.errors{*} by {stage,tenant,environment,functionname}.as_count() > 0
+  message: |
+    Lambda {{functionname.name}} in
+    ({{tenant.name}}-{{environment.name}}-{{stage.name}})
+    has {{value}} errors over the last 5 minutes.
+  tags: []
+  threshold_windows: { }
+  thresholds:
+    critical: 0
+  notify_audit: false
+  require_full_window: false
+  notify_no_data: false
+  renotify_interval: 0
+  include_tags: true
+  evaluation_delay: 900
+  new_group_delay: 60


### PR DESCRIPTION
## what
* better qualify the name of lambda monitors

## why
* names were colliding and preventing multiple lambda monitors for different
stages
* name had invalid template text

