### PR TITLE
[github-oidc-provider] extra-compatible provider

### DIFF
--- a/modules/github-oidc-provider/README.md
+++ b/modules/github-oidc-provider/README.md
@@ -107,6 +107,7 @@ permissions:
 | <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br>Characters matching the regex will be removed from the ID elements.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS Region | `string` | n/a | yes |
 | <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
+| <a name="input_superadmin"></a> [superadmin](#input\_superadmin) | Set `true` if running as the SuperAdmin user | `bool` | `false` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
 | <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |
 | <a name="input_thumbprint_list"></a> [thumbprint\_list](#input\_thumbprint\_list) | List of OIDC provider certificate thumbprints | `list(string)` | <pre>[<br>  "6938fd4d98bab03faadb97b34396831e3780aea1",<br>  "1c58a3a8518e8759bf075b76b750d4f2df264fcd"<br>]</pre> | no |

--- a/modules/github-oidc-provider/providers.tf
+++ b/modules/github-oidc-provider/providers.tf
@@ -30,7 +30,7 @@ provider "aws" {
       !var.superadmin && module.iam_roles.profiles_enabled ? null : (
         var.superadmin ? {
           role_arn = module.iam_roles.org_role_arn
-        } : {
+          } : {
           role_arn = module.iam_roles.terraform_role_arn
         }
       )

--- a/modules/github-oidc-provider/providers.tf
+++ b/modules/github-oidc-provider/providers.tf
@@ -1,19 +1,56 @@
+# This is a special provider configuration that allows us to use many different
+# versions of the Cloud Posse reference architecture to deploy this component
+# in any account, including the identity and root accounts.
+
+# If you have dynamic Terraform roles enabled and an `aws-team` (such as `managers`)
+# empowered to make changes in the identity and root accounts. Then you can
+# use those roles to deploy this component in the identity and root accounts,
+# just like almost any other component.
+#
+# If you are restricted to using the SuperAdmin role to deploy this component
+# in the identity and root accounts, then modify the stack configuration for
+# this component for the identity and/or root accounts to set `superadmin: true`
+# and backend `role_arn` to `null`.
+#
+#  components:
+#    terraform:
+#      github-oidc-provider:
+#        backend:
+#          s3:
+#            role_arn: null
+#        vars:
+#          superadmin: true
+
 provider "aws" {
   region = var.region
 
-  # Profile is deprecated in favor of terraform_role_arn. When profiles are not in use, terraform_profile_name is null.
-  profile = module.iam_roles.terraform_profile_name
-
+  profile = !var.superadmin && module.iam_roles.profiles_enabled ? module.iam_roles.terraform_profile_name : null
   dynamic "assume_role" {
-    # module.iam_roles.terraform_role_arn may be null, in which case do not assume a role.
-    for_each = compact([module.iam_roles.terraform_role_arn])
+    for_each = [
+      !var.superadmin && module.iam_roles.profiles_enabled ? null : (
+        var.superadmin ? {
+          role_arn = module.iam_roles.org_role_arn
+        } : {
+          role_arn = module.iam_roles.terraform_role_arn
+        }
+      )
+    ]
     content {
-      role_arn = assume_role.value
+      role_arn = module.iam_roles.terraform_role_arn
     }
   }
 }
 
+
 module "iam_roles" {
-  source  = "../account-map/modules/iam-roles"
+  source     = "../account-map/modules/iam-roles"
+  privileged = var.superadmin
+
   context = module.this.context
+}
+
+variable "superadmin" {
+  type        = bool
+  default     = false
+  description = "Set `true` if running as the SuperAdmin user"
 }


### PR DESCRIPTION
## what && why

- This updates `provider.tf` to provide compatibility with various legacy configurations as well as the current reference architecture
- This update does NOT require updating `account-map`

## Upgrade notes:

After installing this version of the component, you may need to change the configuration in your stacks.

- If you have dynamic Terraform roles enabled, then this should be configured like a normal component. The previous component may have required you to set 

    ```yaml
    backend:
      s3:
        role_arn: null
    ````
and **that configuration should be removed** everywhere.
- If you only use SuperAdmin to deploy things to the `identity` account, then for the `identity` (and `root`, if applicable) account ***only***, set

    ```yaml
    backend:
      s3:
        role_arn: null
    vars:
      superadmin: true
    ````
**Deployments to other accounts should not have any of those settings**. 