### PR TITLE
Upstream `spa-s3-cloudfront`

### DIFF
--- a/modules/spa-s3-cloudfront/README.md
+++ b/modules/spa-s3-cloudfront/README.md
@@ -112,18 +112,18 @@ an extensive explanation for how these preview environments work.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_acm_request_certificate"></a> [acm\_request\_certificate](#module\_acm\_request\_certificate) | cloudposse/acm-request-certificate/aws | 0.17.0 |
-| <a name="module_dns_delegated"></a> [dns\_delegated](#module\_dns\_delegated) | cloudposse/stack-config/yaml//modules/remote-state | 1.4.1 |
+| <a name="module_acm_request_certificate"></a> [acm\_request\_certificate](#module\_acm\_request\_certificate) | cloudposse/acm-request-certificate/aws | 0.16.3 |
+| <a name="module_dns_delegated"></a> [dns\_delegated](#module\_dns\_delegated) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
 | <a name="module_gha_assume_role"></a> [gha\_assume\_role](#module\_gha\_assume\_role) | ../account-map/modules/team-assume-role-policy | n/a |
 | <a name="module_gha_role_name"></a> [gha\_role\_name](#module\_gha\_role\_name) | cloudposse/label/null | 0.25.0 |
-| <a name="module_github_runners"></a> [github\_runners](#module\_github\_runners) | cloudposse/stack-config/yaml//modules/remote-state | 1.4.1 |
+| <a name="module_github_runners"></a> [github\_runners](#module\_github\_runners) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
 | <a name="module_lambda_edge_preview"></a> [lambda\_edge\_preview](#module\_lambda\_edge\_preview) | ./modules/lambda-edge-preview | n/a |
 | <a name="module_lambda_edge_redirect_404"></a> [lambda\_edge\_redirect\_404](#module\_lambda\_edge\_redirect\_404) | ./modules/lambda_edge_redirect_404 | n/a |
-| <a name="module_spa_web"></a> [spa\_web](#module\_spa\_web) | cloudposse/cloudfront-s3-cdn/aws | 0.83.0 |
+| <a name="module_spa_web"></a> [spa\_web](#module\_spa\_web) | cloudposse/cloudfront-s3-cdn/aws | 0.91.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 | <a name="module_utils"></a> [utils](#module\_utils) | cloudposse/utils/aws | 0.8.1 |
-| <a name="module_waf"></a> [waf](#module\_waf) | cloudposse/stack-config/yaml//modules/remote-state | 1.4.1 |
+| <a name="module_waf"></a> [waf](#module\_waf) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
 
 ## Resources
 

--- a/modules/spa-s3-cloudfront/main.tf
+++ b/modules/spa-s3-cloudfront/main.tf
@@ -54,7 +54,7 @@ locals {
 # Create an ACM and explicitly set it to us-east-1 (requirement of CloudFront)
 module "acm_request_certificate" {
   source  = "cloudposse/acm-request-certificate/aws"
-  version = "0.17.0"
+  version = "0.16.3"
   providers = {
     aws = aws.us-east-1
   }
@@ -70,13 +70,13 @@ module "acm_request_certificate" {
 
 module "spa_web" {
   source  = "cloudposse/cloudfront-s3-cdn/aws"
-  version = "0.83.0"
+  version = "0.91.0"
 
   block_origin_public_access_enabled = local.block_origin_public_access_enabled
   encryption_enabled                 = var.origin_encryption_enabled
   origin_force_destroy               = var.origin_force_destroy
   versioning_enabled                 = var.origin_versioning_enabled
-  web_acl_id                         = local.aws_waf_enabled ? module.waf.outputs.acl.arn : null
+  web_acl_id                         = local.aws_waf_enabled ? module.waf[0].outputs.acl.arn : null
 
   cloudfront_access_log_create_bucket = var.cloudfront_access_log_create_bucket
   cloudfront_access_log_bucket_name   = local.cloudfront_access_log_bucket_name

--- a/modules/spa-s3-cloudfront/remote-state.tf
+++ b/modules/spa-s3-cloudfront/remote-state.tf
@@ -1,8 +1,9 @@
 module "waf" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "1.4.1"
+  version = "1.5.0"
 
-  bypass      = !local.aws_waf_enabled
+  count = local.aws_waf_enabled ? 1 : 0
+
   component   = var.cloudfront_aws_waf_component_name
   privileged  = false
   environment = var.cloudfront_aws_waf_environment
@@ -18,7 +19,7 @@ module "waf" {
 
 module "dns_delegated" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "1.4.1"
+  version = "1.5.0"
 
   component   = "dns-delegated"
   environment = var.dns_delegated_environment_name
@@ -28,7 +29,7 @@ module "dns_delegated" {
 
 module "github_runners" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "1.4.1"
+  version = "1.5.0"
 
   count = local.github_runners_enabled ? 1 : 0
 


### PR DESCRIPTION
## what
- Upstream changes to `spa-s3-cloudfront`

## why
- Updated the included modules to support Terraform v5
- Handle disabled WAF from remote-state

## references
- https://github.com/cloudposse/terraform-aws-cloudfront-s3-cdn/pull/284
