### PR TITLE
`alb` and `ssm-parameters` Upstream for Basic Use

### DIFF
--- a/modules/alb/README.md
+++ b/modules/alb/README.md
@@ -36,6 +36,7 @@ No providers.
 |------|--------|---------|
 | <a name="module_alb"></a> [alb](#module\_alb) | cloudposse/alb/aws | 1.10.0 |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
+| <a name="module_remote_acm"></a> [remote\_acm](#module\_remote\_acm) | cloudposse/stack-config/yaml//modules/remote-state | 1.4.3 |
 | <a name="module_remote_dns"></a> [remote\_dns](#module\_remote\_dns) | cloudposse/stack-config/yaml//modules/remote-state | 1.4.3 |
 | <a name="module_remote_vpc"></a> [remote\_vpc](#module\_remote\_vpc) | cloudposse/stack-config/yaml//modules/remote-state | 1.4.3 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
@@ -51,6 +52,7 @@ No resources.
 | <a name="input_access_logs_enabled"></a> [access\_logs\_enabled](#input\_access\_logs\_enabled) | A boolean flag to enable/disable access\_logs | `bool` | `true` | no |
 | <a name="input_access_logs_prefix"></a> [access\_logs\_prefix](#input\_access\_logs\_prefix) | The S3 log bucket prefix | `string` | `""` | no |
 | <a name="input_access_logs_s3_bucket_id"></a> [access\_logs\_s3\_bucket\_id](#input\_access\_logs\_s3\_bucket\_id) | An external S3 Bucket name to store access logs in. If specified, no logging bucket will be created. | `string` | `null` | no |
+| <a name="input_acm_component_name"></a> [acm\_component\_name](#input\_acm\_component\_name) | Atmos `acm` component name | `string` | `"acm"` | no |
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br>This is for some rare cases where resources want additional configuration of tags<br>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
 | <a name="input_alb_access_logs_s3_bucket_force_destroy"></a> [alb\_access\_logs\_s3\_bucket\_force\_destroy](#input\_alb\_access\_logs\_s3\_bucket\_force\_destroy) | A boolean that indicates all objects should be deleted from the ALB access logs S3 bucket so that the bucket can be destroyed without error | `bool` | `false` | no |
 | <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br>in the order they appear in the list. New attributes are appended to the<br>end of the list. The elements of the list are joined by the `delimiter`<br>and treated as a single ID element. | `list(string)` | `[]` | no |
@@ -60,6 +62,7 @@ No resources.
 | <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between ID elements.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
 | <a name="input_deregistration_delay"></a> [deregistration\_delay](#input\_deregistration\_delay) | The amount of time to wait in seconds before changing the state of a deregistering target to unused | `number` | `15` | no |
 | <a name="input_descriptor_formats"></a> [descriptor\_formats](#input\_descriptor\_formats) | Describe additional descriptors to be output in the `descriptors` output map.<br>Map of maps. Keys are names of descriptors. Values are maps of the form<br>`{<br>   format = string<br>   labels = list(string)<br>}`<br>(Type is `any` so the map values can later be enhanced to provide additional options.)<br>`format` is a Terraform format string to be passed to the `format()` function.<br>`labels` is a list of labels, in order, to pass to `format()` function.<br>Label values will be normalized before being passed to `format()` so they will be<br>identical to how they appear in `id`.<br>Default is `{}` (`descriptors` output will be empty). | `any` | `{}` | no |
+| <a name="input_dns_acm_enabled"></a> [dns\_acm\_enabled](#input\_dns\_acm\_enabled) | If `true`, use the ACM ARN created by the given `dns-delegated` component. Otherwise, use the ACM ARN created by the given `acm` component. | `bool` | `false` | no |
 | <a name="input_dns_delegated_component_name"></a> [dns\_delegated\_component\_name](#input\_dns\_delegated\_component\_name) | Atmos `dns-delegated` component name | `string` | `"dns-delegated"` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |

--- a/modules/alb/main.tf
+++ b/modules/alb/main.tf
@@ -4,7 +4,7 @@ module "alb" {
 
   vpc_id          = module.remote_vpc.outputs.vpc_id
   subnet_ids      = module.remote_vpc.outputs.public_subnet_ids
-  certificate_arn = module.remote_dns.outputs.certificate.arn
+  certificate_arn = var.dns_acm_enabled ? module.remote_dns.outputs.certificate.arn : module.remote_acm.outputs.arn
 
   internal                                = var.internal
   http_port                               = var.http_port

--- a/modules/alb/remote-state.tf
+++ b/modules/alb/remote-state.tf
@@ -13,7 +13,7 @@ module "remote_dns" {
 
   component = var.dns_delegated_component_name
 
-  # Ignore errors if component doesnt exist
+  # Ignore errors if component doesn't exist
   ignore_errors = true
 
   context = module.this.context
@@ -25,7 +25,7 @@ module "remote_acm" {
 
   component = var.acm_component_name
 
-  # Ignore errors if component doesnt exist
+  # Ignore errors if component doesn't exist
   ignore_errors = true
 
   context = module.this.context

--- a/modules/alb/remote-state.tf
+++ b/modules/alb/remote-state.tf
@@ -13,5 +13,20 @@ module "remote_dns" {
 
   component = var.dns_delegated_component_name
 
+  # Ignore errors if component doesnt exist
+  ignore_errors = true
+
+  context = module.this.context
+}
+
+module "remote_acm" {
+  source  = "cloudposse/stack-config/yaml//modules/remote-state"
+  version = "1.4.3"
+
+  component = var.acm_component_name
+
+  # Ignore errors if component doesnt exist
+  ignore_errors = true
+
   context = module.this.context
 }

--- a/modules/alb/variables.tf
+++ b/modules/alb/variables.tf
@@ -221,3 +221,15 @@ variable "dns_delegated_component_name" {
   default     = "dns-delegated"
   description = "Atmos `dns-delegated` component name"
 }
+
+variable "acm_component_name" {
+  type        = string
+  default     = "acm"
+  description = "Atmos `acm` component name"
+}
+
+variable "dns_acm_enabled" {
+  type        = bool
+  default     = false
+  description = "If `true`, use the ACM ARN created by the given `dns-delegated` component. Otherwise, use the ACM ARN created by the given `acm` component."
+}

--- a/modules/ssm-parameters/README.md
+++ b/modules/ssm-parameters/README.md
@@ -77,8 +77,8 @@ components:
 | <a name="input_params"></a> [params](#input\_params) | A map of parameter values to write to SSM Parameter Store | <pre>map(object({<br>    value       = string<br>    description = string<br>    overwrite   = optional(bool, false)<br>    tier        = optional(string, "Standard")<br>    type        = string<br>  }))</pre> | n/a | yes |
 | <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br>Characters matching the regex will be removed from the ID elements.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS Region | `string` | n/a | yes |
-| <a name="input_sops_source_file"></a> [sops\_source\_file](#input\_sops\_source\_file) | The relative path to the SOPS file which is consumed as the source for creating parameter resources. | `string` | n/a | yes |
-| <a name="input_sops_source_key"></a> [sops\_source\_key](#input\_sops\_source\_key) | The SOPS key to pull from the source file. | `string` | n/a | yes |
+| <a name="input_sops_source_file"></a> [sops\_source\_file](#input\_sops\_source\_file) | The relative path to the SOPS file which is consumed as the source for creating parameter resources. | `string` | `""` | no |
+| <a name="input_sops_source_key"></a> [sops\_source\_key](#input\_sops\_source\_key) | The SOPS key to pull from the source file. | `string` | `""` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
 | <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |

--- a/modules/ssm-parameters/variables.tf
+++ b/modules/ssm-parameters/variables.tf
@@ -6,17 +6,19 @@ variable "region" {
 variable "sops_source_file" {
   type        = string
   description = "The relative path to the SOPS file which is consumed as the source for creating parameter resources."
+  default     = ""
 }
 
 variable "sops_source_key" {
   type        = string
   description = "The SOPS key to pull from the source file."
+  default     = ""
 }
 
 variable "kms_arn" {
   type        = string
-  default     = ""
   description = "The ARN of a KMS key used to encrypt and decrypt SecretString values"
+  default     = ""
 }
 
 variable "params" {

--- a/modules/waf/README.md
+++ b/modules/waf/README.md
@@ -19,6 +19,10 @@ components:
         acl_name: default
         default_action: allow
         description: Default web ACL
+        visibility_config:
+          cloudwatch_metrics_enabled: false
+          metric_name: "default"
+          sampled_requests_enabled: false
         managed_rule_group_statement_rules:
         - name: "OWASP-10"
           # Rules are processed in order based on the value of priority, lowest number first


### PR DESCRIPTION
## what
- `alb` component can get the ACM cert from either `dns-delegated` or `acm`
- Support deploying `ssm-parameters` without SOPS
- `waf` requires a value for `visibility_config` in the stack catalog

## why
- resolving bugs while deploying example components

## references
- https://cloudposse.atlassian.net/browse/JUMPSTART-1185