### PR TITLE
Add TFLint configuration

### DIFF
--- a/.github/workflows/pre-commit-check-and-autocommit-changes.yaml
+++ b/.github/workflows/pre-commit-check-and-autocommit-changes.yaml
@@ -73,6 +73,21 @@ jobs:
         with:
           terraform_version: ${{ steps.get-terraform-version.outputs.terraform_semver }}
 
+      # Install TFLint for pre-commit hook
+      - name: TFLint cache plugin dir
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        with:
+          path: ~/.tflint.d/plugins
+          key: ubuntu-latest-tflint-${{ hashFiles('.tflint.hcl') }}
+
+      - name: Setup TFLint
+        uses: terraform-linters/setup-tflint@ba6bb2989f94daf58a4cc6eac2c1ca7398a678bf # v3
+        with:
+          github_token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Init TFLint
+        run: tflint --init
+
       # Install terraform-docs for pre-commit hook
       - name: Install terraform-docs
         shell: bash

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,11 +30,15 @@ repos:
           )$
 
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.80.0
+    rev: v1.81.0
     hooks:
       - id: terraform_fmt
       - id: terraform_docs
         args: ["--args=--lockfile=false"]
+      - id: terraform_tflint
+        args:
+          - --args=--config=__GIT_WORKING_DIR__/.tflint.hcl
+        exclude: "context.tf$"
   - repo: local
     hooks:
       - id: rebuild-mixins-docs

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,0 +1,86 @@
+# Required `tflint --init`
+plugin "aws" {
+    enabled    = true
+    version    = "0.23.1"
+    source     = "github.com/terraform-linters/tflint-ruleset-aws"
+    # Used only in Spacelift: .spacelift/config.yml
+    deep_check = false
+    assume_role { role_arn = "" }
+
+}
+
+#
+# https://github.com/terraform-linters/tflint/tree/master/docs/rules
+#
+
+rule "terraform_comment_syntax" {
+    # Disallow `//` comments in favor of `#`
+    enabled = true
+}
+rule "terraform_deprecated_index" {
+    # Disallow legacy dot index syntax
+    enabled = true
+}
+rule "terraform_deprecated_interpolation" {
+    # Disallow deprecated (0.11-style) interpolation
+    # Enabled by default
+    enabled = true
+}
+rule "terraform_documented_outputs" {
+    # Disallow output declarations without description
+    enabled = true
+}
+rule "terraform_documented_variables" {
+    # Disallow variable declarations without description
+    enabled = true
+}
+rule "terraform_module_pinned_source" {
+    # Disallow specifying a git or mercurial repository as a module source without pinning to a version
+    # Enabled by default
+    enabled = true
+}
+rule "terraform_module_version" {
+    # Checks that Terraform modules sourced from a registry specify a version
+    # Enabled by default
+    enabled = true
+}
+rule "terraform_naming_convention" {
+    # Enforces naming conventions for resources, data sources, etc
+    enabled = true
+}
+rule "terraform_required_providers" {
+    # Require that all providers have version constraints through required_providers
+    enabled = true
+}
+rule "terraform_required_version" {
+    # Disallow terraform declarations without require_version
+    enabled = true
+}
+rule "terraform_standard_module_structure" {
+    # Ensure that a module complies with the Terraform Standard Module Structure
+    enabled = false # TODO p4: enable and fix
+}
+rule "terraform_typed_variables" {
+    # Disallow variable declarations without type
+    enabled = true
+}
+rule "terraform_unused_declarations" {
+    # Disallow variables, data sources, and locals that are declared but never used
+    enabled = true
+}
+rule "terraform_unused_required_providers" {
+    # Check that all required_providers are used in the module
+    enabled = true
+}
+rule "terraform_workspace_remote" {
+    # terraform.workspace should not be used with a "remote" backend with remote execution.
+    # Enabled by default
+    enabled = true
+}
+rule "aws_db_instance_invalid_parameter_group" {
+    # TODO: Figure out requirements to turn this back on; not sure it's providing value even as is due to AWS multi-account arch.
+    enabled = false
+}
+config {
+    variables = ["namespace=fake-namespace", "stage=fake-stage", "name=fake-name"]
+}


### PR DESCRIPTION
## what
* That is a TFLint setup that we use in our repos.

## why
* TFLint is able to detect many deprecations and violations, so better to use it whenever it possible

> **Note**: It's the only configuration as is, not include fixes. I suggest doing next:
> 1. disable all rules
> 2. Enable rules one by one and fix all violations
>
> Also, you may like to `exclude: ^deprecated/` and add `# tflint-ignore: <rule> # <description why it disabled>` in some cases

