### PR TITLE
Preserve custom roles when vendoring in updates

### DIFF
--- a/modules/aws-team-roles/additional-policy-map.tf
+++ b/modules/aws-team-roles/additional-policy-map.tf
@@ -2,8 +2,9 @@ locals {
   # If you have custom policies, override this declaration by creating
   # a file called `additional-policy-map_override.tf`.
   # Then add the custom policies to the additional_custom_policy_map in that file.
+  # See the README for more details.
   overridable_additional_custom_policy_map = {
     # Example:
-    #   eks_viewer        = try(aws_iam_policy.eks_viewer[0].arn, null)
+    #   eks_viewer = aws_iam_policy.eks_viewer.arn
   }
 }

--- a/modules/aws-team-roles/additional-policy-map.tf
+++ b/modules/aws-team-roles/additional-policy-map.tf
@@ -1,10 +1,8 @@
 locals {
-  # If you have custom policies, delete this file and add
-  #      - "**/additional-policy-map.tf"
-  # to `excluded_paths` in component.yaml
-
-  # Then add the custom policies to the additional_custom_policy_map in another file.
-  additional_custom_policy_map = {
+  # If you have custom policies, override this declaration by creating
+  # a file called `additional-policy-map_override.tf`.
+  # Then add the custom policies to the additional_custom_policy_map in that file.
+  overridable_additional_custom_policy_map = {
     # Example:
     #   eks_viewer        = try(aws_iam_policy.eks_viewer[0].arn, null)
   }

--- a/modules/aws-team-roles/additional-policy-map.tf
+++ b/modules/aws-team-roles/additional-policy-map.tf
@@ -1,0 +1,11 @@
+locals {
+  # If you have custom policies, delete this file and add
+  #      - "**/additional-policy-map.tf"
+  # to `excluded_paths` in component.yaml
+
+  # Then add the custom policies to the additional_custom_policy_map in another file.
+  additional_custom_policy_map = {
+    # Example:
+    #   eks_viewer        = try(aws_iam_policy.eks_viewer[0].arn, null)
+  }
+}

--- a/modules/aws-team-roles/main.tf
+++ b/modules/aws-team-roles/main.tf
@@ -16,7 +16,7 @@ locals {
     support           = try(aws_iam_policy.support[0].arn, null)
     eks_viewer        = try(aws_iam_policy.eks_viewer[0].arn, null)
   }
-  custom_policy_map = merge(local.supplied_custom_policy_map, local.additional_custom_policy_map)
+  custom_policy_map = merge(local.supplied_custom_policy_map, local.overridable_additional_custom_policy_map)
 
   configured_policies = flatten([for k, v in local.roles_config : v.role_policy_arns])
 

--- a/modules/aws-team-roles/main.tf
+++ b/modules/aws-team-roles/main.tf
@@ -10,12 +10,13 @@ locals {
   # If you want to create custom policies to add to multiple roles by name, create the policy
   # using an aws_iam_policy resource and then map it to the name you want to use in the
   # YAML configuration by adding an entry in `custom_policy_map`.
-  custom_policy_map = {
+  supplied_custom_policy_map = {
     billing_read_only = try(aws_iam_policy.billing_read_only[0].arn, null)
     billing_admin     = try(aws_iam_policy.billing_admin[0].arn, null)
     support           = try(aws_iam_policy.support[0].arn, null)
     eks_viewer        = try(aws_iam_policy.eks_viewer[0].arn, null)
   }
+  custom_policy_map = merge(local.supplied_custom_policy_map, local.additional_custom_policy_map)
 
   configured_policies = flatten([for k, v in local.roles_config : v.role_policy_arns])
 

--- a/modules/aws-teams/README.md
+++ b/modules/aws-teams/README.md
@@ -6,7 +6,7 @@ This component implements the hub of a hub-and-spoke account access hierarchy, w
 This allows you to assign each user to a single "team" (implemented as an IAM role) in the `identity` account, which they access
 via a single authentication (login), which then allows them to access a set of roles in a set of accounts.
 
-This component is responsible for provisioning team roles the centralized identity account.
+This component is responsible for provisioning team roles in the centralized identity account.
 This is expected to be used alongside [the `aws-team-roles` component](../aws-team-roles)
 which provisions the roles in the spoke accounts and configures their privileges and which teams can access them.
 

--- a/modules/aws-teams/README.md
+++ b/modules/aws-teams/README.md
@@ -1,14 +1,23 @@
 # Component: `aws-teams`
 
-This component is responsible for provisioning all primary user and system roles into the centralized identity account.
-This is expected to be use alongside [the `aws-team-roles` component](../aws-team-roles) to provide
-fine grained role delegation across the account hierarchy.
+## Purpose
+
+This component implements the hub of a hub-and-spoke account access hierarchy, where the hub is the `identity` account.
+This allows you to assign each user to a single "team" (implemented as an IAM role) in the `identity` account, which they access
+via a single authentication (login), which then allows them to access a set of roles in a set of accounts.
+
+This component is responsible for provisioning team roles the centralized identity account.
+This is expected to be used alongside [the `aws-team-roles` component](../aws-team-roles)
+which provisions the roles in the spoke accounts and configures their privileges and which teams can access them.
 
 ### Teams Function Like Groups and are Implemented as Roles
 The "teams" created in the `identity` account by this module can be thought of as access control "groups":
 a user who is allowed access one of these teams gets access to a set of roles (and corresponding permissions)
 across a set of accounts. Generally, there is nothing else provisioned in the `identity` account,
 so the teams have limited access to resources in the `identity` account by design.
+
+Privileges for the users within the identity account itself are generally limited, and are configured
+via the `role_policy_arns` variable, just as with `aws-team-roles`. See the `aws-team-roles` README for more details.
 
 Teams are implemented as IAM Roles in each account. Access to the "teams" in the `identity`
 account is controlled by the `aws-saml` and `aws-sso` components. Access to the roles in all the

--- a/modules/aws-teams/additional-policy-map.tf
+++ b/modules/aws-teams/additional-policy-map.tf
@@ -2,8 +2,9 @@ locals {
   # If you have custom policies, override this declaration by creating
   # a file called `additional-policy-map_override.tf`.
   # Then add the custom policies to the additional_custom_policy_map in that file.
+  # See the README in `aws-team-roles` for more details.
   overridable_additional_custom_policy_map = {
     # Example:
-    #   eks_viewer        = try(aws_iam_policy.eks_viewer[0].arn, null)
+    #   eks_viewer = aws_iam_policy.eks_viewer.arn
   }
 }

--- a/modules/aws-teams/additional-policy-map.tf
+++ b/modules/aws-teams/additional-policy-map.tf
@@ -1,10 +1,8 @@
 locals {
-  # If you have custom policies, delete this file and add
-  #      - "**/additional-policy-map.tf"
-  # to `excluded_paths` in component.yaml
-
-  # Then add the custom policies to the additional_custom_policy_map in another file.
-  additional_custom_policy_map = {
+  # If you have custom policies, override this declaration by creating
+  # a file called `additional-policy-map_override.tf`.
+  # Then add the custom policies to the additional_custom_policy_map in that file.
+  overridable_additional_custom_policy_map = {
     # Example:
     #   eks_viewer        = try(aws_iam_policy.eks_viewer[0].arn, null)
   }

--- a/modules/aws-teams/additional-policy-map.tf
+++ b/modules/aws-teams/additional-policy-map.tf
@@ -1,0 +1,11 @@
+locals {
+  # If you have custom policies, delete this file and add
+  #      - "**/additional-policy-map.tf"
+  # to `excluded_paths` in component.yaml
+
+  # Then add the custom policies to the additional_custom_policy_map in another file.
+  additional_custom_policy_map = {
+    # Example:
+    #   eks_viewer        = try(aws_iam_policy.eks_viewer[0].arn, null)
+  }
+}

--- a/modules/aws-teams/main.tf
+++ b/modules/aws-teams/main.tf
@@ -10,7 +10,7 @@ locals {
     team_role_access = aws_iam_policy.team_role_access.arn
     support          = try(aws_iam_policy.support[0].arn, null)
   }
-  custom_policy_map = merge(local.supplied_custom_policy_map, local.additional_custom_policy_map)
+  custom_policy_map = merge(local.supplied_custom_policy_map, local.overridable_additional_custom_policy_map)
 
   configured_policies = flatten([for k, v in local.roles_config : v.role_policy_arns])
 

--- a/modules/aws-teams/main.tf
+++ b/modules/aws-teams/main.tf
@@ -6,10 +6,11 @@ locals {
   # If you want to create custom policies to add to multiple roles by name, create the policy
   # using an aws_iam_policy resource and then map it to the name you want to use in the
   # YAML configuration by adding an entry in `custom_policy_map`.
-  custom_policy_map = {
+  supplied_custom_policy_map = {
     team_role_access = aws_iam_policy.team_role_access.arn
     support          = try(aws_iam_policy.support[0].arn, null)
   }
+  custom_policy_map = merge(local.supplied_custom_policy_map, local.additional_custom_policy_map)
 
   configured_policies = flatten([for k, v in local.roles_config : v.role_policy_arns])
 


### PR DESCRIPTION
## what

- Add `additional-policy-map.tf` as glue meant to be replaced by customers with map of their custom policies.

## why

- Currently, custom polices have to be manually added to the map in `main.tf`, but that gets overwritten with every vendor update. Putting that map in a separate, optional file allows for the custom code to survive vendoring.



