### PR TITLE
Made AWS Config respect privileged argument

### DIFF
--- a/modules/aws-config/providers.tf
+++ b/modules/aws-config/providers.tf
@@ -3,7 +3,7 @@ provider "aws" {
 
   profile = module.iam_roles.profiles_enabled ? coalesce(var.import_profile_name, module.iam_roles.terraform_profile_name) : null
   dynamic "assume_role" {
-    for_each = module.iam_roles.profiles_enabled ? [] : ["role"]
+    for_each = var.privileged || module.iam_roles.profiles_enabled ? [] : ["role"]
     content {
       role_arn = coalesce(var.import_role_arn, module.iam_roles.terraform_role_arn)
     }
@@ -15,7 +15,7 @@ provider "awsutils" {
 
   profile = module.iam_roles.profiles_enabled ? coalesce(var.import_profile_name, module.iam_roles.terraform_profile_name) : null
   dynamic "assume_role" {
-    for_each = module.iam_roles.profiles_enabled ? [] : ["role"]
+    for_each = var.privileged || module.iam_roles.profiles_enabled ? [] : ["role"]
     content {
       role_arn = coalesce(var.import_role_arn, module.iam_roles.terraform_role_arn)
     }
@@ -23,9 +23,9 @@ provider "awsutils" {
 }
 
 module "iam_roles" {
-  source = "../account-map/modules/iam-roles"
-
-  context = module.this.context
+  source     = "../account-map/modules/iam-roles"
+  privileged = var.privileged
+  context    = module.this.context
 }
 
 variable "import_profile_name" {

--- a/modules/aws-config/remote-state.tf
+++ b/modules/aws-config/remote-state.tf
@@ -19,7 +19,7 @@ module "config_bucket" {
   tenant      = (var.config_bucket_tenant != "") ? var.config_bucket_tenant : module.this.tenant
   stage       = var.config_bucket_stage
   environment = var.config_bucket_env
-  privileged  = false
+  privileged  = var.privileged
 
   context = module.this.context
 }
@@ -44,6 +44,7 @@ module "aws_team_roles" {
 
   component   = "aws-team-roles"
   environment = var.iam_roles_environment_name
+  privileged  = var.privileged
 
   context = module.this.context
 }


### PR DESCRIPTION
## what
* Made AWS Config respect privileged argument

## why
* While applying to some accounts like `root` or `identity` user should be `SuperAdmin`. Once user is SuperAdmin remote-state will not be pulled. In this case variable `var.privileged=true` fixes this issue.

## references
