### PR TITLE
Fix documentation for eks/external-secrets-operator

### DIFF
--- a/modules/eks/external-secrets-operator/examples/app-secrets.yaml
+++ b/modules/eks/external-secrets-operator/examples/app-secrets.yaml
@@ -1,24 +1,24 @@
-# example to fetch all secrets underneath the `/app` prefix (service).
-# Keys are rewritten within the K8S Secret to be predictable and omit the 
+# example to fetch all secrets underneath the `/app/` prefix (service).
+# Keys are rewritten within the K8S Secret to be predictable and omit the
 # prefix.
 
-apiVersion: external-secrets.io/v1beta1 
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: app-secrets
 spec:
-  refreshInterval: "0"
+  refreshInterval: 30s
   secretStoreRef:
-    name: "secret-store-parameter-store"
-    kind: SecretStore
+    name: "secret-store-parameter-store" # Must match name of the Cluster Secret Store created by this component
+    kind: ClusterSecretStore
   target:
-    creationPolicy: 'Owner'
+    creationPolicy: Owner
     name: app-secrets
   dataFrom:
-    - find:
-        name:
-          regexp: "^/app"
-      rewrite:
-        - regexp:
-            source: "/app/(.*)"
-            target: "$1"
+  - find:
+      name:
+        regexp: "^/app/" # Match the path prefix of your service
+    rewrite:
+    - regexp:
+        source: "/app/(.*)" # Remove the path prefix of your service from the name before creating the envars
+        target: "$1"

--- a/modules/eks/external-secrets-operator/examples/external-secrets.yaml
+++ b/modules/eks/external-secrets-operator/examples/external-secrets.yaml
@@ -1,16 +1,16 @@
 # example to fetch a single secret from our Parameter Store `SecretStore`
 
-apiVersion: external-secrets.io/v1beta1 
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: single-secret
 spec:
-  refreshInterval: 0
+  refreshInterval: 30s
   secretStoreRef:
-    name: "secret-store-parameter-store"
-    kind: SecretStore
+    name: "secret-store-parameter-store" # Must match name of the Cluster Secret Store created by this component
+    kind: ClusterSecretStore
   target:
-    creationPolicy: 'Owner'
+    creationPolicy: Owner
     name: single-secret
   data:
   - secretKey: good_secret


### PR DESCRIPTION
## what

- Update documentation and examples for `eks/external-secrets-operator` to properly show that the component creates `ClusterSecretStores` and not `SecretStores` (namespaced)

## why

- Previous documentation lead to improper (failed) operation


