### PR TITLE
Added policy for extending Poweruser for `aws-teams`

### DIFF
--- a/modules/aws-teams/README.md
+++ b/modules/aws-teams/README.md
@@ -158,11 +158,13 @@ components:
 
 | Name | Type |
 |------|------|
+| [aws_iam_policy.extended_poweruser](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.team_role_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [local_file.account_info](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
 | [aws_iam_policy_document.assume_role_aggregated](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.extended_poweruser](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.team_role_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs

--- a/modules/aws-teams/main.tf
+++ b/modules/aws-teams/main.tf
@@ -7,7 +7,8 @@ locals {
   # using an aws_iam_policy resource and then map it to the name you want to use in the
   # YAML configuration by adding an entry in `custom_policy_map`.
   supplied_custom_policy_map = {
-    team_role_access = aws_iam_policy.team_role_access.arn
+    team_role_access   = aws_iam_policy.team_role_access.arn
+    extended_poweruser = try(aws_iam_policy.extended_poweruser[0].arn, null)
   }
   custom_policy_map = merge(local.supplied_custom_policy_map, local.overridable_additional_custom_policy_map)
 

--- a/modules/aws-teams/policy-extended-poweruser.tf
+++ b/modules/aws-teams/policy-extended-poweruser.tf
@@ -1,4 +1,4 @@
-# This policy adds additional permission required to apply a limit set of Terraform
+# This policy adds additional permission required to apply a limited set of Terraform
 # resources in the `core-identity` account. We do not want to grant the full
 # admin access to `core-identity` so that we do not allow users to lock themselves out.
 

--- a/modules/aws-teams/policy-extended-poweruser.tf
+++ b/modules/aws-teams/policy-extended-poweruser.tf
@@ -1,0 +1,33 @@
+# This policy adds additional permission required to apply a limit set of Terraform
+# resources in the `core-identity` account. We do not want to grant the full
+# admin access to `core-identity` so that we do not allow users to lock themselves out.
+
+locals {
+  extended_poweruser_policy_enabled = contains(local.configured_policies, "extended_poweruser")
+}
+
+data "aws_iam_policy_document" "extended_poweruser" {
+  count = local.extended_poweruser_policy_enabled ? 1 : 0
+
+  statement {
+    sid    = "ExtendedPowerUserAccess"
+    effect = "Allow"
+    actions = [
+      "iam:GetOpenIDConnectProvider",
+      "iam:UpdateOpenIDConnectProviderThumbprint"
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "extended_poweruser" {
+  count = local.extended_poweruser_policy_enabled ? 1 : 0
+
+  name   = format("%s-extended-poweruser", module.this.id)
+  policy = data.aws_iam_policy_document.extended_poweruser[0].json
+
+  tags = module.this.tags
+}


### PR DESCRIPTION
## what
- Added a policy to extend the Poweruser access for the `devops` team in `core-identity`

## why
- Since we are no longer using `SuperAdmin` to apply `github-oidc-provider` across the accounts, we need permission to apply the component in each account using the given AWS IAM role. In all accounts except `core-identity`, this is already Admin, so this is a non problem. 
- However in `core-identity` only, we dont want to do that because we dont want to give `devops` the ability to lock itself out in the middle of an apply, and PowerUser alone is not enough.
- Add only the permission we need to the `devops` team. I created an `extended_poweruser` policy that adds only what we need to plan and apply, and I attached that to the `devops` team in `core-identity`

## references
- n/a