### PR TITLE
Bump `spaces` module versions

### DIFF
--- a/modules/spacelift/spaces/README.md
+++ b/modules/spacelift/spaces/README.md
@@ -81,8 +81,8 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_policy"></a> [policy](#module\_policy) | cloudposse/cloud-infrastructure-automation/spacelift//modules/spacelift-policy | 1.0.0 |
-| <a name="module_space"></a> [space](#module\_space) | cloudposse/cloud-infrastructure-automation/spacelift//modules/spacelift-space | 1.0.0 |
+| <a name="module_policy"></a> [policy](#module\_policy) | cloudposse/cloud-infrastructure-automation/spacelift//modules/spacelift-policy | 1.1.0 |
+| <a name="module_space"></a> [space](#module\_space) | cloudposse/cloud-infrastructure-automation/spacelift//modules/spacelift-space | 1.1.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 
 ## Resources

--- a/modules/spacelift/spaces/main.tf
+++ b/modules/spacelift/spaces/main.tf
@@ -36,7 +36,7 @@ locals {
 
 module "space" {
   source  = "cloudposse/cloud-infrastructure-automation/spacelift//modules/spacelift-space"
-  version = "1.0.0"
+  version = "1.1.0"
 
   # Create a space for each entry in the `spaces` variable, except for the root space which already exists by default
   # and cannot be deleted.
@@ -51,7 +51,7 @@ module "space" {
 
 module "policy" {
   source  = "cloudposse/cloud-infrastructure-automation/spacelift//modules/spacelift-policy"
-  version = "1.0.0"
+  version = "1.1.0"
 
   for_each = local.all_policies_inputs
 


### PR DESCRIPTION
## what
- bumped module version for `terraform-spacelift-cloud-infrastructure-automation`

## why
- New policy added to `spaces`

## references
- https://github.com/cloudposse/terraform-spacelift-cloud-infrastructure-automation/releases/tag/1.1.0
