### PR TITLE
Upstream `gitops` Policy Update

### DIFF
--- a/modules/gitops/github-actions-iam-policy.tf
+++ b/modules/gitops/github-actions-iam-policy.tf
@@ -39,7 +39,8 @@ data "aws_iam_policy_document" "github_actions_iam_policy" {
       "dynamodb:PutItem"
     ]
     resources = [
-      local.dynamodb_table_arn
+      local.dynamodb_table_arn,
+      "${local.dynamodb_table_arn}/*"
     ]
   }
 


### PR DESCRIPTION
## what
- allow actions on table resources

## why
- required to be able to query using a global secondary index

## references
- https://github.com/cloudposse/github-action-terraform-plan-storage/pull/16
