### PR TITLE
Add Missing `github-oidc-provider` Thumbprint

### DIFF
--- a/modules/github-oidc-provider/README.md
+++ b/modules/github-oidc-provider/README.md
@@ -33,6 +33,13 @@ the provider's thumbprint may change, at which point you can use
 [scripts/get_github_oidc_thumbprint.sh](./scripts/get_github_oidc_thumbprint.sh)
 to get the new thumbprint and add it to the list in `var.thumbprint_list`.
 
+This script will pull one of two thumbprints. There are two possible intermediary certificates for the Actions SSL
+certificate and either can be returned by the GitHub servers, requiring customers to trust both. This is a known
+behavior when the intermediary certificates are cross-signed by the CA. Therefore, run this script until both values
+are retrieved. Add both to `var.thumbprint_list`.
+
+For more, see https://github.blog/changelog/2023-06-27-github-actions-update-on-oidc-integration-with-aws/
+
 ## FAQ
 
 ### I cannot assume the role from GitHub Actions after deploying

--- a/modules/github-oidc-provider/README.md
+++ b/modules/github-oidc-provider/README.md
@@ -102,7 +102,7 @@ permissions:
 | <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
 | <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |
-| <a name="input_thumbprint_list"></a> [thumbprint\_list](#input\_thumbprint\_list) | List of OIDC provider certificate thumbprints | `list(string)` | <pre>[<br>  "6938fd4d98bab03faadb97b34396831e3780aea1"<br>]</pre> | no |
+| <a name="input_thumbprint_list"></a> [thumbprint\_list](#input\_thumbprint\_list) | List of OIDC provider certificate thumbprints | `list(string)` | <pre>[<br>  "6938fd4d98bab03faadb97b34396831e3780aea1",<br>  "1c58a3a8518e8759bf075b76b750d4f2df264fcd"<br>]</pre> | no |
 
 ## Outputs
 

--- a/modules/github-oidc-provider/scripts/get_github_oidc_thumbprint.sh
+++ b/modules/github-oidc-provider/scripts/get_github_oidc_thumbprint.sh
@@ -4,6 +4,13 @@
 # This script downloads the certificate information from $GITHUB_OIDC_HOST, extracts the certificate material, then uses
 # the openssl command to calculate the thumbprint. It is meant to be called manually and the output used to populate
 # the `thumbprint_list` variable in the terraform configuration for this module.
+#
+# This script will pull one of two thumbprints. There are two possible intermediary certificates for the Actions SSL
+# certificate and either can be returned by the GitHub servers, requiring customers to trust both. This is a known
+# behavior when the intermediary certificates are cross-signed by the CA. Therefore, run this script until both values
+# are retrieved.
+#
+# For more, see https://github.blog/changelog/2023-06-27-github-actions-update-on-oidc-integration-with-aws/
 ########################################################################################################################
 GITHUB_OIDC_HOST="token.actions.githubusercontent.com"
 THUMBPRINT=$(echo \

--- a/modules/github-oidc-provider/variables.tf
+++ b/modules/github-oidc-provider/variables.tf
@@ -6,5 +6,5 @@ variable "region" {
 variable "thumbprint_list" {
   type        = list(string)
   description = "List of OIDC provider certificate thumbprints"
-  default     = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
+  default     = ["6938fd4d98bab03faadb97b34396831e3780aea1", "1c58a3a8518e8759bf075b76b750d4f2df264fcd"]
 }


### PR DESCRIPTION
## what
- include both thumbprints for GitHub OIDC

## why
- There are two possible intermediary certificates for the Actions SSL certificate and either can be returned by Github's servers, requiring customers to trust both. This is a known behavior when the intermediary certificates are cross-signed by the CA. 

## references
- https://github.blog/changelog/2023-06-27-github-actions-update-on-oidc-integration-with-aws/
