### PR TITLE
Use s3_object_ownership variable

### DIFF
--- a/modules/s3-bucket/main.tf
+++ b/modules/s3-bucket/main.tf
@@ -54,6 +54,7 @@ module "s3_bucket" {
   source_policy_documents      = [local.bucket_policy]
   privileged_principal_actions = var.privileged_principal_actions
   privileged_principal_arns    = var.privileged_principal_arns
+  s3_object_ownership          = var.s3_object_ownership
 
   # Static website configuration
   cors_configuration = var.cors_configuration


### PR DESCRIPTION
## what
* Pass s3_object_ownership variable into s3 module

## why
* I think it was accidentally not included
* Make possible to disable ACL from stack config

## references

* https://github.com/cloudposse/terraform-aws-s3-bucket/releases/tag/3.1.0
