### PR TITLE
Restore backwards compatibility of account-map output

### DIFF
--- a/modules/account-map/README.md
+++ b/modules/account-map/README.md
@@ -129,9 +129,13 @@ components:
 | <a name="output_artifacts_account_account_name"></a> [artifacts\_account\_account\_name](#output\_artifacts\_account\_account\_name) | The short name for the artifacts account |
 | <a name="output_audit_account_account_name"></a> [audit\_account\_account\_name](#output\_audit\_account\_account\_name) | The short name for the audit account |
 | <a name="output_aws_partition"></a> [aws\_partition](#output\_aws\_partition) | The AWS "partition" to use when constructing resource ARNs |
+| <a name="output_cicd_profiles"></a> [cicd\_profiles](#output\_cicd\_profiles) | OBSOLETE: dummy results returned to avoid breaking code that depends on this output |
+| <a name="output_cicd_roles"></a> [cicd\_roles](#output\_cicd\_roles) | OBSOLETE: dummy results returned to avoid breaking code that depends on this output |
 | <a name="output_dns_account_account_name"></a> [dns\_account\_account\_name](#output\_dns\_account\_account\_name) | The short name for the primary DNS account |
 | <a name="output_eks_accounts"></a> [eks\_accounts](#output\_eks\_accounts) | A list of all accounts in the AWS Organization that contain EKS clusters |
 | <a name="output_full_account_map"></a> [full\_account\_map](#output\_full\_account\_map) | The map of account name to account ID (number). |
+| <a name="output_helm_profiles"></a> [helm\_profiles](#output\_helm\_profiles) | OBSOLETE: dummy results returned to avoid breaking code that depends on this output |
+| <a name="output_helm_roles"></a> [helm\_roles](#output\_helm\_roles) | OBSOLETE: dummy results returned to avoid breaking code that depends on this output |
 | <a name="output_iam_role_arn_templates"></a> [iam\_role\_arn\_templates](#output\_iam\_role\_arn\_templates) | Map of accounts to corresponding IAM Role ARN templates |
 | <a name="output_identity_account_account_name"></a> [identity\_account\_account\_name](#output\_identity\_account\_account\_name) | The short name for the account holding primary IAM roles |
 | <a name="output_non_eks_accounts"></a> [non\_eks\_accounts](#output\_non\_eks\_accounts) | A list of all accounts in the AWS Organization that do not contain EKS clusters |

--- a/modules/account-map/main.tf
+++ b/modules/account-map/main.tf
@@ -30,6 +30,11 @@ locals {
   all_accounts     = concat(local.eks_accounts, local.non_eks_accounts)
   account_info_map = module.accounts.outputs.account_info_map
 
+  # Provide empty lists for deprecated outputs, to avoid breaking old code
+  # before it can be replaced.
+  empty_account_map = merge({ for name, info in local.account_info_map : name => "" }, { _OBSOLETE = "DUMMY RESULTS for backwards compatibility" })
+
+
   # We should move this to be specified by tags on the accounts,
   # like we do with EKS, but for now....
   account_role_map = {

--- a/modules/account-map/outputs.tf
+++ b/modules/account-map/outputs.tf
@@ -115,3 +115,37 @@ resource "local_file" "account_info" {
   })
   filename = "${path.module}/account-info/${module.this.id}.sh"
 }
+
+
+######################
+## Deprecated outputs
+## These outputs are deprecated and will be removed in a future release
+## As of this release, they return empty lists so as not to break old
+## versions of account-map/modules/iam-roles and imposing an order
+## on deploying new code vs applying the updated account-map
+######################
+
+output "helm_roles" {
+  value       = local.empty_account_map
+  description = "OBSOLETE: dummy results returned to avoid breaking code that depends on this output"
+}
+
+output "helm_profiles" {
+  value       = local.empty_account_map
+  description = "OBSOLETE: dummy results returned to avoid breaking code that depends on this output"
+}
+
+output "cicd_roles" {
+  value       = local.empty_account_map
+  description = "OBSOLETE: dummy results returned to avoid breaking code that depends on this output"
+}
+
+output "cicd_profiles" {
+  value       = local.empty_account_map
+  description = "OBSOLETE: dummy results returned to avoid breaking code that depends on this output"
+}
+
+######################
+## End of Deprecated outputs
+## Please add new outputs above this section
+######################


### PR DESCRIPTION
## what

- Restore backwards compatibility of `account-map` output

## why

- PR #715 removed outputs from `account-map` that `iam-roles` relied on. Although it removed the references in `iam-roles`, this imposed an ordering on the upgrade: the `iam-roles` code had to be deployed before the module could be applied. That proved to be inconvenient. Furthermore, if a future `account-map` upgrade added outputs that iam-roles` required, neither order of operations would go smoothly. With this update, the standard practice of applying `account-map` before deploying code will work again. 

