### PR TITLE
Bump `lambda-elasticsearch-cleanup` module

### DIFF
--- a/modules/elasticsearch/README.md
+++ b/modules/elasticsearch/README.md
@@ -49,7 +49,7 @@ components:
 |------|--------|---------|
 | <a name="module_dns_delegated"></a> [dns\_delegated](#module\_dns\_delegated) | cloudposse/stack-config/yaml//modules/remote-state | 1.4.1 |
 | <a name="module_elasticsearch"></a> [elasticsearch](#module\_elasticsearch) | cloudposse/elasticsearch/aws | 0.42.0 |
-| <a name="module_elasticsearch_log_cleanup"></a> [elasticsearch\_log\_cleanup](#module\_elasticsearch\_log\_cleanup) | cloudposse/lambda-elasticsearch-cleanup/aws | 0.13.0 |
+| <a name="module_elasticsearch_log_cleanup"></a> [elasticsearch\_log\_cleanup](#module\_elasticsearch\_log\_cleanup) | cloudposse/lambda-elasticsearch-cleanup/aws | 0.14.0 |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | cloudposse/stack-config/yaml//modules/remote-state | 1.4.1 |

--- a/modules/elasticsearch/main.tf
+++ b/modules/elasticsearch/main.tf
@@ -99,7 +99,7 @@ resource "aws_ssm_parameter" "elasticsearch_kibana_endpoint" {
 
 module "elasticsearch_log_cleanup" {
   source  = "cloudposse/lambda-elasticsearch-cleanup/aws"
-  version = "0.13.0"
+  version = "0.14.0"
 
   es_endpoint          = module.elasticsearch.domain_endpoint
   es_domain_arn        = module.elasticsearch.domain_arn


### PR DESCRIPTION
## what
- bump version of `lambda-elasticsearch-cleanup` module

## why
- Support Terraform provider v5

## references
- https://github.com/cloudposse/terraform-aws-lambda-elasticsearch-cleanup/pull/48