### PR TITLE
bug: handle lowercase name tag when explicitly defining Name tag

### DIFF
--- a/modules/aws-team-roles/main.tf
+++ b/modules/aws-team-roles/main.tf
@@ -69,7 +69,7 @@ resource "aws_iam_role" "default" {
   description          = each.value["role_description"]
   assume_role_policy   = data.aws_iam_policy_document.assume_role_aggregated[each.key].json
   max_session_duration = each.value["max_session_duration"]
-  tags                 = merge(module.this.tags, { Name = local.role_name_map[each.key] })
+  tags                 = merge(module.this.tags, { Name = local.role_name_map[each.key], name = null })
 }
 
 resource "aws_iam_role_policy_attachment" "default" {

--- a/modules/aws-teams/main.tf
+++ b/modules/aws-teams/main.tf
@@ -65,7 +65,7 @@ resource "aws_iam_role" "default" {
   description          = local.roles_config[each.key]["role_description"]
   assume_role_policy   = data.aws_iam_policy_document.assume_role_aggregated[each.key].json
   max_session_duration = each.value["max_session_duration"]
-  tags                 = merge(module.this.tags, { Name = local.role_name_map[each.key] })
+  tags                 = merge(module.this.tags, { Name = local.role_name_map[each.key], name = null })
 }
 
 resource "aws_iam_role_policy_attachment" "default" {

--- a/modules/tfstate-backend/iam.tf
+++ b/modules/tfstate-backend/iam.tf
@@ -75,7 +75,7 @@ resource "aws_iam_role" "default" {
   name               = each.key
   description        = "${each.value.write_enabled ? "Access" : "Read-only access"} role for ${module.this.id}"
   assume_role_policy = module.assume_role[each.key].policy_document
-  tags               = merge(module.this.tags, { Name = each.key })
+  tags               = merge(module.this.tags, { Name = each.key, name = null })
 
   inline_policy {
     name   = each.key


### PR DESCRIPTION
## what
* gracefully handle lowercase `name` tag when explicitly defining `Name` tag
  - setting `name` to `null` means the provider ignore the key-value pair and therefore creates no conflicts with `Name`

## why
* aws provider (least with latest provider) does not allow both `name` and `Name` keys to exists for `tags` variable

## references
* n/a