### PR TITLE
Add `dns-primary` to `eks/cert-manager`

### DIFF
--- a/modules/eks/cert-manager/README.md
+++ b/modules/eks/cert-manager/README.md
@@ -72,6 +72,7 @@ The default catalog values `e.g. stacks/catalog/eks/cert-manager.yaml`
 | <a name="module_cert_manager"></a> [cert\_manager](#module\_cert\_manager) | cloudposse/helm-release/aws | 0.7.0 |
 | <a name="module_cert_manager_issuer"></a> [cert\_manager\_issuer](#module\_cert\_manager\_issuer) | cloudposse/helm-release/aws | 0.7.0 |
 | <a name="module_dns_gbl_delegated"></a> [dns\_gbl\_delegated](#module\_dns\_gbl\_delegated) | cloudposse/stack-config/yaml//modules/remote-state | 1.4.1 |
+| <a name="module_dns_gbl_primary"></a> [dns\_gbl\_primary](#module\_dns\_gbl\_primary) | cloudposse/stack-config/yaml//modules/remote-state | 1.4.1 |
 | <a name="module_eks"></a> [eks](#module\_eks) | cloudposse/stack-config/yaml//modules/remote-state | 1.4.1 |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../../account-map/modules/iam-roles | n/a |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |

--- a/modules/eks/cert-manager/main.tf
+++ b/modules/eks/cert-manager/main.tf
@@ -61,7 +61,8 @@ module "cert_manager" {
       resources = [
         for zone_id in concat(
           [],
-          [for value in module.dns_gbl_delegated.outputs.zones : value.zone_id]
+          [for value in module.dns_gbl_delegated.outputs.zones : value.zone_id],
+          [for value in module.dns_gbl_primary.outputs.zones : value.zone_id]
         ) :
         "arn:${local.partition}:route53:::hostedzone/${zone_id}"
       ]

--- a/modules/eks/cert-manager/remote-state.tf
+++ b/modules/eks/cert-manager/remote-state.tf
@@ -27,7 +27,7 @@ module "dns_gbl_primary" {
   # Ignore errors if component doesnt exist
   ignore_errors = true
 
-  # Set empty zone set if component does exist, but doesnt have any zones
+  # Set empty zone set if component does exist but doesnt have any zones
   defaults = {
     zones = {}
   }

--- a/modules/eks/cert-manager/remote-state.tf
+++ b/modules/eks/cert-manager/remote-state.tf
@@ -16,3 +16,21 @@ module "dns_gbl_delegated" {
 
   context = module.this.context
 }
+
+module "dns_gbl_primary" {
+  source  = "cloudposse/stack-config/yaml//modules/remote-state"
+  version = "1.4.1"
+
+  component   = "dns-primary"
+  environment = "gbl"
+
+  # Ignore errors if component doesnt exist
+  ignore_errors = true
+
+  # Set empty zone set if component does exist, but doesnt have any zones
+  defaults = {
+    zones = {}
+  }
+
+  context = module.this.context
+}


### PR DESCRIPTION
## what
- Added dns-primary zones to cert-manager

## why
- We want to allow cert-manager to update Route 53 Hosted Zone records in the primary zones as well. This permission is required for Cert Manager to issue certificates for the primary domains. For example, when `var.letsencrypt_enabled` to set to `true`

## references
- [internal slack reference](https://cloudposse.slack.com/archives/C04N39YPVAS/p1686267088255179?thread_ts=1686265911.001219&cid=C04N39YPVAS)

