### PR TITLE
feat: filter out “SUSPENDED” accounts for account-map

### DIFF
--- a/modules/account-map/main.tf
+++ b/modules/account-map/main.tf
@@ -8,7 +8,7 @@ locals {
 
   full_account_map = {
     for acct in data.aws_organizations_organization.organization.accounts
-    : acct.name == var.root_account_aws_name ? var.root_account_account_name : acct.name => acct.id
+    : acct.name == var.root_account_aws_name ? var.root_account_account_name : acct.name => acct.id if acct.status != "SUSPENDED"
   }
 
   iam_role_arn_templates = {


### PR DESCRIPTION
## what
* filter out “SUSPENDED” accounts  (aka accounts in waiting period for termination) for `account-map` component

## why
* suspended account cannot be used, so therefore it should not exist in the account-map
* allows for new _active_ accounts with same exact name of suspended account to exists and work with `account-map`

## references
* n/a
