### PR TITLE
Bump `cloudposse/ec2-autoscale-group/aws` to `0.35.0`

### DIFF
--- a/modules/bastion/README.md
+++ b/modules/bastion/README.md
@@ -71,7 +71,7 @@ components:
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_bastion_autoscale_group"></a> [bastion\_autoscale\_group](#module\_bastion\_autoscale\_group) | cloudposse/ec2-autoscale-group/aws | 0.30.1 |
+| <a name="module_bastion_autoscale_group"></a> [bastion\_autoscale\_group](#module\_bastion\_autoscale\_group) | cloudposse/ec2-autoscale-group/aws | 0.35.0 |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
 | <a name="module_sg"></a> [sg](#module\_sg) | cloudposse/security-group/aws | 2.0.0 |
 | <a name="module_ssm_tls_ssh_key_pair"></a> [ssm\_tls\_ssh\_key\_pair](#module\_ssm\_tls\_ssh\_key\_pair) | cloudposse/ssm-tls-ssh-key-pair/aws | 0.10.2 |

--- a/modules/bastion/main.tf
+++ b/modules/bastion/main.tf
@@ -91,7 +91,7 @@ data "aws_ami" "bastion_image" {
 
 module "bastion_autoscale_group" {
   source  = "cloudposse/ec2-autoscale-group/aws"
-  version = "0.30.1"
+  version = "0.35.0"
 
   image_id                    = join("", data.aws_ami.bastion_image.*.id)
   instance_type               = var.instance_type

--- a/modules/github-runners/README.md
+++ b/modules/github-runners/README.md
@@ -180,7 +180,7 @@ chamber write github token <value>
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_account_map"></a> [account\_map](#module\_account\_map) | cloudposse/stack-config/yaml//modules/remote-state | 1.4.1 |
-| <a name="module_autoscale_group"></a> [autoscale\_group](#module\_autoscale\_group) | cloudposse/ec2-autoscale-group/aws | 0.30.1 |
+| <a name="module_autoscale_group"></a> [autoscale\_group](#module\_autoscale\_group) | cloudposse/ec2-autoscale-group/aws | 0.35.0 |
 | <a name="module_graceful_scale_in"></a> [graceful\_scale\_in](#module\_graceful\_scale\_in) | ./modules/graceful_scale_in | n/a |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
 | <a name="module_sg"></a> [sg](#module\_sg) | cloudposse/security-group/aws | 1.0.1 |

--- a/modules/github-runners/main.tf
+++ b/modules/github-runners/main.tf
@@ -107,7 +107,7 @@ module "sg" {
 
 module "autoscale_group" {
   source  = "cloudposse/ec2-autoscale-group/aws"
-  version = "0.30.1"
+  version = "0.35.0"
 
   image_id                    = join("", data.aws_ami.runner.*.id)
   instance_type               = var.instance_type


### PR DESCRIPTION
## what
- bumped ASG module version, `cloudposse/ec2-autoscale-group/aws` to `0.35.0`

## why
- Recent versions of this module resolve errors for these components

## references
- https://github.com/cloudposse/terraform-aws-ec2-autoscale-group
