### PR TITLE
feat: acm no longer requires zone

### DIFF
--- a/modules/acm/main.tf
+++ b/modules/acm/main.tf
@@ -14,7 +14,7 @@ locals {
 }
 
 data "aws_route53_zone" "default" {
-  count        = local.enabled ? 1 : 0
+  count        = local.enabled && var.process_domain_validation_options ? 1 : 0
   name         = length(var.zone_name) > 0 ? var.zone_name : module.dns_delegated.outputs.default_domain_name
   private_zone = local.private_enabled
 }


### PR DESCRIPTION
## what
* `acm` only looks up zones of `process_domain_validation_options` is true

## why
* Allow external validation of acm certs
