### PR TITLE
Make alb-controller default Ingress actually the default Ingress

### DIFF
--- a/modules/eks/alb-controller/main.tf
+++ b/modules/eks/alb-controller/main.tf
@@ -350,9 +350,8 @@ module "alb_controller" {
       createIngressClassResource = var.default_ingress_enabled
       ingressClass               = var.default_ingress_class_name
       ingressClassParams = {
-        name    = var.default_ingress_class_name
-        create  = var.default_ingress_enabled
-        default = true
+        name   = var.default_ingress_class_name
+        create = var.default_ingress_enabled
         spec = {
           group = {
             name = var.default_ingress_group
@@ -362,6 +361,9 @@ module "alb_controller" {
           tags                   = [for k, v in merge(module.this.tags, var.default_ingress_additional_tags) : { key = k, value = v }]
           loadBalancerAttributes = var.default_ingress_load_balancer_attributes
         }
+      }
+      ingressClassConfig = {
+        default = var.default_ingress_enabled
       }
       defaultTags = module.this.tags
     }),


### PR DESCRIPTION
## what

- Make the `alb-controller` default Ingress actually the default Ingress

## why

- When setting `default_ingress_enabled = true` it is a reasonable expectation that the deployed Ingress be marked as the Default Ingress. The previous code suggests this was the intended behavior, but does not work with the current Helm chart and may have never worked.

