### PR TITLE
Expand ECR GH OIDC Default Policy

### DIFF
--- a/mixins/github-actions-iam-policy/ecr/github-actions-iam-policy.tf
+++ b/mixins/github-actions-iam-policy/ecr/github-actions-iam-policy.tf
@@ -1,37 +1,55 @@
 locals {
-  github_actions_iam_policy = join("", data.aws_iam_policy_document.github_actions_iam_policy.*.json)
+  enabled                   = module.this.enabled
+  github_actions_iam_policy = data.aws_iam_policy_document.github_actions_iam_policy.json
+  ecr_resources_static      = [for k, v in module.ecr.repository_arn_map : v]
+  ecr_resources_wildcard    = [for k, v in module.ecr.repository_arn_map : "${v}/*"]
+  resources                 = concat(local.ecr_resources_static, local.ecr_resources_wildcard)
 }
 
 data "aws_iam_policy_document" "github_actions_iam_policy" {
-  count = var.github_actions_iam_role_enabled ? 1 : 0
-
-  # Permissions copied from https://docs.aws.amazon.com/AmazonECR/latest/userguide/security-iam-awsmanpol.html#security-iam-awsmanpol-AmazonEC2ContainerRegistryPowerUser
-  # This policy grants administrative permissions that allow IAM users to read and write to repositories,
-  # but doesn't allow them to delete repositories or change the policy documents that are applied to them.
   statement {
-    sid    = "AmazonEC2ContainerRegistryPowerUser"
+    sid    = "AllowECRPermissions"
+    effect = "Allow"
+    actions = [
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:BatchDeleteImage",
+      "ecr:BatchGetImage",
+      "ecr:CompleteLayerUpload",
+      "ecr:DeleteLifecyclePolicy",
+      "ecr:DescribeImages",
+      "ecr:DescribeImageScanFindings",
+      "ecr:DescribeRepositories",
+      "ecr:GetAuthorizationToken",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:GetLifecyclePolicy",
+      "ecr:GetLifecyclePolicyPreview",
+      "ecr:GetRepositoryPolicy",
+      "ecr:InitiateLayerUpload",
+      "ecr:ListImages",
+      "ecr:PutImage",
+      "ecr:PutImageScanningConfiguration",
+      "ecr:PutImageTagMutability",
+      "ecr:PutLifecyclePolicy",
+      "ecr:StartImageScan",
+      "ecr:StartLifecyclePolicyPreview",
+      "ecr:TagResource",
+      "ecr:UntagResource",
+      "ecr:UploadLayerPart",
+    ]
+    resources = local.resources
+  }
+
+  # required as minimum permissions for pushing and logging into a public ECR repository
+  # https://github.com/aws-actions/amazon-ecr-login#permissions
+  # https://docs.aws.amazon.com/AmazonECR/latest/public/docker-push-ecr-image.html
+  statement {
+    sid    = "AllowEcrGetAuthorizationToken"
     effect = "Allow"
     actions = [
       "ecr:GetAuthorizationToken",
-      "ecr:BatchCheckLayerAvailability",
-      "ecr:GetDownloadUrlForLayer",
-      "ecr:GetRepositoryPolicy",
-      "ecr:DescribeRepositories",
-      "ecr:ListImages",
-      "ecr:DescribeImages",
-      "ecr:BatchGetImage",
-      "ecr:GetLifecyclePolicy",
-      "ecr:GetLifecyclePolicyPreview",
-      "ecr:ListTagsForResource",
-      "ecr:DescribeImageScanFindings",
-      "ecr:InitiateLayerUpload",
-      "ecr:UploadLayerPart",
-      "ecr:CompleteLayerUpload",
-      "ecr:PutImage",
+      "sts:GetServiceBearerToken"
     ]
-
-    #bridgecrew:skip=BC_AWS_IAM_57:OK to allow write access to all ECRs because ECRs have their own access policies
-    # and this policy prohibits the user from making changes to the access policy.
     resources = ["*"]
   }
 }
+


### PR DESCRIPTION
## what
- updated default ECR GH OIDC policy

## why
- This policy should grant GH OIDC access both public and private ECR repos

## references
- https://cloudposse.slack.com/archives/CA4TC65HS/p1685993698149499?thread_ts=1685990234.560589&cid=CA4TC65HS
