### PR TITLE
[eks/storage-class] Initial implementation

### DIFF
--- a/modules/eks/storage-class/README.md
+++ b/modules/eks/storage-class/README.md
@@ -1,0 +1,196 @@
+# Component: `eks/storage-class`
+
+This component is responsible for provisioning `StorageClasses` in an EKS cluster.
+See the list of guides and references linked at the bottom of this README for more information.
+
+A StorageClass provides part of the configuration for a PersistentVolumeClaim,
+which copies the configuration when it is created. Thus, you can delete a StorageClass
+without affecting existing PersistentVolumeClaims, and changes to a StorageClass
+do not propagate to existing PersistentVolumeClaims.
+
+## Usage
+
+**Stack Level**: Regional, per cluster
+
+This component can create storage classes backed by EBS or EFS, and is intended to be used
+with the corresponding EKS add-ons `aws-ebs-csi-driver` and `aws-efs-csi-driver` respectively.
+In the case of EFS, this component also requires that you have provisioned an EFS filesystem
+in the same region as your cluster, and expects you have used the `eks/efs` component to do so.
+The EFS storage classes will get the file system ID from the EFS component's output.
+
+### Note: Default Storage Class
+
+Exactly one StorageClass can be designated as the default StorageClass for a cluster.
+This default StorageClass is then used by PersistentVolumeClaims that do not specify a storage class.
+
+Prior to Kubernetes 1.26, if more than one StorageClass is marked as default,
+a PersistentVolumeClaim without `storageClassName` explicitly specified cannot be created.
+In Kubernetes 1.26 and later, if more than one StorageClass is marked as default,
+the last one created will be used.
+
+EKS always creates a default storage class for the cluster, typically an EBS backed class named `gp2`. Find out
+what the default storage class is for your cluster by running this command:
+
+```bash
+kubectl get storageclass
+```
+
+This will list the available storage classes, with the default one marked with `(default)` next to its name.
+
+If you want to change the default, you can unset the existing default manually, like this:
+
+```bash
+SC_NAME=gp2 # Replace with the name of the storage class you want to unset as default
+kubectl patch storageclass $SC_NAME -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'
+```
+
+Or you can import the existing default storage class into Terraform and manage or delete it entirely, like this:
+
+```bash
+SC_NAME=gp2 # Replace with the name of the storage class you want to unset as default
+atmos terraform import eks/storage-class 'kubernetes_storage_class_v1.ebs["'${SC_NAME}'"]' $SC_NAME -s=core-usw2-dev
+```
+
+View the parameters of a storage class by running this command:
+
+```bash
+SC_NAME=gp2 # Replace with the name of the storage class you want to view
+kubectl get storageclass $SC_NAME -o yaml
+```
+
+You can then match that configuration, except that you cannot omit `allow_volume_exansion`.
+
+```yaml
+ebs_storage_classes:
+  gp2:
+    make_default_storage_class: true
+    include_tags: false
+    # Preserve values originally set by eks/cluster.
+    # Set to "" to omit.
+    provisioner: kubernetes.io/aws-ebs
+    parameters:
+      type: gp2
+      encrypted: ""
+```
+
+Here's an example snippet for how to use this component.
+
+```yaml
+    eks/storage-class:
+      vars:
+        ebs_storage_classes:
+          gp2:
+            make_default_storage_class: false
+            include_tags: false
+            # Preserve values originally set by eks/cluster.
+            # Set to "" to omit.
+            provisioner: kubernetes.io/aws-ebs
+            parameters:
+              type: gp2
+              encrypted: ""
+          gp3:
+            make_default_storage_class: true
+            parameters:
+              type: gp3
+        efs_storage_classes:
+          efs-sc:
+            make_default_storage_class: false
+```
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9.0 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.22.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.9.0 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.22.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_efs"></a> [efs](#module\_efs) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
+| <a name="module_eks"></a> [eks](#module\_eks) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
+| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../../account-map/modules/iam-roles | n/a |
+| <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [kubernetes_storage_class_v1.ebs](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/storage_class_v1) | resource |
+| [kubernetes_storage_class_v1.efs](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/storage_class_v1) | resource |
+| [aws_eks_cluster_auth.eks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster_auth) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br>This is for some rare cases where resources want additional configuration of tags<br>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
+| <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br>in the order they appear in the list. New attributes are appended to the<br>end of the list. The elements of the list are joined by the `delimiter`<br>and treated as a single ID element. | `list(string)` | `[]` | no |
+| <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "descriptor_formats": {},<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "labels_as_tags": [<br>    "unset"<br>  ],<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {},<br>  "tenant": null<br>}</pre> | no |
+| <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between ID elements.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
+| <a name="input_descriptor_formats"></a> [descriptor\_formats](#input\_descriptor\_formats) | Describe additional descriptors to be output in the `descriptors` output map.<br>Map of maps. Keys are names of descriptors. Values are maps of the form<br>`{<br>   format = string<br>   labels = list(string)<br>}`<br>(Type is `any` so the map values can later be enhanced to provide additional options.)<br>`format` is a Terraform format string to be passed to the `format()` function.<br>`labels` is a list of labels, in order, to pass to `format()` function.<br>Label values will be normalized before being passed to `format()` so they will be<br>identical to how they appear in `id`.<br>Default is `{}` (`descriptors` output will be empty). | `any` | `{}` | no |
+| <a name="input_ebs_storage_classes"></a> [ebs\_storage\_classes](#input\_ebs\_storage\_classes) | A map of storage class name to EBS parameters to create | <pre>map(object({<br>    make_default_storage_class = optional(bool, false)<br>    include_tags               = optional(bool, true) # If true, StorageClass will set our tags on created EBS volumes<br>    labels                     = optional(map(string), null)<br>    reclaim_policy             = optional(string, "Delete")<br>    volume_binding_mode        = optional(string, "WaitForFirstConsumer")<br>    mount_options              = optional(list(string), null)<br>    # Allowed topologies are poorly documented, and poorly implemented.<br>    # According to the API spec https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#storageclass-v1-storage-k8s-io<br>    # it should be a list of objects with a `matchLabelExpressions` key, which is a list of objects with `key` and `values` keys.<br>    # However, the Terraform resource only allows a single object in a matchLabelExpressions block, not a list,<br>    # the EBS driver appears to only allow a single matchLabelExpressions block, and it is entirely unclear<br>    # what should happen if either of the lists has more than one element.<br>    # So we simplify it here to be singletons, not lists, and allow for a future change to the resource to support lists,<br>    # and a future replacement for this flattened object which can maintain backward compatibility.<br>    allowed_topologies_match_label_expressions = optional(object({<br>      key    = optional(string, "topology.ebs.csi.aws.com/zone")<br>      values = list(string)<br>    }), null)<br>    allow_volume_expansion = optional(bool, true)<br>    # parameters, see https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/docs/parameters.md<br>    parameters = object({<br>      fstype                     = optional(string, "ext4") # "csi.storage.k8s.io/fstype"<br>      type                       = optional(string, "gp3")<br>      iopsPerGB                  = optional(string, null)<br>      allowAutoIOPSPerGBIncrease = optional(string, null) # "true" or "false"<br>      iops                       = optional(string, null)<br>      throughput                 = optional(string, null)<br><br>      encrypted    = optional(string, "true")<br>      kmsKeyId     = optional(string, null) # ARN of the KMS key to use for encryption. If not specified, the default key is used.<br>      blockExpress = optional(string, null) # "true" or "false"<br>      blockSize    = optional(string, null)<br>    })<br>    provisioner = optional(string, "ebs.csi.aws.com")<br><br>    # TODO: support tags<br>    # https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/docs/tagging.md<br>  }))</pre> | `{}` | no |
+| <a name="input_efs_storage_classes"></a> [efs\_storage\_classes](#input\_efs\_storage\_classes) | A map of storage class name to EFS parameters to create | <pre>map(object({<br>    make_default_storage_class = optional(bool, false)<br>    labels                     = optional(map(string), null)<br>    efs_component_name         = optional(string, "eks/efs")<br>    reclaim_policy             = optional(string, "Delete")<br>    volume_binding_mode        = optional(string, "Immediate")<br>    # Mount options are poorly documented.<br>    # TLS is now the default and need not be specified. https://github.com/kubernetes-sigs/aws-efs-csi-driver/tree/master/docs#encryption-in-transit<br>    # Other options include `lookupcache` and `iam`.<br>    mount_options = optional(list(string), null)<br>    parameters = optional(object({<br>      basePath         = optional(string, "/efs_controller")<br>      directoryPerms   = optional(string, "700")<br>      provisioningMode = optional(string, "efs-ap")<br>      gidRangeStart    = optional(string, null)<br>      gidRangeEnd      = optional(string, null)<br>      # Support for cross-account EFS mounts<br>      # See https://github.com/kubernetes-sigs/aws-efs-csi-driver/tree/master/examples/kubernetes/cross_account_mount<br>      # and for gritty details on secrets: https://kubernetes-csi.github.io/docs/secrets-and-credentials-storage-class.html<br>      az                           = optional(string, null)<br>      provisioner-secret-name      = optional(string, null) # "csi.storage.k8s.io/provisioner-secret-name"<br>      provisioner-secret-namespace = optional(string, null) # "csi.storage.k8s.io/provisioner-secret-namespace"<br>    }), {})<br>    provisioner = optional(string, "efs.csi.aws.com")<br>  }))</pre> | `{}` | no |
+| <a name="input_eks_component_name"></a> [eks\_component\_name](#input\_eks\_component\_name) | The name of the EKS component for the cluster in which to create the storage classes | `string` | `"eks/cluster"` | no |
+| <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
+| <a name="input_helm_manifest_experiment_enabled"></a> [helm\_manifest\_experiment\_enabled](#input\_helm\_manifest\_experiment\_enabled) | Enable storing of the rendered manifest for helm\_release so the full diff of what is changing can been seen in the plan | `bool` | `false` | no |
+| <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for keep the existing setting, which defaults to `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
+| <a name="input_kube_data_auth_enabled"></a> [kube\_data\_auth\_enabled](#input\_kube\_data\_auth\_enabled) | If `true`, use an `aws_eks_cluster_auth` data source to authenticate to the EKS cluster.<br>Disabled by `kubeconfig_file_enabled` or `kube_exec_auth_enabled`. | `bool` | `false` | no |
+| <a name="input_kube_exec_auth_aws_profile"></a> [kube\_exec\_auth\_aws\_profile](#input\_kube\_exec\_auth\_aws\_profile) | The AWS config profile for `aws eks get-token` to use | `string` | `""` | no |
+| <a name="input_kube_exec_auth_aws_profile_enabled"></a> [kube\_exec\_auth\_aws\_profile\_enabled](#input\_kube\_exec\_auth\_aws\_profile\_enabled) | If `true`, pass `kube_exec_auth_aws_profile` as the `profile` to `aws eks get-token` | `bool` | `false` | no |
+| <a name="input_kube_exec_auth_enabled"></a> [kube\_exec\_auth\_enabled](#input\_kube\_exec\_auth\_enabled) | If `true`, use the Kubernetes provider `exec` feature to execute `aws eks get-token` to authenticate to the EKS cluster.<br>Disabled by `kubeconfig_file_enabled`, overrides `kube_data_auth_enabled`. | `bool` | `true` | no |
+| <a name="input_kube_exec_auth_role_arn"></a> [kube\_exec\_auth\_role\_arn](#input\_kube\_exec\_auth\_role\_arn) | The role ARN for `aws eks get-token` to use | `string` | `""` | no |
+| <a name="input_kube_exec_auth_role_arn_enabled"></a> [kube\_exec\_auth\_role\_arn\_enabled](#input\_kube\_exec\_auth\_role\_arn\_enabled) | If `true`, pass `kube_exec_auth_role_arn` as the role ARN to `aws eks get-token` | `bool` | `true` | no |
+| <a name="input_kubeconfig_context"></a> [kubeconfig\_context](#input\_kubeconfig\_context) | Context to choose from the Kubernetes kube config file | `string` | `""` | no |
+| <a name="input_kubeconfig_exec_auth_api_version"></a> [kubeconfig\_exec\_auth\_api\_version](#input\_kubeconfig\_exec\_auth\_api\_version) | The Kubernetes API version of the credentials returned by the `exec` auth plugin | `string` | `"client.authentication.k8s.io/v1beta1"` | no |
+| <a name="input_kubeconfig_file"></a> [kubeconfig\_file](#input\_kubeconfig\_file) | The Kubernetes provider `config_path` setting to use when `kubeconfig_file_enabled` is `true` | `string` | `""` | no |
+| <a name="input_kubeconfig_file_enabled"></a> [kubeconfig\_file\_enabled](#input\_kubeconfig\_file\_enabled) | If `true`, configure the Kubernetes provider with `kubeconfig_file` and use that kubeconfig file for authenticating to the EKS cluster | `bool` | `false` | no |
+| <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | Controls the letter case of the `tags` keys (label names) for tags generated by this module.<br>Does not affect keys of tags passed in via the `tags` input.<br>Possible values: `lower`, `title`, `upper`.<br>Default value: `title`. | `string` | `null` | no |
+| <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The order in which the labels (ID elements) appear in the `id`.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present. | `list(string)` | `null` | no |
+| <a name="input_label_value_case"></a> [label\_value\_case](#input\_label\_value\_case) | Controls the letter case of ID elements (labels) as included in `id`,<br>set as tag values, and output by this module individually.<br>Does not affect values of tags passed in via the `tags` input.<br>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br>Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.<br>Default value: `lower`. | `string` | `null` | no |
+| <a name="input_labels_as_tags"></a> [labels\_as\_tags](#input\_labels\_as\_tags) | Set of labels (ID elements) to include as tags in the `tags` output.<br>Default is to include all labels.<br>Tags with empty values will not be included in the `tags` output.<br>Set to `[]` to suppress all generated tags.<br>**Notes:**<br>  The value of the `name` tag, if included, will be the `id`, not the `name`.<br>  Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be<br>  changed in later chained modules. Attempts to change it will be silently ignored. | `set(string)` | <pre>[<br>  "default"<br>]</pre> | no |
+| <a name="input_name"></a> [name](#input\_name) | ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.<br>This is the only ID element not also included as a `tag`.<br>The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input. | `string` | `null` | no |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique | `string` | `null` | no |
+| <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br>Characters matching the regex will be removed from the ID elements.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
+| <a name="input_region"></a> [region](#input\_region) | AWS Region. | `string` | n/a | yes |
+| <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
+| <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_storage_classes"></a> [storage\_classes](#output\_storage\_classes) | Storage classes created by this module |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+## Related How-to Guides
+
+- [EBS CSI Migration FAQ](https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi-migration-faq.html)
+- [Migrating Clusters From gp2 to gp3 EBS Volumes](https://aws.amazon.com/blogs/containers/migrating-amazon-eks-clusters-from-gp2-to-gp3-ebs-volumes/)
+- [Kubernetes: Change the Default StorageClass](https://kubernetes.io/docs/tasks/administer-cluster/change-default-storage-class/)
+
+## References
+
+- [Kubernetes Storage Classes](https://kubernetes.io/docs/concepts/storage/storage-classes)
+-
+- [EBS CSI driver (Amazon)](https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html)
+- [EBS CSI driver (GitHub)](https://github.com/kubernetes-sigs/aws-ebs-csi-driver#documentation)
+- [EBS CSI StorageClass Parameters](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/docs/parameters.md)
+- [EFS CSI driver (Amazon)](https://docs.aws.amazon.com/eks/latest/userguide/efs-csi.html)
+- [EFS CSI driver (GitHub)](https://github.com/kubernetes-sigs/aws-efs-csi-driver/blob/master/docs/README.md#examples)
+- [EFS CSI StorageClass Parameters](https://github.com/kubernetes-sigs/aws-efs-csi-driver/tree/master/docs#storage-class-parameters-for-dynamic-provisioning)
+- [cloudposse/terraform-aws-components](https://github.com/cloudposse/terraform-aws-components/tree/main/modules/eks/cluster) - Cloud Posse's upstream component
+
+[<img src="https://cloudposse.com/logo-300x69.svg" height="32" align="right"/>](https://cpco.io/component)

--- a/modules/eks/storage-class/README.md
+++ b/modules/eks/storage-class/README.md
@@ -104,6 +104,7 @@ Here's an example snippet for how to use this component.
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9.0 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.22.0 |
 
 ## Providers

--- a/modules/eks/storage-class/context.tf
+++ b/modules/eks/storage-class/context.tf
@@ -1,0 +1,279 @@
+#
+# ONLY EDIT THIS FILE IN github.com/cloudposse/terraform-null-label
+# All other instances of this file should be a copy of that one
+#
+#
+# Copy this file from https://github.com/cloudposse/terraform-null-label/blob/master/exports/context.tf
+# and then place it in your Terraform module to automatically get
+# Cloud Posse's standard configuration inputs suitable for passing
+# to Cloud Posse modules.
+#
+# curl -sL https://raw.githubusercontent.com/cloudposse/terraform-null-label/master/exports/context.tf -o context.tf
+#
+# Modules should access the whole context as `module.this.context`
+# to get the input variables with nulls for defaults,
+# for example `context = module.this.context`,
+# and access individual variables as `module.this.<var>`,
+# with final values filled in.
+#
+# For example, when using defaults, `module.this.context.delimiter`
+# will be null, and `module.this.delimiter` will be `-` (hyphen).
+#
+
+module "this" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0" # requires Terraform >= 0.13.0
+
+  enabled             = var.enabled
+  namespace           = var.namespace
+  tenant              = var.tenant
+  environment         = var.environment
+  stage               = var.stage
+  name                = var.name
+  delimiter           = var.delimiter
+  attributes          = var.attributes
+  tags                = var.tags
+  additional_tag_map  = var.additional_tag_map
+  label_order         = var.label_order
+  regex_replace_chars = var.regex_replace_chars
+  id_length_limit     = var.id_length_limit
+  label_key_case      = var.label_key_case
+  label_value_case    = var.label_value_case
+  descriptor_formats  = var.descriptor_formats
+  labels_as_tags      = var.labels_as_tags
+
+  context = var.context
+}
+
+# Copy contents of cloudposse/terraform-null-label/variables.tf here
+
+variable "context" {
+  type = any
+  default = {
+    enabled             = true
+    namespace           = null
+    tenant              = null
+    environment         = null
+    stage               = null
+    name                = null
+    delimiter           = null
+    attributes          = []
+    tags                = {}
+    additional_tag_map  = {}
+    regex_replace_chars = null
+    label_order         = []
+    id_length_limit     = null
+    label_key_case      = null
+    label_value_case    = null
+    descriptor_formats  = {}
+    # Note: we have to use [] instead of null for unset lists due to
+    # https://github.com/hashicorp/terraform/issues/28137
+    # which was not fixed until Terraform 1.0.0,
+    # but we want the default to be all the labels in `label_order`
+    # and we want users to be able to prevent all tag generation
+    # by setting `labels_as_tags` to `[]`, so we need
+    # a different sentinel to indicate "default"
+    labels_as_tags = ["unset"]
+  }
+  description = <<-EOT
+    Single object for setting entire context at once.
+    See description of individual variables for details.
+    Leave string and numeric variables as `null` to use default value.
+    Individual variable settings (non-null) override settings in context object,
+    except for attributes, tags, and additional_tag_map, which are merged.
+  EOT
+
+  validation {
+    condition     = lookup(var.context, "label_key_case", null) == null ? true : contains(["lower", "title", "upper"], var.context["label_key_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+
+  validation {
+    condition     = lookup(var.context, "label_value_case", null) == null ? true : contains(["lower", "title", "upper", "none"], var.context["label_value_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+variable "enabled" {
+  type        = bool
+  default     = null
+  description = "Set to false to prevent the module from creating any resources"
+}
+
+variable "namespace" {
+  type        = string
+  default     = null
+  description = "ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique"
+}
+
+variable "tenant" {
+  type        = string
+  default     = null
+  description = "ID element _(Rarely used, not included by default)_. A customer identifier, indicating who this instance of a resource is for"
+}
+
+variable "environment" {
+  type        = string
+  default     = null
+  description = "ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT'"
+}
+
+variable "stage" {
+  type        = string
+  default     = null
+  description = "ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release'"
+}
+
+variable "name" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.
+    This is the only ID element not also included as a `tag`.
+    The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input.
+    EOT
+}
+
+variable "delimiter" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Delimiter to be used between ID elements.
+    Defaults to `-` (hyphen). Set to `""` to use no delimiter at all.
+  EOT
+}
+
+variable "attributes" {
+  type        = list(string)
+  default     = []
+  description = <<-EOT
+    ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,
+    in the order they appear in the list. New attributes are appended to the
+    end of the list. The elements of the list are joined by the `delimiter`
+    and treated as a single ID element.
+    EOT
+}
+
+variable "labels_as_tags" {
+  type        = set(string)
+  default     = ["default"]
+  description = <<-EOT
+    Set of labels (ID elements) to include as tags in the `tags` output.
+    Default is to include all labels.
+    Tags with empty values will not be included in the `tags` output.
+    Set to `[]` to suppress all generated tags.
+    **Notes:**
+      The value of the `name` tag, if included, will be the `id`, not the `name`.
+      Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be
+      changed in later chained modules. Attempts to change it will be silently ignored.
+    EOT
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+    Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).
+    Neither the tag keys nor the tag values will be modified by this module.
+    EOT
+}
+
+variable "additional_tag_map" {
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+    Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.
+    This is for some rare cases where resources want additional configuration of tags
+    and therefore take a list of maps with tag key, value, and additional configuration.
+    EOT
+}
+
+variable "label_order" {
+  type        = list(string)
+  default     = null
+  description = <<-EOT
+    The order in which the labels (ID elements) appear in the `id`.
+    Defaults to ["namespace", "environment", "stage", "name", "attributes"].
+    You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present.
+    EOT
+}
+
+variable "regex_replace_chars" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Terraform regular expression (regex) string.
+    Characters matching the regex will be removed from the ID elements.
+    If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits.
+  EOT
+}
+
+variable "id_length_limit" {
+  type        = number
+  default     = null
+  description = <<-EOT
+    Limit `id` to this many characters (minimum 6).
+    Set to `0` for unlimited length.
+    Set to `null` for keep the existing setting, which defaults to `0`.
+    Does not affect `id_full`.
+  EOT
+  validation {
+    condition     = var.id_length_limit == null ? true : var.id_length_limit >= 6 || var.id_length_limit == 0
+    error_message = "The id_length_limit must be >= 6 if supplied (not null), or 0 for unlimited length."
+  }
+}
+
+variable "label_key_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Controls the letter case of the `tags` keys (label names) for tags generated by this module.
+    Does not affect keys of tags passed in via the `tags` input.
+    Possible values: `lower`, `title`, `upper`.
+    Default value: `title`.
+  EOT
+
+  validation {
+    condition     = var.label_key_case == null ? true : contains(["lower", "title", "upper"], var.label_key_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+}
+
+variable "label_value_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Controls the letter case of ID elements (labels) as included in `id`,
+    set as tag values, and output by this module individually.
+    Does not affect values of tags passed in via the `tags` input.
+    Possible values: `lower`, `title`, `upper` and `none` (no transformation).
+    Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.
+    Default value: `lower`.
+  EOT
+
+  validation {
+    condition     = var.label_value_case == null ? true : contains(["lower", "title", "upper", "none"], var.label_value_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+variable "descriptor_formats" {
+  type        = any
+  default     = {}
+  description = <<-EOT
+    Describe additional descriptors to be output in the `descriptors` output map.
+    Map of maps. Keys are names of descriptors. Values are maps of the form
+    `{
+       format = string
+       labels = list(string)
+    }`
+    (Type is `any` so the map values can later be enhanced to provide additional options.)
+    `format` is a Terraform format string to be passed to the `format()` function.
+    `labels` is a list of labels, in order, to pass to `format()` function.
+    Label values will be normalized before being passed to `format()` so they will be
+    identical to how they appear in `id`.
+    Default is `{}` (`descriptors` output will be empty).
+    EOT
+}
+
+#### End of copy of cloudposse/terraform-null-label/variables.tf

--- a/modules/eks/storage-class/main.tf
+++ b/modules/eks/storage-class/main.tf
@@ -47,10 +47,6 @@ resource "kubernetes_storage_class_v1" "ebs" {
   volume_binding_mode = each.value.volume_binding_mode
   mount_options       = each.value.mount_options
 
-  # Unfortunately, the provider always sets allow_volume_expansion whether you provide it or not.
-  # There is no way to omit it.
-  allow_volume_expansion = each.value.allow_volume_expansion
-
   # Allowed topologies are poorly documented, and poorly implemented.
   # According to the API spec https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#storageclass-v1-storage-k8s-io
   # it should be a list of objects with a `matchLabelExpressions` key, which is a list of objects with `key` and `values` keys.
@@ -67,7 +63,9 @@ resource "kubernetes_storage_class_v1" "ebs" {
     }
   }
 
-
+  # Unfortunately, the provider always sets allow_volume_expansion to something whether you provide it or not.
+  # There is no way to omit it.
+  allow_volume_expansion = each.value.allow_volume_expansion
 }
 
 resource "kubernetes_storage_class_v1" "efs" {

--- a/modules/eks/storage-class/main.tf
+++ b/modules/eks/storage-class/main.tf
@@ -1,0 +1,90 @@
+locals {
+  enabled = module.this.enabled
+
+  efs_components = local.enabled ? toset([for k, v in var.efs_storage_classes : v.efs_component_name]) : []
+
+  # In order to use `optional()`, the variable must be an object, but
+  # object keys must be valid identifiers and cannot be like "csi.storage.k8s.io/fstype"
+  # See https://github.com/hashicorp/terraform/issues/22681
+  # So we have to convert the object to a map with the keys the StorageClass expects
+  ebs_key_map = {
+    fstype = "csi.storage.k8s.io/fstype"
+  }
+  old_ebs_key_map = {
+    fstype = "fsType"
+  }
+
+  efs_key_map = {
+    provisioner-secret-name      = "csi.storage.k8s.io/provisioner-secret-name"
+    provisioner-secret-namespace = "csi.storage.k8s.io/provisioner-secret-namespace"
+  }
+
+  # Tag with cluster name rather than just stage ID.
+  tags = merge(module.this.tags, { Name = module.eks.outputs.eks_cluster_id })
+}
+
+resource "kubernetes_storage_class_v1" "ebs" {
+  for_each = local.enabled ? var.ebs_storage_classes : {}
+
+  metadata {
+    name = each.key
+    annotations = {
+      "storageclass.kubernetes.io/is-default-class" = each.value.make_default_storage_class ? "true" : "false"
+    }
+    labels = each.value.labels
+  }
+
+  # Tags are implemented via parameters. We use "tagSpecification_n" as the key, starting at 1.
+  # See https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/docs/tagging.md#storageclass-tagging
+  parameters = merge({ for k, v in each.value.parameters : (
+    # provisioner kubernetes.io/aws-ebs uses the key "fsType" instead of "csi.storage.k8s.io/fstype"
+    lookup((each.value.provisioner == "kubernetes.io/aws-ebs" ? local.old_ebs_key_map : local.ebs_key_map), k, k)) => v if v != null && v != "" },
+    each.value.include_tags ? { for i, k in keys(local.tags) : "tagSpecification_${i + 1}" => "${k}=${local.tags[k]}" } : {},
+  )
+
+  storage_provisioner = each.value.provisioner
+  reclaim_policy      = each.value.reclaim_policy
+  volume_binding_mode = each.value.volume_binding_mode
+  mount_options       = each.value.mount_options
+
+  # Unfortunately, the provider always sets allow_volume_expansion whether you provide it or not.
+  # There is no way to omit it.
+  allow_volume_expansion = each.value.allow_volume_expansion
+
+  # Allowed topologies are poorly documented, and poorly implemented.
+  # According to the API spec https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#storageclass-v1-storage-k8s-io
+  # it should be a list of objects with a `matchLabelExpressions` key, which is a list of objects with `key` and `values` keys.
+  # However, the Terraform resource only allows a single object in a matchLabelExpressions block, not a list,,
+  # the EBS driver appears to only allow a single matchLabelExpressions block, and it is entirely unclear
+  # what should happen if either of the lists has more than one element. So we simplify it here to be singletons, not lists.
+  dynamic "allowed_topologies" {
+    for_each = each.value.allowed_topologies_match_label_expressions != null ? ["zones"] : []
+    content {
+      match_label_expressions {
+        key    = each.value.allowed_topologies_match_label_expressions.key
+        values = each.value.allowed_topologies_match_label_expressions.values
+      }
+    }
+  }
+
+
+}
+
+resource "kubernetes_storage_class_v1" "efs" {
+  for_each = local.enabled ? var.efs_storage_classes : {}
+
+  metadata {
+    name = each.key
+    annotations = {
+      "storageclass.kubernetes.io/is-default-class" = each.value.make_default_storage_class ? "true" : "false"
+    }
+    labels = each.value.labels
+  }
+  parameters = merge({ fileSystemId = module.efs[each.value.efs_component_name].outputs.efs_id },
+  { for k, v in each.value.parameters : lookup(local.efs_key_map, k, k) => v if v != null && v != "" })
+
+  storage_provisioner = each.value.provisioner
+  reclaim_policy      = each.value.reclaim_policy
+  volume_binding_mode = each.value.volume_binding_mode
+  mount_options       = each.value.mount_options
+}

--- a/modules/eks/storage-class/outputs.tf
+++ b/modules/eks/storage-class/outputs.tf
@@ -1,0 +1,4 @@
+output "storage_classes" {
+  value       = merge(kubernetes_storage_class_v1.ebs, kubernetes_storage_class_v1.efs)
+  description = "Storage classes created by this module"
+}

--- a/modules/eks/storage-class/provider-helm.tf
+++ b/modules/eks/storage-class/provider-helm.tf
@@ -1,0 +1,166 @@
+##################
+#
+# This file is a drop-in to provide a helm provider.
+#
+# It depends on 2 standard Cloud Posse data source modules to be already
+# defined in the same component:
+#
+#   1. module.iam_roles to provide the AWS profile or Role ARN to use to access the cluster
+#   2. module.eks to provide the EKS cluster information
+#
+# All the following variables are just about configuring the Kubernetes provider
+# to be able to modify EKS cluster. The reason there are so many options is
+# because at various times, each one of them has had problems, so we give you a choice.
+#
+# The reason there are so many "enabled" inputs rather than automatically
+# detecting whether or not they are enabled based on the value of the input
+# is that any logic based on input values requires the values to be known during
+# the "plan" phase of Terraform, and often they are not, which causes problems.
+#
+variable "kubeconfig_file_enabled" {
+  type        = bool
+  default     = false
+  description = "If `true`, configure the Kubernetes provider with `kubeconfig_file` and use that kubeconfig file for authenticating to the EKS cluster"
+}
+
+variable "kubeconfig_file" {
+  type        = string
+  default     = ""
+  description = "The Kubernetes provider `config_path` setting to use when `kubeconfig_file_enabled` is `true`"
+}
+
+variable "kubeconfig_context" {
+  type        = string
+  default     = ""
+  description = "Context to choose from the Kubernetes kube config file"
+}
+
+variable "kube_data_auth_enabled" {
+  type        = bool
+  default     = false
+  description = <<-EOT
+    If `true`, use an `aws_eks_cluster_auth` data source to authenticate to the EKS cluster.
+    Disabled by `kubeconfig_file_enabled` or `kube_exec_auth_enabled`.
+    EOT
+}
+
+variable "kube_exec_auth_enabled" {
+  type        = bool
+  default     = true
+  description = <<-EOT
+    If `true`, use the Kubernetes provider `exec` feature to execute `aws eks get-token` to authenticate to the EKS cluster.
+    Disabled by `kubeconfig_file_enabled`, overrides `kube_data_auth_enabled`.
+    EOT
+}
+
+variable "kube_exec_auth_role_arn" {
+  type        = string
+  default     = ""
+  description = "The role ARN for `aws eks get-token` to use"
+}
+
+variable "kube_exec_auth_role_arn_enabled" {
+  type        = bool
+  default     = true
+  description = "If `true`, pass `kube_exec_auth_role_arn` as the role ARN to `aws eks get-token`"
+}
+
+variable "kube_exec_auth_aws_profile" {
+  type        = string
+  default     = ""
+  description = "The AWS config profile for `aws eks get-token` to use"
+}
+
+variable "kube_exec_auth_aws_profile_enabled" {
+  type        = bool
+  default     = false
+  description = "If `true`, pass `kube_exec_auth_aws_profile` as the `profile` to `aws eks get-token`"
+}
+
+variable "kubeconfig_exec_auth_api_version" {
+  type        = string
+  default     = "client.authentication.k8s.io/v1beta1"
+  description = "The Kubernetes API version of the credentials returned by the `exec` auth plugin"
+}
+
+variable "helm_manifest_experiment_enabled" {
+  type        = bool
+  default     = false
+  description = "Enable storing of the rendered manifest for helm_release so the full diff of what is changing can been seen in the plan"
+}
+
+locals {
+  kubeconfig_file_enabled = var.kubeconfig_file_enabled
+  kube_exec_auth_enabled  = local.kubeconfig_file_enabled ? false : var.kube_exec_auth_enabled
+  kube_data_auth_enabled  = local.kube_exec_auth_enabled ? false : var.kube_data_auth_enabled
+
+  # Eventually we might try to get this from an environment variable
+  kubeconfig_exec_auth_api_version = var.kubeconfig_exec_auth_api_version
+
+  exec_profile = local.kube_exec_auth_enabled && var.kube_exec_auth_aws_profile_enabled ? [
+    "--profile", var.kube_exec_auth_aws_profile
+  ] : []
+
+  kube_exec_auth_role_arn = coalesce(var.kube_exec_auth_role_arn, module.iam_roles.terraform_role_arn)
+  exec_role = local.kube_exec_auth_enabled && var.kube_exec_auth_role_arn_enabled ? [
+    "--role-arn", local.kube_exec_auth_role_arn
+  ] : []
+
+  # Provide dummy configuration for the case where the EKS cluster is not available.
+  certificate_authority_data = try(module.eks.outputs.eks_cluster_certificate_authority_data, "")
+  # Use coalesce+try to handle both the case where the output is missing and the case where it is empty.
+  eks_cluster_id       = coalesce(try(module.eks.outputs.eks_cluster_id, ""), "missing")
+  eks_cluster_endpoint = try(module.eks.outputs.eks_cluster_endpoint, "")
+}
+
+data "aws_eks_cluster_auth" "eks" {
+  count = local.kube_data_auth_enabled ? 1 : 0
+  name  = local.eks_cluster_id
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = local.eks_cluster_endpoint
+    cluster_ca_certificate = base64decode(local.certificate_authority_data)
+    token                  = local.kube_data_auth_enabled ? one(data.aws_eks_cluster_auth.eks[*].token) : null
+    # The Kubernetes provider will use information from KUBECONFIG if it exists, but if the default cluster
+    # in KUBECONFIG is some other cluster, this will cause problems, so we override it always.
+    config_path    = local.kubeconfig_file_enabled ? var.kubeconfig_file : ""
+    config_context = var.kubeconfig_context
+
+    dynamic "exec" {
+      for_each = local.kube_exec_auth_enabled && length(local.certificate_authority_data) > 0 ? ["exec"] : []
+      content {
+        api_version = local.kubeconfig_exec_auth_api_version
+        command     = "aws"
+        args = concat(local.exec_profile, [
+          "eks", "get-token", "--cluster-name", local.eks_cluster_id
+        ], local.exec_role)
+      }
+    }
+  }
+  experiments {
+    manifest = var.helm_manifest_experiment_enabled && module.this.enabled
+  }
+}
+
+provider "kubernetes" {
+  host                   = local.eks_cluster_endpoint
+  cluster_ca_certificate = base64decode(local.certificate_authority_data)
+  token                  = local.kube_data_auth_enabled ? one(data.aws_eks_cluster_auth.eks[*].token) : null
+  # The Kubernetes provider will use information from KUBECONFIG if it exists, but if the default cluster
+  # in KUBECONFIG is some other cluster, this will cause problems, so we override it always.
+  config_path    = local.kubeconfig_file_enabled ? var.kubeconfig_file : ""
+  config_context = var.kubeconfig_context
+
+  dynamic "exec" {
+    for_each = local.kube_exec_auth_enabled && length(local.certificate_authority_data) > 0 ? ["exec"] : []
+    content {
+      api_version = local.kubeconfig_exec_auth_api_version
+      command     = "aws"
+      args = concat(local.exec_profile, [
+        "eks", "get-token", "--cluster-name", local.eks_cluster_id
+      ], local.exec_role)
+    }
+  }
+}

--- a/modules/eks/storage-class/providers.tf
+++ b/modules/eks/storage-class/providers.tf
@@ -8,7 +8,7 @@ provider "aws" {
     # module.iam_roles.terraform_role_arn may be null, in which case do not assume a role.
     for_each = compact([module.iam_roles.terraform_role_arn])
     content {
-      role_arn = module.iam_roles.terraform_role_arn
+      role_arn = assume_role.value
     }
   }
 }

--- a/modules/eks/storage-class/providers.tf
+++ b/modules/eks/storage-class/providers.tf
@@ -1,0 +1,19 @@
+provider "aws" {
+  region = var.region
+
+  # Profile is deprecated in favor of terraform_role_arn. When profiles are not in use, terraform_profile_name is null.
+  profile = module.iam_roles.terraform_profile_name
+
+  dynamic "assume_role" {
+    # module.iam_roles.terraform_role_arn may be null, in which case do not assume a role.
+    for_each = compact([module.iam_roles.terraform_role_arn])
+    content {
+      role_arn = module.iam_roles.terraform_role_arn
+    }
+  }
+}
+
+module "iam_roles" {
+  source  = "../../account-map/modules/iam-roles"
+  context = module.this.context
+}

--- a/modules/eks/storage-class/remote-state.tf
+++ b/modules/eks/storage-class/remote-state.tf
@@ -1,0 +1,19 @@
+module "efs" {
+  source  = "cloudposse/stack-config/yaml//modules/remote-state"
+  version = "1.5.0"
+
+  for_each = local.efs_components
+
+  component = each.value
+
+  context = module.this.context
+}
+
+module "eks" {
+  source  = "cloudposse/stack-config/yaml//modules/remote-state"
+  version = "1.5.0"
+
+  component = var.eks_component_name
+
+  context = module.this.context
+}

--- a/modules/eks/storage-class/variables.tf
+++ b/modules/eks/storage-class/variables.tf
@@ -1,0 +1,87 @@
+variable "region" {
+  description = "AWS Region."
+  type        = string
+}
+
+variable "eks_component_name" {
+  type        = string
+  description = "The name of the EKS component for the cluster in which to create the storage classes"
+  default     = "eks/cluster"
+  nullable    = false
+}
+
+variable "ebs_storage_classes" {
+  type = map(object({
+    make_default_storage_class = optional(bool, false)
+    include_tags               = optional(bool, true) # If true, StorageClass will set our tags on created EBS volumes
+    labels                     = optional(map(string), null)
+    reclaim_policy             = optional(string, "Delete")
+    volume_binding_mode        = optional(string, "WaitForFirstConsumer")
+    mount_options              = optional(list(string), null)
+    # Allowed topologies are poorly documented, and poorly implemented.
+    # According to the API spec https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#storageclass-v1-storage-k8s-io
+    # it should be a list of objects with a `matchLabelExpressions` key, which is a list of objects with `key` and `values` keys.
+    # However, the Terraform resource only allows a single object in a matchLabelExpressions block, not a list,
+    # the EBS driver appears to only allow a single matchLabelExpressions block, and it is entirely unclear
+    # what should happen if either of the lists has more than one element.
+    # So we simplify it here to be singletons, not lists, and allow for a future change to the resource to support lists,
+    # and a future replacement for this flattened object which can maintain backward compatibility.
+    allowed_topologies_match_label_expressions = optional(object({
+      key    = optional(string, "topology.ebs.csi.aws.com/zone")
+      values = list(string)
+    }), null)
+    allow_volume_expansion = optional(bool, true)
+    # parameters, see https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/docs/parameters.md
+    parameters = object({
+      fstype                     = optional(string, "ext4") # "csi.storage.k8s.io/fstype"
+      type                       = optional(string, "gp3")
+      iopsPerGB                  = optional(string, null)
+      allowAutoIOPSPerGBIncrease = optional(string, null) # "true" or "false"
+      iops                       = optional(string, null)
+      throughput                 = optional(string, null)
+
+      encrypted    = optional(string, "true")
+      kmsKeyId     = optional(string, null) # ARN of the KMS key to use for encryption. If not specified, the default key is used.
+      blockExpress = optional(string, null) # "true" or "false"
+      blockSize    = optional(string, null)
+    })
+    provisioner = optional(string, "ebs.csi.aws.com")
+
+    # TODO: support tags
+    # https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/docs/tagging.md
+  }))
+  description = "A map of storage class name to EBS parameters to create"
+  default     = {}
+  nullable    = false
+}
+
+variable "efs_storage_classes" {
+  type = map(object({
+    make_default_storage_class = optional(bool, false)
+    labels                     = optional(map(string), null)
+    efs_component_name         = optional(string, "eks/efs")
+    reclaim_policy             = optional(string, "Delete")
+    volume_binding_mode        = optional(string, "Immediate")
+    # Mount options are poorly documented.
+    # TLS is now the default and need not be specified. https://github.com/kubernetes-sigs/aws-efs-csi-driver/tree/master/docs#encryption-in-transit
+    # Other options include `lookupcache` and `iam`.
+    mount_options = optional(list(string), null)
+    parameters = optional(object({
+      basePath         = optional(string, "/efs_controller")
+      directoryPerms   = optional(string, "700")
+      provisioningMode = optional(string, "efs-ap")
+      gidRangeStart    = optional(string, null)
+      gidRangeEnd      = optional(string, null)
+      # Support for cross-account EFS mounts
+      # See https://github.com/kubernetes-sigs/aws-efs-csi-driver/tree/master/examples/kubernetes/cross_account_mount
+      # and for gritty details on secrets: https://kubernetes-csi.github.io/docs/secrets-and-credentials-storage-class.html
+      az                           = optional(string, null)
+      provisioner-secret-name      = optional(string, null) # "csi.storage.k8s.io/provisioner-secret-name"
+      provisioner-secret-namespace = optional(string, null) # "csi.storage.k8s.io/provisioner-secret-namespace"
+    }), {})
+    provisioner = optional(string, "efs.csi.aws.com")
+  }))
+  description = "A map of storage class name to EFS parameters to create"
+  default     = {}
+  nullable    = false
+}

--- a/modules/eks/storage-class/versions.tf
+++ b/modules/eks/storage-class/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.9.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.22.0"
+    }
+  }
+}

--- a/modules/eks/storage-class/versions.tf
+++ b/modules/eks/storage-class/versions.tf
@@ -10,5 +10,9 @@ terraform {
       source  = "hashicorp/kubernetes"
       version = ">= 2.22.0"
     }
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.0"
+    }
   }
 }


### PR DESCRIPTION
## what

- Initial implementation of `eks/storage-class`

## why

- Until now, we provisioned StorageClasses as a part of deploying [eks/ebs-controller](https://github.com/cloudposse/terraform-aws-components/blob/ba309ab4ffa96169b2b8dadce0643d13c1bd3ae9/modules/eks/ebs-controller/main.tf#L20-L56) and [eks/efs-controller](https://github.com/cloudposse/terraform-aws-components/blob/ba309ab4ffa96169b2b8dadce0643d13c1bd3ae9/modules/eks/efs-controller/main.tf#L48-L60). However, with the switch from deploying "self-managed" controllers to EKS add-ons, we no longer deploy `eks/ebs-controller` or `eks/efs-controller`. Therefore, we need a new component to manage StorageClasses independently of controllers.


## references

- #723 
