### PR TITLE
AWS provider V5 dependency updates

### DIFF
--- a/modules/bastion/main.tf
+++ b/modules/bastion/main.tf
@@ -32,7 +32,7 @@ locals {
 
 module "sg" {
   source  = "cloudposse/security-group/aws"
-  version = "2.0.0"
+  version = "2.2.0"
 
   rules  = var.security_group_rules
   vpc_id = local.vpc_id
@@ -91,7 +91,7 @@ data "aws_ami" "bastion_image" {
 
 module "bastion_autoscale_group" {
   source  = "cloudposse/ec2-autoscale-group/aws"
-  version = "0.30.1"
+  version = "0.34.2"
 
   image_id                    = join("", data.aws_ami.bastion_image.*.id)
   instance_type               = var.instance_type

--- a/modules/cloudtrail-bucket/main.tf
+++ b/modules/cloudtrail-bucket/main.tf
@@ -1,6 +1,6 @@
 module "cloudtrail_s3_bucket" {
   source  = "cloudposse/cloudtrail-s3-bucket/aws"
-  version = "0.25.0"
+  version = "0.26.1"
 
   acl                                = var.acl
   expiration_days                    = var.expiration_days

--- a/modules/config-bucket/main.tf
+++ b/modules/config-bucket/main.tf
@@ -1,6 +1,6 @@
 module "config_bucket" {
   source  = "cloudposse/config-storage/aws"
-  version = "0.8.1"
+  version = "1.0.0"
 
   expiration_days                    = var.expiration_days
   force_destroy                      = false

--- a/modules/datadog-logs-archive/main.tf
+++ b/modules/datadog-logs-archive/main.tf
@@ -138,7 +138,7 @@ data "aws_iam_policy_document" "default" {
 
 module "bucket_policy" {
   source  = "cloudposse/iam-policy/aws"
-  version = "0.3.0"
+  version = "1.0.1"
 
   iam_policy_statements = try(lookup(local.policy, "Statement"), null)
 
@@ -159,7 +159,7 @@ data "aws_partition" "current" {
 
 module "archive_bucket" {
   source  = "cloudposse/s3-bucket/aws"
-  version = "2.0.1"
+  version = "3.1.2"
 
   count = local.enabled ? 1 : 0
 
@@ -218,7 +218,7 @@ module "archive_bucket" {
 
 module "cloudtrail_s3_bucket" {
   source  = "cloudposse/s3-bucket/aws"
-  version = "2.0.1"
+  version = "3.1.2"
 
   depends_on = [data.aws_iam_policy_document.default]
 


### PR DESCRIPTION
## what
* Update component dependencies for the AWS provider V5

Requested components:
cloudtrail-bucket
config-bucket
datadog-logs-archive
eks/argocd
eks/efs-controller
eks/metric-server
spacelift-worker-pool
eks/external-secrets-operator

## why
* Maintenance