Here are found violations (`pre-commit run -a`):

```bash
Terraform validate with tflint...........................................Failed
- hook id: terraform_tflint
- exit code: 2

Command 'tflint --init' successfully done:
Plugin `aws` is already installed



TFLint in deprecated/account-map/modules/iam-assume-role-policy/:
3 issue(s) found:

Warning: terraform "required_version" attribute is required (terraform_required_version)

  on  line 0:
   (source code not available)

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_required_version.md

Warning: Missing version constraint for provider "aws" in "required_providers" (terraform_required_providers)

  on main.tf line 50:
  50: data "aws_iam_policy_document" "assume_role" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_required_providers.md

Warning: List items should be accessed using square brackets (terraform_deprecated_index)

  on outputs.tf line 3:
   3:   value       = join("", data.aws_iam_policy_document.assume_role.*.json)

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_deprecated_index.md
TFLint in deprecated/account-map/modules/iam-roles/:
13 issue(s) found:

Warning: terraform "required_version" attribute is required (terraform_required_version)

  on  line 0:
   (source code not available)

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_required_version.md

Notice: `terraform_role_arn` output has no description (terraform_documented_outputs)

  on outputs.tf line 1:
   1: output "terraform_role_arn" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md

Notice: `terraform_profile_name` output has no description (terraform_documented_outputs)

  on outputs.tf line 5:
   5: output "terraform_profile_name" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md

Notice: `org_role_arn` output has no description (terraform_documented_outputs)

  on outputs.tf line 9:
   9: output "org_role_arn" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md

Notice: `dns_terraform_role_arn` output has no description (terraform_documented_outputs)

  on outputs.tf line 16:
  16: output "dns_terraform_role_arn" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md

Notice: `dns_terraform_profile_name` output has no description (terraform_documented_outputs)

  on outputs.tf line 20:
  20: output "dns_terraform_profile_name" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md

Notice: `audit_terraform_role_arn` output has no description (terraform_documented_outputs)

  on outputs.tf line 24:
  24: output "audit_terraform_role_arn" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md

Notice: `audit_terraform_profile_name` output has no description (terraform_documented_outputs)

  on outputs.tf line 28:
  28: output "audit_terraform_profile_name" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md

Notice: `identity_terraform_role_arn` output has no description (terraform_documented_outputs)

  on outputs.tf line 32:
  32: output "identity_terraform_role_arn" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md

Notice: `identity_terraform_profile_name` output has no description (terraform_documented_outputs)

  on outputs.tf line 36:
  36: output "identity_terraform_profile_name" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md

Notice: `identity_cicd_role_arn` output has no description (terraform_documented_outputs)

  on outputs.tf line 40:
  40: output "identity_cicd_role_arn" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md

Notice: `identity_cicd_profile_name` output has no description (terraform_documented_outputs)

  on outputs.tf line 44:
  44: output "identity_cicd_profile_name" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md

Notice: `profiles_enabled` output has no description (terraform_documented_outputs)

  on outputs.tf line 48:
  48: output "profiles_enabled" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md
TFLint in deprecated/account-map/modules/roles-to-principals/:
1 issue(s) found:

Warning: terraform "required_version" attribute is required (terraform_required_version)

  on  line 0:
   (source code not available)

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_required_version.md
TFLint in deprecated/aws/account-dns/:
5 issue(s) found:

Notice: `aws_assume_role_arn` variable has no description (terraform_documented_variables)

  on main.tf line 7:
   7: variable "aws_assume_role_arn" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_variables.md

Warning: Missing version constraint for provider "aws" in "required_providers" (terraform_required_providers)

  on main.tf line 26:
  26: resource "aws_route53_record" "dns_zone_soa" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_required_providers.md

Warning: List items should be accessed using square brackets (terraform_deprecated_index)

  on main.tf line 34:
  34:     "${aws_route53_zone.dns_zone.name_servers.0}. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400",

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_deprecated_index.md

Notice: `zone_id` output has no description (terraform_documented_outputs)

  on main.tf line 38:
  38: output "zone_id" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md

Notice: `name_servers` output has no description (terraform_documented_outputs)

  on main.tf line 42:
  42: output "name_servers" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md
TFLint in deprecated/aws/account-settings/:
6 issue(s) found:

Warning: Missing version constraint for provider "aws" in "required_providers" (terraform_required_providers)

  on main.tf line 7:
   7: provider "aws" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_required_providers.md

Notice: `account_alias` output has no description (terraform_documented_outputs)

  on outputs.tf line 1:
   1: output "account_alias" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md

Notice: `minimum_password_length` output has no description (terraform_documented_outputs)

  on outputs.tf line 5:
   5: output "minimum_password_length" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md

Notice: `signin_url` output has no description (terraform_documented_outputs)

  on outputs.tf line 9:
   9: output "signin_url" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md

Notice: `aws_assume_role_arn` variable has no description (terraform_documented_variables)

  on variables.tf line 9:
   9: variable "aws_assume_role_arn" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_variables.md

Warning: `enabled` variable has no type (terraform_typed_variables)

  on variables.tf line 29:
  29: variable "enabled" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_typed_variables.md
TFLint in deprecated/aws/accounts/:
29 issue(s) found:

Notice: `audit_account_arn` output has no description (terraform_documented_outputs)

  on audit.tf line 11:
  11: output "audit_account_arn" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md

Notice: `audit_account_id` output has no description (terraform_documented_outputs)

  on audit.tf line 15:
  15: output "audit_account_id" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md

Notice: `audit_organization_account_access_role` output has no description (terraform_documented_outputs)

  on audit.tf line 19:
  19: output "audit_organization_account_access_role" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md

Notice: `corp_account_arn` output has no description (terraform_documented_outputs)

  on corp.tf line 11:
  11: output "corp_account_arn" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md

Notice: `corp_account_id` output has no description (terraform_documented_outputs)

  on corp.tf line 15:
  15: output "corp_account_id" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md

Notice: `corp_organization_account_access_role` output has no description (terraform_documented_outputs)

  on corp.tf line 19:
  19: output "corp_organization_account_access_role" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md

Notice: `data_account_arn` output has no description (terraform_documented_outputs)

  on data.tf line 11:
  11: output "data_account_arn" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md

Notice: `data_account_id` output has no description (terraform_documented_outputs)

  on data.tf line 15:
  15: output "data_account_id" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md

Notice: `data_organization_account_access_role` output has no description (terraform_documented_outputs)

  on data.tf line 19:
  19: output "data_organization_account_access_role" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md

Notice: `dev_account_arn` output has no description (terraform_documented_outputs)

  on dev.tf line 11:
  11: output "dev_account_arn" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md

Notice: `dev_account_id` output has no description (terraform_documented_outputs)

  on dev.tf line 15:
  15: output "dev_account_id" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md

Notice: `dev_organization_account_access_role` output has no description (terraform_documented_outputs)

  on dev.tf line 19:
  19: output "dev_organization_account_access_role" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md

Notice: `identity_account_arn` output has no description (terraform_documented_outputs)

  on identity.tf line 11:
  11: output "identity_account_arn" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md

Notice: `identity_account_id` output has no description (terraform_documented_outputs)

  on identity.tf line 15:
  15: output "identity_account_id" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md

Notice: `identity_organization_account_access_role` output has no description (terraform_documented_outputs)

  on identity.tf line 19:
  19: output "identity_organization_account_access_role" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md

Notice: `aws_assume_role_arn` variable has no description (terraform_documented_variables)

  on main.tf line 7:
   7: variable "aws_assume_role_arn" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_variables.md

Warning: Missing version constraint for provider "aws" in "required_providers" (terraform_required_providers)

  on main.tf line 39:
  39: provider "aws" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_required_providers.md

Notice: `prod_account_arn` output has no description (terraform_documented_outputs)

  on prod.tf line 11:
  11: output "prod_account_arn" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md

Notice: `prod_account_id` output has no description (terraform_documented_outputs)

  on prod.tf line 15:
  15: output "prod_account_id" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md

Notice: `prod_organization_account_access_role` output has no description (terraform_documented_outputs)

  on prod.tf line 19:
  19: output "prod_organization_account_access_role" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md

Notice: `security_account_arn` output has no description (terraform_documented_outputs)

  on security.tf line 11:
  11: output "security_account_arn" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md

Notice: `security_account_id` output has no description (terraform_documented_outputs)

  on security.tf line 15:
  15: output "security_account_id" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md

Notice: `security_organization_account_access_role` output has no description (terraform_documented_outputs)

  on security.tf line 19:
  19: output "security_organization_account_access_role" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md

Notice: `staging_account_arn` output has no description (terraform_documented_outputs)

  on staging.tf line 11:
  11: output "staging_account_arn" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md

Notice: `staging_account_id` output has no description (terraform_documented_outputs)

  on staging.tf line 15:
  15: output "staging_account_id" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md

Notice: `staging_organization_account_access_role` output has no description (terraform_documented_outputs)

  on staging.tf line 19:
  19: output "staging_organization_account_access_role" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md

Notice: `testing_account_arn` output has no description (terraform_documented_outputs)

  on testing.tf line 11:
  11: output "testing_account_arn" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md

Notice: `testing_account_id` output has no description (terraform_documented_outputs)

  on testing.tf line 15:
  15: output "testing_account_id" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md

Notice: `testing_organization_account_access_role` output has no description (terraform_documented_outputs)

  on testing.tf line 19:
  19: output "testing_organization_account_access_role" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md
TFLint in deprecated/aws/accounts/stage/:
8 issue(s) found:

Warning: terraform "required_version" attribute is required (terraform_required_version)

  on  line 0:
   (source code not available)

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_required_version.md

Warning: List items should be accessed using square brackets (terraform_deprecated_index)

  on main.tf line 11:
  11:   account_arn                      = join("", aws_organizations_account.default.*.arn)

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_deprecated_index.md

Warning: List items should be accessed using square brackets (terraform_deprecated_index)

  on main.tf line 12:
  12:   account_id                       = join("", aws_organizations_account.default.*.id)

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_deprecated_index.md

Warning: List items should be accessed using square brackets (terraform_deprecated_index)

  on main.tf line 13:
  13:   organization_account_access_role = "arn:aws:iam::${join("", aws_organizations_account.default.*.id)}:role/OrganizationAccountAccessRole"

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_deprecated_index.md

Warning: Missing version constraint for provider "aws" in "required_providers" (terraform_required_providers)

  on main.tf line 34:
  34: resource "aws_ssm_parameter" "organization_account_access_role" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_required_providers.md

Notice: `account_arn` output has no description (terraform_documented_outputs)

  on outputs.tf line 1:
   1: output "account_arn" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md

Notice: `account_id` output has no description (terraform_documented_outputs)

  on outputs.tf line 5:
   5: output "account_id" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md

Notice: `organization_account_access_role` output has no description (terraform_documented_outputs)

  on outputs.tf line 9:
   9: output "organization_account_access_role" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md
TFLint in deprecated/aws/acm/:
8 issue(s) found:

Notice: `certificate_domain_name` output has no description (terraform_documented_outputs)

  on main.tf line 30:
  30: output "certificate_domain_name" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md

Notice: `certificate_id` output has no description (terraform_documented_outputs)

  on main.tf line 34:
  34: output "certificate_id" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md

Notice: `certificate_arn` output has no description (terraform_documented_outputs)

  on main.tf line 38:
  38: output "certificate_arn" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md

Notice: `certificate_domain_validation_options` output has no description (terraform_documented_outputs)

  on main.tf line 42:
  42: output "certificate_domain_validation_options" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md

Notice: `aws_assume_role_arn` variable has no description (terraform_documented_variables)

  on variables.tf line 2:
   2: variable "aws_assume_role_arn" {}

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_variables.md

Warning: `aws_assume_role_arn` variable has no type (terraform_typed_variables)

  on variables.tf line 2:
   2: variable "aws_assume_role_arn" {}

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_typed_variables.md

Warning: `chamber_service` variable has no type (terraform_typed_variables)

  on variables.tf line 11:
  11: variable "chamber_service" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_typed_variables.md

Warning: `certificate_arn_parameter_name` variable has no type (terraform_typed_variables)

  on variables.tf line 17:
  17: variable "certificate_arn_parameter_name" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_typed_variables.md
TFLint in deprecated/aws/acm-cloudfront/:
7 issue(s) found:

Notice: `aws_assume_role_arn` variable has no description (terraform_documented_variables)

  on main.tf line 7:
   7: variable "aws_assume_role_arn" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_variables.md

Warning: Missing version constraint for provider "aws" in "required_providers" (terraform_required_providers)

  on main.tf line 11:
  11: provider "aws" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_required_providers.md

Warning: `domain_name` variable has no type (terraform_typed_variables)

  on main.tf line 24:
  24: variable "domain_name" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_typed_variables.md

Notice: `certificate_domain_name` output has no description (terraform_documented_outputs)

  on main.tf line 36:
  36: output "certificate_domain_name" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md

Notice: `certificate_id` output has no description (terraform_documented_outputs)

  on main.tf line 40:
  40: output "certificate_id" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md

Notice: `certificate_arn` output has no description (terraform_documented_outputs)

  on main.tf line 44:
  44: output "certificate_arn" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md

Notice: `certificate_domain_validation_options` output has no description (terraform_documented_outputs)

  on main.tf line 48:
  48: output "certificate_domain_validation_options" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md
TFLint in deprecated/aws/acm-teleport/:
11 issue(s) found:

Notice: `aws_assume_role_arn` variable has no description (terraform_documented_variables)

  on main.tf line 7:
   7: variable "aws_assume_role_arn" {}

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_variables.md

Warning: `aws_assume_role_arn` variable has no type (terraform_typed_variables)

  on main.tf line 7:
   7: variable "aws_assume_role_arn" {}

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_typed_variables.md

Warning: Missing version constraint for provider "aws" in "required_providers" (terraform_required_providers)

  on main.tf line 23:
  23: resource "aws_ssm_parameter" "certificate_arn_parameter" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_required_providers.md

Notice: `certificate_domain_name` output has no description (terraform_documented_outputs)

  on outputs.tf line 1:
   1: output "certificate_domain_name" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md

Notice: `certificate_id` output has no description (terraform_documented_outputs)

  on outputs.tf line 5:
   5: output "certificate_id" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md

Notice: `certificate_arn` output has no description (terraform_documented_outputs)

  on outputs.tf line 9:
   9: output "certificate_arn" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md

Notice: `certificate_domain_validation_options` output has no description (terraform_documented_outputs)

  on outputs.tf line 13:
  13: output "certificate_domain_validation_options" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md

Warning: `domain_name` variable has no type (terraform_typed_variables)

  on variables.tf line 1:
   1: variable "domain_name" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_typed_variables.md

Warning: `chamber_service` variable has no type (terraform_typed_variables)

  on variables.tf line 5:
   5: variable "chamber_service" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_typed_variables.md

Warning: `chamber_parameter_name` variable has no type (terraform_typed_variables)

  on variables.tf line 10:
  10: variable "chamber_parameter_name" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_typed_variables.md

Warning: `certificate_arn_parameter_name` variable has no type (terraform_typed_variables)

  on variables.tf line 15:
  15: variable "certificate_arn_parameter_name" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_typed_variables.md
TFLint in deprecated/aws/artifacts/:
4 issue(s) found:

Warning: Missing version constraint for provider "aws" in "required_providers" (terraform_required_providers)

  on main.tf line 17:
  17: data "aws_acm_certificate" "acm_cloudfront_certificate" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_required_providers.md

Warning: Interpolation-only expressions are deprecated in Terraform v0.12.14 (terraform_deprecated_interpolation)

  on main.tf line 54:
  54:     "${local.artifacts_user_arn}" = [""]

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_deprecated_interpolation.md

Warning: Interpolation-only expressions are deprecated in Terraform v0.12.14 (terraform_deprecated_interpolation)

  on main.tf line 72:
  72:   aliases                = ["${local.cdn_domain}", "artifacts.cloudposse.com"]

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_deprecated_interpolation.md

Notice: `domain_name` variable has no description (terraform_documented_variables)

  on variables.tf line 6:
   6: variable "domain_name" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_variables.md
TFLint in deprecated/aws/audit-cloudtrail/:
8 issue(s) found:

Warning: data "aws_caller_identity" "default" is declared but not used (terraform_unused_declarations)

  on main.tf line 13:
  13: data "aws_caller_identity" "default" {}

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_unused_declarations.md

Warning: Missing version constraint for provider "aws" in "required_providers" (terraform_required_providers)

  on main.tf line 49:
  49: data "aws_iam_policy_document" "kms_key_cloudtrail" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_required_providers.md

Notice: `cloudtrail_kms_key_arn` output has no description (terraform_documented_outputs)

  on output.tf line 1:
   1: output "cloudtrail_kms_key_arn" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md

Notice: `cloudtrail_bucket_domain_name` output has no description (terraform_documented_outputs)

  on output.tf line 5:
   5: output "cloudtrail_bucket_domain_name" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md

Notice: `cloudtrail_bucket_id` output has no description (terraform_documented_outputs)

  on output.tf line 9:
   9: output "cloudtrail_bucket_id" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md

Notice: `cloudtrail_bucket_arn` output has no description (terraform_documented_outputs)

  on output.tf line 13:
  13: output "cloudtrail_bucket_arn" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_outputs.md

Notice: `aws_assume_role_arn` variable has no description (terraform_documented_variables)

  on varaibles.tf line 1:
   1: variable "aws_assume_role_arn" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_documented_variables.md

Warning: `cloudwatch_logs_retention_in_days` variable has no type (terraform_typed_variables)

  on varaibles.tf line 28:
  28: variable "cloudwatch_logs_retention_in_days" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_typed_variables.md
```

Other violations are trimmed