### PR TITLE
Use absolute links for refarch docs

### DIFF
--- a/modules/account-map/README.md
+++ b/modules/account-map/README.md
@@ -4,7 +4,7 @@ This component is responsible for provisioning information only: it simply popul
 
 ## Pre-requisites
 
-- [account](/components/library/aws/account) must be provisioned before [account-map](/components/library/aws/account-map) component
+- [account](https://docs.cloudposse.com/components/library/aws/account) must be provisioned before [account-map](https://docs.cloudposse.com/components/library/aws/account-map) component
 
 ## Usage
 

--- a/modules/account/README.md
+++ b/modules/account/README.md
@@ -3,7 +3,7 @@
 This component is responsible for provisioning the full account hierarchy along with Organizational Units (OUs). It includes the ability to associate Service Control Policies (SCPs) to the Organization, each Organizational Unit and account.
 
 :::info
-Part of a [cold start](/reference-architecture/how-to-guides/implementation/enterprise/implement-aws-cold-start) so it has to be initially run with `SuperAdmin` role.
+Part of a [cold start](https://docs.cloudposse.com/reference-architecture/how-to-guides/implementation/enterprise/implement-aws-cold-start) so it has to be initially run with `SuperAdmin` role.
 
 :::
 
@@ -161,7 +161,7 @@ Unfortunately, there are some tasks that need to be done via the console. Log in
 #### Request an increase in the maximum number of accounts allowed
 
 :::caution
-Make sure your support plan for the _root_ account was upgraded to the "Business" level (or Higher). This is necessary to expedite the quota increase requests, which could take several days on a basic support plan. Without it, AWS support will claim that since we’re not currently utilizing any of the resources, so they do not want to approve the requests. AWS support is not aware of your other organization. If AWS still gives you problems, please escalate to your AWS TAM. See [AWS](/reference-architecture/reference/aws).
+Make sure your support plan for the _root_ account was upgraded to the "Business" level (or Higher). This is necessary to expedite the quota increase requests, which could take several days on a basic support plan. Without it, AWS support will claim that since we’re not currently utilizing any of the resources, so they do not want to approve the requests. AWS support is not aware of your other organization. If AWS still gives you problems, please escalate to your AWS TAM. See [AWS](https://docs.cloudposse.com/reference-architecture/reference/aws).
 
 :::
 
@@ -280,7 +280,7 @@ AWS accounts and organizational units are generated dynamically by the `terrafor
 
 :::info
 _**Special note:**_ **** In the rare case where you will need to be enabling non-default AWS Regions, temporarily comment out the `DenyRootAccountAccess` service control policy setting in `gbl-root.yaml`. You will restore it later, after enabling the optional Regions.
-See related: [Decide on Opting Into Non-default Regions](/reference-architecture/design-decisions/cold-start/decide-on-opting-into-non-default-regions)
+See related: [Decide on Opting Into Non-default Regions](https://docs.cloudposse.com/reference-architecture/design-decisions/cold-start/decide-on-opting-into-non-default-regions)
 
 :::
 

--- a/modules/acm/README.md
+++ b/modules/acm/README.md
@@ -2,7 +2,7 @@
 
 This component is responsible for requesting an ACM certificate for a domain and adding a CNAME record to the DNS zone to complete certificate validation.
 
-The ACM component is to manage an unlimited number of certificates, predominantly for vanity domains. While the [dns-primary](/components/library/aws/dns-primary) component has the ability to generate ACM certificates, it is very opinionated and can only manage one zone. In reality, companies have many branded domains associated with a load balancer, so we need to be able to generate more complicated certificates.
+The ACM component is to manage an unlimited number of certificates, predominantly for vanity domains. While the [dns-primary](https://docs.cloudposse.com/components/library/aws/dns-primary) component has the ability to generate ACM certificates, it is very opinionated and can only manage one zone. In reality, companies have many branded domains associated with a load balancer, so we need to be able to generate more complicated certificates.
 
 We have, as a convenience, the ability to create an ACM certificate as part of creating a DNS zone, whether primary or delegated. That convenience is limited to creating `example.com` and `*.example.com` when creating a zone for `example.com`. For example, Acme has delegated `acct.acme.com` and in addition to `*.acct.acme.com` needed an ACM certificate for `*.usw2.acct.acme.com`, so we use the ACM component to provision that, rather than extend the DNS primary or delegated components to take a list of additional certificates. Both are different views on the Single Responsibility Principle.
 

--- a/modules/aws-backup/README.md
+++ b/modules/aws-backup/README.md
@@ -266,4 +266,4 @@ No resources.
 
 ## Related How-to Guides
 
-- [How to Enable Cross-Region Backups in AWS-Backup](/reference-architecture/how-to-guides/tutorials/how-to-enable-cross-region-backups-in-aws-backup)
+- [How to Enable Cross-Region Backups in AWS-Backup](https://docs.cloudposse.com/reference-architecture/how-to-guides/tutorials/how-to-enable-cross-region-backups-in-aws-backup)

--- a/modules/datadog-monitor/README.md
+++ b/modules/datadog-monitor/README.md
@@ -36,7 +36,7 @@ components:
 ```
 
 ## Conventions
-- Treat datadog like a separate cloud provider with integrations ([datadog-integration](/components/library/aws/datadog-integration)) into your accounts.
+- Treat datadog like a separate cloud provider with integrations ([datadog-integration](https://docs.cloudposse.com/components/library/aws/datadog-integration)) into your accounts.
 
 - Use the `catalog` convention to define a step of alerts. You can use ours or define your own.
   [https://github.com/cloudposse/terraform-datadog-platform/tree/master/catalog/monitors](https://github.com/cloudposse/terraform-datadog-platform/tree/master/catalog/monitors)
@@ -252,13 +252,13 @@ No resources.
 
 ## Related How-to Guides
 
-- [How to Onboard a New Service with Datadog and OpsGenie](/reference-architecture/how-to-guides/tutorials/how-to-implement-incident-management-with-opsgenie/how-to-onboard-a-new-service-with-datadog-and-opsgenie)
-- [How to Sign Up for Datadog?](/reference-architecture/how-to-guides/tutorials/how-to-sign-up-for-datadog)
-- [How to use Datadog Metrics for Horizontal Pod Autoscaling (HPA)](/reference-architecture/how-to-guides/tutorials/how-to-use-datadog-metrics-for-horizontal-pod-autoscaling-hpa)
-- [How to Implement SRE with Datadog](/reference-architecture/how-to-guides/tutorials/how-to-implement-sre-with-datadog)
+- [How to Onboard a New Service with Datadog and OpsGenie](https://docs.cloudposse.com/reference-architecture/how-to-guides/tutorials/how-to-implement-incident-management-with-opsgenie/how-to-onboard-a-new-service-with-datadog-and-opsgenie)
+- [How to Sign Up for Datadog?](https://docs.cloudposse.com/reference-architecture/how-to-guides/tutorials/how-to-sign-up-for-datadog)
+- [How to use Datadog Metrics for Horizontal Pod Autoscaling (HPA)](https://docs.cloudposse.com/reference-architecture/how-to-guides/tutorials/how-to-use-datadog-metrics-for-horizontal-pod-autoscaling-hpa)
+- [How to Implement SRE with Datadog](https://docs.cloudposse.com/reference-architecture/how-to-guides/tutorials/how-to-implement-sre-with-datadog)
 
 ## Component Dependencies
-- [datadog-integration](/reference-architecture/components/datadog-integration)
+- [datadog-integration](https://docs.cloudposse.com/components/library/aws/datadog-integration/)
 
 ## References
 * [cloudposse/terraform-aws-components](https://github.com/cloudposse/terraform-aws-components/tree/master/modules/datadog-monitor) - Cloud Posse's upstream component

--- a/modules/dns-primary/README.md
+++ b/modules/dns-primary/README.md
@@ -56,7 +56,7 @@ components:
 ```
 
 :::info
-Use the [acm](/components/library/aws/acm)  component for more advanced certificate requirements.
+Use the [acm](https://docs.cloudposse.com/components/library/aws/acm)  component for more advanced certificate requirements.
 
 :::
 

--- a/modules/ecr/README.md
+++ b/modules/ecr/README.md
@@ -132,9 +132,9 @@ components:
 
 ## Related
 
-- [Decide How to distribute Docker Images](/reference-architecture/design-decisions/foundational-platform/decide-how-to-distribute-docker-images)
+- [Decide How to distribute Docker Images](https://docs.cloudposse.com/reference-architecture/design-decisions/foundational-platform/decide-how-to-distribute-docker-images)
 
-- [Decide on ECR Strategy](/reference-architecture/design-decisions/foundational-platform/decide-on-ecr-strategy)
+- [Decide on ECR Strategy](https://docs.cloudposse.com/reference-architecture/design-decisions/foundational-platform/decide-on-ecr-strategy)
 
 ## References
 * [cloudposse/terraform-aws-components](https://github.com/cloudposse/terraform-aws-components/tree/master/modules/ecr) - Cloud Posse's upstream component

--- a/modules/eks/cluster/README.md
+++ b/modules/eks/cluster/README.md
@@ -501,12 +501,12 @@ If the new addon requires an EKS IAM Role for Kubernetes Service Account, perfor
 
 ## Related How-to Guides
 
-- [How to Load Test in AWS](/reference-architecture/how-to-guides/tutorials/how-to-load-test-in-aws)
-- [How to Tune EKS with AWS Managed Node Groups](/reference-architecture/how-to-guides/tutorials/how-to-tune-eks-with-aws-managed-node-groups)
-- [How to Keep Everything Up to Date](/reference-architecture/how-to-guides/upgrades/how-to-keep-everything-up-to-date)
-- [How to Tune SpotInst Parameters for EKS](/reference-architecture/how-to-guides/tutorials/how-to-tune-spotinst-parameters-for-eks)
-- [How to Upgrade EKS Cluster Addons](/reference-architecture/how-to-guides/upgrades/how-to-upgrade-eks-cluster-addons)
-- [How to Upgrade EKS](/reference-architecture/how-to-guides/upgrades/how-to-upgrade-eks)
+- [How to Load Test in AWS](https://docs.cloudposse.com/reference-architecture/how-to-guides/tutorials/how-to-load-test-in-aws)
+- [How to Tune EKS with AWS Managed Node Groups](https://docs.cloudposse.com/reference-architecture/how-to-guides/tutorials/how-to-tune-eks-with-aws-managed-node-groups)
+- [How to Keep Everything Up to Date](https://docs.cloudposse.com/reference-architecture/how-to-guides/upgrades/how-to-keep-everything-up-to-date)
+- [How to Tune SpotInst Parameters for EKS](https://docs.cloudposse.com/reference-architecture/how-to-guides/tutorials/how-to-tune-spotinst-parameters-for-eks)
+- [How to Upgrade EKS Cluster Addons](https://docs.cloudposse.com/reference-architecture/how-to-guides/upgrades/how-to-upgrade-eks-cluster-addons)
+- [How to Upgrade EKS](https://docs.cloudposse.com/reference-architecture/how-to-guides/upgrades/how-to-upgrade-eks)
 
 ## References
 

--- a/modules/eks/eks-without-spotinst/README.md
+++ b/modules/eks/eks-without-spotinst/README.md
@@ -8,7 +8,7 @@ If Spotinst is going to be used, the following course of action needs to be foll
 1. Create Spotinst account and subscribe to a Business Plan.
 1. Provision [spotinst-integration](https://spot.io/), as documented in the component.
 1. Provision EKS with Spotinst Ocean pool only.
-1. Deploy core K8s components, including [metrics-server](/components/library/aws/eks/metrics-server), [external-dns](/components/library/aws/eks/external-dns), etc.
+1. Deploy core K8s components, including [metrics-server](https://docs.cloudposse.com/components/library/aws/eks/metrics-server), [external-dns](https://docs.cloudposse.com/components/library/aws/eks/external-dns), etc.
 1. Deploy Spotinst [ocean-controller](https://docs.spot.io/ocean/tutorials/spot-kubernetes-controller/).
 
 ## Usage

--- a/modules/opsgenie-team/README.md
+++ b/modules/opsgenie-team/README.md
@@ -339,14 +339,14 @@ Track the issue: https://github.com/opsgenie/terraform-provider-opsgenie/issues/
 
 ## Related How-to Guides
 
-- [How to Add Users to a Team in OpsGenie](/reference-architecture/how-to-guides/tutorials/how-to-implement-incident-management-with-opsgenie/how-to-add-users-to-a-team-in-opsgenie)
-- [How to Pass Tags Along to Datadog](/reference-architecture/how-to-guides/tutorials/how-to-implement-incident-management-with-opsgenie/how-to-pass-tags-along-to-datadog)
-- [How to Onboard a New Service with Datadog and OpsGenie](/reference-architecture/how-to-guides/tutorials/how-to-implement-incident-management-with-opsgenie/how-to-onboard-a-new-service-with-datadog-and-opsgenie)
-- [How to Create Escalation Rules in OpsGenie](/reference-architecture/how-to-guides/tutorials/how-to-implement-incident-management-with-opsgenie/how-to-create-escalation-rules-in-opsgenie)
-- [How to Setup Rotations in OpsGenie](/reference-architecture/how-to-guides/tutorials/how-to-implement-incident-management-with-opsgenie/how-to-setup-rotations-in-opsgenie)
-- [How to Create New Teams in OpsGenie](/reference-architecture/how-to-guides/tutorials/how-to-implement-incident-management-with-opsgenie/how-to-create-new-teams-in-opsgenie)
-- [How to Sign Up for OpsGenie?](/reference-architecture/how-to-guides/tutorials/how-to-implement-incident-management-with-opsgenie/how-to-sign-up-for-opsgenie/)
-- [How to Implement Incident Management with OpsGenie](/reference-architecture/how-to-guides/tutorials/how-to-implement-incident-management-with-opsgenie)
+- [How to Add Users to a Team in OpsGenie](https://docs.cloudposse.com/reference-architecture/how-to-guides/tutorials/how-to-implement-incident-management-with-opsgenie/how-to-add-users-to-a-team-in-opsgenie)
+- [How to Pass Tags Along to Datadog](https://docs.cloudposse.com/reference-architecture/how-to-guides/tutorials/how-to-implement-incident-management-with-opsgenie/how-to-pass-tags-along-to-datadog)
+- [How to Onboard a New Service with Datadog and OpsGenie](https://docs.cloudposse.com/reference-architecture/how-to-guides/tutorials/how-to-implement-incident-management-with-opsgenie/how-to-onboard-a-new-service-with-datadog-and-opsgenie)
+- [How to Create Escalation Rules in OpsGenie](https://docs.cloudposse.com/reference-architecture/how-to-guides/tutorials/how-to-implement-incident-management-with-opsgenie/how-to-create-escalation-rules-in-opsgenie)
+- [How to Setup Rotations in OpsGenie](https://docs.cloudposse.com/reference-architecture/how-to-guides/tutorials/how-to-implement-incident-management-with-opsgenie/how-to-setup-rotations-in-opsgenie)
+- [How to Create New Teams in OpsGenie](https://docs.cloudposse.com/reference-architecture/how-to-guides/tutorials/how-to-implement-incident-management-with-opsgenie/how-to-create-new-teams-in-opsgenie)
+- [How to Sign Up for OpsGenie?](https://docs.cloudposse.com/reference-architecture/how-to-guides/tutorials/how-to-implement-incident-management-with-opsgenie/how-to-sign-up-for-opsgenie/)
+- [How to Implement Incident Management with OpsGenie](https://docs.cloudposse.com/reference-architecture/how-to-guides/tutorials/how-to-implement-incident-management-with-opsgenie)
 
 ## References
 * [cloudposse/terraform-aws-components](https://github.com/cloudposse/terraform-aws-components/tree/master/modules/opsgenie-team) - Cloud Posse's upstream component

--- a/modules/tfstate-backend/README.md
+++ b/modules/tfstate-backend/README.md
@@ -7,7 +7,7 @@ However, perhaps counter-intuitively, all Terraform users require read access to
 
 :::info
 Part of cold start so it has to initially be run with `SuperAdmin`, multiple times: to create the S3 bucket and then to move the state into it.
-Follow the guide **[here](/reference-architecture/how-to-guides/implementation/enterprise/implement-aws-cold-start/#provision-tfstate-backend-component)** to get started.
+Follow the guide **[here](https://docs.cloudposse.com/reference-architecture/how-to-guides/implementation/enterprise/implement-aws-cold-start/#provision-tfstate-backend-component)** to get started.
 :::
 
 ### Access Control

--- a/modules/vpc/README.md
+++ b/modules/vpc/README.md
@@ -1,6 +1,6 @@
 # Component: `vpc`
 
-This component is responsible for provisioning a VPC and corresponding Subnets. Additionally, VPC Flow Logs can optionally be enabled for auditing purposes. See the existing [VPC configuration](./vpc-configuration.md) documentation for the provisioned subnets.
+This component is responsible for provisioning a VPC and corresponding Subnets. Additionally, VPC Flow Logs can optionally be enabled for auditing purposes. See the existing VPC configuration documentation for the provisioned subnets.
 
 ## Usage
 


### PR DESCRIPTION
## what
* Set to use absolute links for refarch docs

## why
* With absolute links both refarch docs and github README.md will work

## references
* 
