### PR TITLE
fix: correct aws-ssosync outputs and logging

### DIFF
--- a/modules/aws-ssosync/.gitignore
+++ b/modules/aws-ssosync/.gitignore
@@ -1,0 +1,3 @@
+*.zip
+*.tar.gz
+dist

--- a/modules/aws-ssosync/README.md
+++ b/modules/aws-ssosync/README.md
@@ -150,7 +150,9 @@ Make sure that all four of the following SSM parameters exist in the `identity` 
 |------|------|
 | [aws_cloudwatch_event_rule.ssosync](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
 | [aws_cloudwatch_event_target.ssosync](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
+| [aws_cloudwatch_log_group.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_iam_role.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.cloudwatch_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_lambda_function.ssosync](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
 | [aws_lambda_permission.allow_cloudwatch_execution](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [null_resource.extract_my_tgz](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |

--- a/modules/aws-ssosync/iam.tf
+++ b/modules/aws-ssosync/iam.tf
@@ -42,3 +42,10 @@ resource "aws_iam_role" "default" {
     policy = data.aws_iam_policy_document.ssosync_lambda_identity_center.json
   }
 }
+
+resource "aws_iam_role_policy_attachment" "cloudwatch_logs" {
+  count = local.enabled ? 1 : 0
+
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+  role       = aws_iam_role.default[0].name
+}

--- a/modules/aws-ssosync/main.tf
+++ b/modules/aws-ssosync/main.tf
@@ -116,6 +116,9 @@ resource "aws_cloudwatch_event_target" "ssosync" {
   arn       = aws_lambda_function.ssosync[0].arn
 }
 
+resource "aws_cloudwatch_log_group" "default" {
+  name = "/aws/lambda/${module.this.id}"
+}
 
 resource "aws_lambda_permission" "allow_cloudwatch_execution" {
   count = local.enabled ? 1 : 0

--- a/modules/aws-ssosync/main.tf
+++ b/modules/aws-ssosync/main.tf
@@ -96,7 +96,7 @@ resource "aws_lambda_function" "ssosync" {
       SSOSYNC_LOAD_ASM_SECRETS   = false
     }
   }
-  depends_on = [null_resource.extract_my_tgz, data.archive_file.lambda]
+  depends_on = [null_resource.extract_my_tgz, data.archive_file.lambda, aws_cloudwatch_log_group.default[0]]
 }
 
 resource "aws_cloudwatch_event_rule" "ssosync" {
@@ -117,7 +117,8 @@ resource "aws_cloudwatch_event_target" "ssosync" {
 }
 
 resource "aws_cloudwatch_log_group" "default" {
-  name = "/aws/lambda/${module.this.id}"
+  count = local.enabled ? 1 : 0
+  name  = "/aws/lambda/${module.this.id}"
 }
 
 resource "aws_lambda_permission" "allow_cloudwatch_execution" {

--- a/modules/aws-ssosync/outputs.tf
+++ b/modules/aws-ssosync/outputs.tf
@@ -1,14 +1,14 @@
 output "arn" {
   description = "ARN of the lambda function"
-  value       = aws_lambda_function.ssosync.arn
+  value       = join("", aws_lambda_function.ssosync.*.arn)
 }
 
 output "invoke_arn" {
   description = "Invoke ARN of the lambda function"
-  value       = aws_lambda_function.ssosync.invoke_arn
+  value       = join("", aws_lambda_function.ssosync.*.invoke_arn)
 }
 
 output "qualified_arn" {
   description = "ARN identifying your Lambda Function Version (if versioning is enabled via publish = true)"
-  value       = aws_lambda_function.ssosync.qualified_arn
+  value       = join("", aws_lambda_function.ssosync.*.qualified_arn)
 }


### PR DESCRIPTION
## what
* aws-ssosync
  * add log-group
  * add service policy
  * adjust outputs to support enabled flag

## why
* won't deploy without output changes
* logging needs a group and permissions to add to it

## references
* [Notes on the
service-role](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AWSLambdaBasicExecutionRole.html)
  * Yes, the resources is a '*', so I'd be okay with potentially changing this
  to be finer grained if folks feel like logging should be more secure around
  user syncs
