### PR TITLE
Spacelift `admin-stack` `var.description`

### DIFF
--- a/modules/spacelift/admin-stack/child-stacks.tf
+++ b/modules/spacelift/admin-stack/child-stacks.tf
@@ -88,7 +88,7 @@ module "child_stack" {
   component_root                          = try(join("/", [var.component_root, try(each.value.metadata.component, each.value.component)]))
   component_vars                          = try(each.value.vars, null)
   context_attachments                     = try(each.value.context_attachments, [])
-  description                             = try(each.value.description, null)
+  description                             = try(each.value.description, var.description)
   drift_detection_enabled                 = try(each.value.settings.spacelift.drift_detection_enabled, var.drift_detection_enabled)
   drift_detection_reconcile               = try(each.value.settings.spacelift.drift_detection_reconcile, var.drift_detection_reconcile)
   drift_detection_schedule                = try(each.value.settings.spacelift.drift_detection_schedule, var.drift_detection_schedule)

--- a/modules/spacelift/admin-stack/root-admin-stack.tf
+++ b/modules/spacelift/admin-stack/root-admin-stack.tf
@@ -55,7 +55,7 @@ module "root_admin_stack" {
   component_root                          = try(join("/", [var.component_root, local.root_admin_stack_config.metadata.component]), null)
   component_vars                          = try(local.root_admin_stack_config.vars, null)
   context_attachments                     = try(local.root_admin_stack_config.context_attachments, [])
-  description                             = try(local.root_admin_stack_config.description, null)
+  description                             = try(local.root_admin_stack_config.description, var.description)
   drift_detection_enabled                 = try(local.root_admin_stack_config.settings.spacelift.drift_detection_enabled, var.drift_detection_enabled)
   drift_detection_reconcile               = try(local.root_admin_stack_config.settings.spacelift.drift_detection_reconcile, var.drift_detection_reconcile)
   drift_detection_schedule                = try(local.root_admin_stack_config.settings.spacelift.drift_detection_schedule, var.drift_detection_schedule)


### PR DESCRIPTION
## what
- added missing description option

## why
- Variable is defined, but never passed to the modules

## references
n/a
