### PR TITLE
Upstream `spa-s3-cloudfront`

### DIFF
--- a/modules/spa-s3-cloudfront/README.md
+++ b/modules/spa-s3-cloudfront/README.md
@@ -120,7 +120,7 @@ an extensive explanation for how these preview environments work.
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
 | <a name="module_lambda_edge_preview"></a> [lambda\_edge\_preview](#module\_lambda\_edge\_preview) | ./modules/lambda-edge-preview | n/a |
 | <a name="module_lambda_edge_redirect_404"></a> [lambda\_edge\_redirect\_404](#module\_lambda\_edge\_redirect\_404) | ./modules/lambda_edge_redirect_404 | n/a |
-| <a name="module_spa_web"></a> [spa\_web](#module\_spa\_web) | cloudposse/cloudfront-s3-cdn/aws | 0.91.0 |
+| <a name="module_spa_web"></a> [spa\_web](#module\_spa\_web) | cloudposse/cloudfront-s3-cdn/aws | 0.92.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 | <a name="module_utils"></a> [utils](#module\_utils) | cloudposse/utils/aws | 0.8.1 |
 | <a name="module_waf"></a> [waf](#module\_waf) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |

--- a/modules/spa-s3-cloudfront/github-actions-iam-policy.tf
+++ b/modules/spa-s3-cloudfront/github-actions-iam-policy.tf
@@ -26,4 +26,15 @@ data "aws_iam_policy_document" "github_actions_iam_policy" {
     ]
     resources = [format("%s/*", module.spa_web.s3_bucket_arn)]
   }
+
+  statement {
+    sid    = "CloudfrontActions"
+    effect = "Allow"
+    actions = [
+      "cloudfront:CreateInvalidation"
+    ]
+    resources = [
+      module.spa_web.cf_arn
+    ]
+  }
 }

--- a/modules/spa-s3-cloudfront/main.tf
+++ b/modules/spa-s3-cloudfront/main.tf
@@ -70,7 +70,7 @@ module "acm_request_certificate" {
 
 module "spa_web" {
   source  = "cloudposse/cloudfront-s3-cdn/aws"
-  version = "0.91.0"
+  version = "0.92.0"
 
   block_origin_public_access_enabled = local.block_origin_public_access_enabled
   encryption_enabled                 = var.origin_encryption_enabled


### PR DESCRIPTION
## what
- Update module
- Add Cloudfront Invalidation permission to GitHub policy

## why
- Corrected bug in the module
- Allow GitHub Actions to run invalidations

## references
- https://github.com/cloudposse/terraform-aws-cloudfront-s3-cdn/pull/288
