### PR TITLE
[eks/karpenter] Script to update Karpenter CRDs

### DIFF
--- a/modules/eks/karpenter/karpenter-crd-upgrade
+++ b/modules/eks/karpenter/karpenter-crd-upgrade
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+function usage() {
+  cat >&2 <<'EOF'
+./karpenter-crd-upgrade <version>
+
+Use this script to upgrade the Karpenter CRDs by installing or upgrading the karpenter-crd helm chart.
+
+EOF
+}
+
+function upgrade() {
+  VERSION="${1}"
+  [[ $VERSION =~ ^v ]] || VERSION="v${VERSION}"
+
+  set -x
+
+  kubectl label crd awsnodetemplates.karpenter.k8s.aws provisioners.karpenter.sh app.kubernetes.io/managed-by=Helm --overwrite
+  kubectl annotate crd awsnodetemplates.karpenter.k8s.aws provisioners.karpenter.sh meta.helm.sh/release-name=karpenter-crd --overwrite
+  kubectl annotate crd awsnodetemplates.karpenter.k8s.aws provisioners.karpenter.sh meta.helm.sh/release-namespace=karpenter --overwrite
+  helm upgrade --install karpenter-crd oci://public.ecr.aws/karpenter/karpenter-crd --version "$VERSION" --namespace karpenter
+}
+
+if (($# == 0)); then
+  usage
+else
+  upgrade $1
+fi


### PR DESCRIPTION
## what

- [eks/karpenter] Script to update Karpenter CRDs

## why

- Upgrading Karpenter to v0.28.0 requires updating CRDs, which is not handled by current Helm chart. This script updates them by modifying the existing CRDs to be labeled as being managed by Helm, then installing the `karpenter-crd` Helm chart.

## references

- Karpenter [CRD Upgrades](https://karpenter.sh/docs/upgrade-guide/#custom-resource-definition-crd-upgrades)


