### PR TITLE
[aws-teams] Remove obsolete restriction on assuming roles in identity account

### DIFF
--- a/modules/aws-teams/policy-team-role-access.tf
+++ b/modules/aws-teams/policy-team-role-access.tf
@@ -22,15 +22,6 @@ data "aws_iam_policy_document" "team_role_access" {
     actions   = ["sts:GetCallerIdentity"]
     resources = ["*"]
   }
-
-  statement {
-    sid     = "DenyIdentityAssumeRole"
-    effect  = "Deny"
-    actions = ["sts:AssumeRole"]
-    resources = [
-      format("arn:%s:iam::%s:role/*", local.aws_partition, local.identity_account_id),
-    ]
-  }
 }
 
 resource "aws_iam_policy" "team_role_access" {


### PR DESCRIPTION
## what

- [aws-teams] Remove obsolete restriction on assuming roles in the `identity` account

## why

Some time ago, there was an implied permission for any IAM role to assume any other IAM role in the same account if the originating role had sufficient permissions to perform `sts:AssumeRole`. For this reason, we had an explicit policy against assuming roles in the `identity` account.

AWS has removed that implied permission and now requires all roles to have explicit trust policies. Our current Team structure requires Teams (e.g. `spacelift`) to be able to assume roles in `identity` (e.g. `planner`). Therefore, the previous restriction is both not needed and actually hinders desired operation.


