### PR TITLE
Bump `elasticache-redis` Module

### DIFF
--- a/modules/elasticache-redis/modules/redis_cluster/main.tf
+++ b/modules/elasticache-redis/modules/redis_cluster/main.tf
@@ -10,7 +10,7 @@ locals {
 
 module "redis" {
   source  = "cloudposse/elasticache-redis/aws"
-  version = "0.44.0"
+  version = "0.52.0"
 
   name = var.cluster_name
 


### PR DESCRIPTION
## what
- Bump `elasticache-redis` module 

## why
- Resolve issues with terraform provider v5

## references
- https://github.com/cloudposse/terraform-aws-elasticache-redis/issues/199
