### PR TITLE
Missing `s3_object_ownership`

### DIFF
--- a/modules/s3-bucket/main.tf
+++ b/modules/s3-bucket/main.tf
@@ -44,6 +44,7 @@ module "s3_bucket" {
   # Object access and permissions
   acl                          = var.acl
   grants                       = var.grants
+  s3_object_ownership          = var.s3_object_ownership
   allow_encrypted_uploads_only = var.allow_encrypted_uploads_only
   allow_ssl_requests_only      = var.allow_ssl_requests_only
   block_public_acls            = var.block_public_acls


### PR DESCRIPTION
## what
- Added `s3_object_ownership` Input

## why
- Variable was defined but not passed to the module

## references
- [Internal Slack Ref](https://cloudposse.slack.com/archives/C053BJ02EFM/p1690640165565679)