### PR TITLE
`.editorconfig` Typo

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,7 +17,7 @@ indent_style = tab
 indent_size = 4
 
 [{*.yaml,*.yml,*.md}]
-intent_style = space
+indent_style = space
 indent_size = 2
 
 [*.sh]


### PR DESCRIPTION
## what
fixed intent typo

## why
should be spelled "indent"

## references
https://cloudposse.slack.com/archives/C01EY65H1PA/p1685638634845009

