### PR TITLE
Transit Gateway Cross-Region Support

### DIFF
--- a/modules/tgw/README.md
+++ b/modules/tgw/README.md
@@ -1,0 +1,341 @@
+# Transit Gateway `tgw`
+
+AWS Transit Gateway connects your Amazon Virtual Private Clouds (VPCs) and on-premises networks through a central hub. This connection simplifies your network and puts an end to complex peering relationships. Transit Gateway acts as a highly scalable cloud router—each new connection is made only once.
+
+For more on Transit Gateway, see [the AWS documentation](https://aws.amazon.com/transit-gateway/).
+
+## Requirements
+
+In order to connect accounts with Transit Gateway, we deploy Transit Gateway to a central account, typically `core-network`, and then deploy Transit Gateway attachments for each connected account. Each connected accounts needs a Transit Gateway attachment for the given account's VPC, either by VPC attachment or by Peering Connection attachment. Furthermore, each private subnet in each connected VPC needs to explicitly list the CIDRs for all allowed connections.
+
+## Solution
+
+First we deploy the Transit Gateway Hub, `tgw/hub`, to a central network account. The component prepares the Transit Gateway network with the following steps:
+
+1. Provision Transit Gateway in the network account
+2. Collect VPC and EKS component output from every account connected to Transit Gateway
+3. Share the Transit Gateway with the Organization using Resource Access Manager (RAM)
+
+By using the `tgw/hub` component to collect Terraform output from connected accounts, only this single component requires access to the Terraform state of all connected accounts.
+
+Next we deploy `tgw/spoke` to the network account and then to every connected account. This spoke component connects the given account to the central hub and any listed connection with the following steps:
+
+1. Create a Transit Gateway VPC attachment in the spoke account. This connects the account's VPC to the shared Transit Gateway from the hub account.
+2. Define all allowed routes for private subnets. Each private subnet in an account's VPC has it's own route table. This route table needs to explicitly list any allowed connection to another account's VPC CIDR.
+3. (Optional) Create an EKS Cluster Security Group rule to allow traffic to the cluster in the given account.
+
+## Implementation
+
+1. Deploy `tgw/hub` to the network account. List every allowed connection:
+
+```yaml
+components:
+  terraform:
+    tgw/hub/defaults:
+      metadata:
+        type: abstract
+        component: tgw/hub
+      vars:
+        enabled: true
+        name: tgw-hub
+        tags:
+          Team: sre
+          Service: tgw-hub
+
+    tgw/hub:
+      metadata:
+        inherits:
+          - tgw/hub/defaults
+        component: tgw/hub
+      vars:
+        # These are all connections available for spokes in this region
+        # Defaults environment to this region
+        connections:
+          - account:
+              tenant: core
+              stage: network
+          - account:
+              tenant: core
+              stage: auto
+            eks_component_names:
+              - eks/cluster
+          - account:
+              tenant: plat
+              stage: sandbox
+            eks_component_names: [] # No clusters deployed for sandbox
+          - account:
+              tenant: plat
+              stage: dev
+            eks_component_names:
+              - eks/cluster
+          - account:
+              tenant: plat
+              stage: staging
+            eks_component_names:
+              - eks/cluster
+          - account:
+              tenant: plat
+              stage: prod
+            eks_component_names:
+              - eks/cluster
+```
+
+2. Deploy `tgw/spoke` to network. List every account connected to network (all accounts):
+
+```yaml
+# stacks/catalog/tgw/spoke
+components:
+  terraform:
+    tgw/spoke-defaults:
+      metadata:
+        type: abstract
+        component: tgw/spoke
+      vars:
+        enabled: true
+        name: tgw-spoke
+        tgw_hub_tenant_name: core
+        tgw_hub_stage_name: network # default, added for visibility
+        tags:
+          Team: sre
+          Service: tgw-spoke
+```
+
+```yaml
+# stacks/orgs/acme/core/network/us-east-1/network.yaml
+tgw/spoke:
+  metadata:
+    inherits:
+      - tgw/spoke-defaults
+  vars:
+    # This is what THIS spoke is allowed to connect to
+    connections:
+      - account:
+          tenant: core
+          stage: network
+      - account:
+          tenant: core
+          stage: auto
+      - account:
+          tenant: plat
+          stage: sandbox
+      - account:
+          tenant: plat
+          stage: dev
+      - account:
+          tenant: plat
+          stage: staging
+      - account:
+          tenant: plat
+          stage: prod
+```
+
+3. Finally, deploy `tgw/spoke` for each connected account and list the allowed connections:
+
+```yaml
+# stacks/orgs/acme/plat/dev/us-east-1/network.yaml
+tgw/spoke:
+  metadata:
+    inherits:
+      - tgw/spoke-defaults
+  vars:
+    connections:
+      # Always list self
+      - account:
+          tenant: plat
+          stage: dev
+      - account:
+          tenant: core
+          stage: network
+      - account:
+          tenant: core
+          stage: auto
+
+```
+
+### Alternate Regions
+
+In order to connect any account to the network, the given account needs:
+
+1. Access to the shared Transit Gateway hub
+2. An attachment for the given Transit Gateway hub
+3. Routes to and from each private subnet
+
+However, sharing the Transit Gateway hub via RAM is only supported in the same region as the primary hub. Therefore, we must instead deploy a new hub in the alternate region and create a [Transit Gateway Peering Connection](https://docs.aws.amazon.com/vpc/latest/tgw/tgw-peering.html) between the two Transit Gateway hubs.
+
+Furthermore, since this Transit Gateway hub for the alternate region is now peered, we must create a Peering Transit Gateway attachment, opposed to a VPC Transit Gateway Attachment.
+
+#### Cross Region Deployment
+
+1. Deploy `tgw/hub` and `tgw/spoke` into the primary region as described in [Implemention](#Implemention)
+
+2. Deploy `tgw/hub` and `tgw/cross-region-hub` into the new region in the network account. See the following configuration:
+
+```yaml
+# stacks/catalog/tgw/cross-region-hub
+import:
+  - catalog/tgw/hub
+
+components:
+  terraform:
+    # Cross region TGW requires additional hub in the alternate region
+    tgw/hub:
+      vars:
+        # These are all connections available for spokes in this region
+        # Defaults environment to this region
+        connections:
+          # Hub for this region is always required
+          - account:
+              tenant: core
+              stage: network
+          # VPN source
+          - account:
+              tenant: core
+              stage: network
+              environment: use1
+          # Github Runners
+          - account:
+              tenant: core
+              stage: auto
+              environment: use1
+            eks_component_names:
+              - eks/cluster
+          # All stacks where a spoke will be deployed
+          - account:
+              tenant: plat
+              stage: dev
+          - account:
+              tenant: plat
+              stage: staging
+          - account:
+              tenant: plat
+              stage: prod
+
+    # This alternate hub needs to be connected to the primary region's hub
+    tgw/cross-region-hub-connector:
+      vars:
+        enabled: true
+        primary_tgw_hub_region: us-east-1
+```
+
+3. Deploy a `tgw/spoke` for network in the new region. For example:
+
+```yaml
+# stacks/orgs/acme/core/network/us-west-2/network.yaml
+tgw/spoke:
+  metadata:
+    inherits:
+      - tgw/spoke-defaults
+  vars:
+    peered_region: true # Required for alternate region spokes
+    connections:
+      # This stack, always included
+      - account:
+          tenant: core
+          stage: network
+      # VPN
+      - account:
+          tenant: core
+          environment: use1
+          stage: network
+      # Automation runners
+      - account:
+          tenant: core
+          environment: use1
+          stage: auto
+        eks_component_names:
+          - eks/cluster
+      # All other connections
+      - account:
+          tenant: plat
+          stage: dev
+      - account:
+          tenant: plat
+          stage: staging
+      - account:
+          tenant: plat
+          stage: prod
+```
+
+4. Deploy the `tgw/spoke` components for all connected accounts. For example:
+
+```yaml
+# stacks/orgs/acme/plat/dev/us-west-2/network.yaml
+tgw/spoke:
+  metadata:
+    inherits:
+      - tgw/spoke-defaults
+  vars:
+    peered_region: true # Required for alternate region spokes
+    connections:
+      # This stack, always included
+      - account:
+          tenant: plat
+          stage: dev
+      # TGW Hub, always included
+      - account:
+          tenant: core
+          stage: network
+      # VPN
+      - account:
+          tenant: core
+          environment: use1
+          stage: network
+      # Automation runners
+      - account:
+          tenant: core
+          environment: use1
+          stage: auto
+        eks_component_names:
+          - eks/cluster
+```
+
+5. Update any existing `tgw/spoke` connections to allow the new account and region. For example:
+
+```yaml
+# stacks/orgs/acme/core/auto/us-east-1/network.yaml
+tgw/spoke:
+  metadata:
+    inherits:
+      - tgw/spoke-defaults
+  vars:
+    connections:
+      - account:
+          tenant: core
+          stage: network
+      - account:
+          tenant: core
+          stage: corp
+      - account:
+          tenant: core
+          stage: auto
+      - account:
+          tenant: plat
+          stage: sandbox
+      - account:
+          tenant: plat
+          stage: dev
+      - account:
+          tenant: plat
+          stage: staging
+      - account:
+          tenant: plat
+          stage: prod
+
+      # Alternate regions     <-------- These are added for alternate region
+      - account:
+          tenant: core
+          stage: network
+          environment: usw2
+      - account:
+          tenant: plat
+          stage: dev
+          environment: usw2
+      - account:
+          tenant: plat
+          stage: staging
+          environment: usw2
+      - account:
+          tenant: plat
+          stage: prod
+          environment: usw2
+```

--- a/modules/tgw/cross-region-hub-connector/README.md
+++ b/modules/tgw/cross-region-hub-connector/README.md
@@ -1,91 +1,57 @@
-# Component: `tgw/spoke`
+# Component: `cross-region-hub-connector`
 
-This component is responsible for provisioning [AWS Transit Gateway](https://aws.amazon.com/transit-gateway) attachments to connect VPCs in a `spoke` account to different accounts through a central `hub`.
+This component is responsible for provisioning an [AWS Transit Gateway Peering Connection](https://aws.amazon.com/transit-gateway) to connect TGWs from different accounts and(or) regions.
+
+Transit Gateway does not support sharing the Transit Gateway hub across regions. You must deploy a Transit Gateway hub for each region and connect the alternate hub to the primary hub.
 
 ## Usage
 
 **Stack Level**: Regional
 
-Here's an example snippet for how to configure and use this component:
+This component is deployed to each alternate region with `tgw/hub`.
 
-stacks/catalog/tgw/spoke.yaml
-
-```yaml
-components:
-  terraform:
-    tgw/spoke-defaults:
-      metadata:
-        type: abstract
-        component: tgw/spoke
-      vars:
-        enabled: true
-        name: tgw-spoke
-        tags:
-          Team: sre
-          Service: tgw-spoke
-        expose_eks_sg: false
-        tgw_hub_tenant_name: core
-        tgw_hub_environment_name: ue1
-
-    tgw/spoke:
-      metadata:
-        inherits:
-          - tgw/spoke-defaults
-      vars:
-        # This is what THIS spoke is allowed to connect to.
-        # since this is deployed to each plat account (dev->prod),
-        # we allow connections to network and auto.
-        connections:
-          - account:
-              tenant: core
-              stage: network
-            # Set this value if the vpc component has a different name in this account
-            vpc_component_names:
-              - vpc-dev
-          - account:
-              tenant: core
-              stage: auto
-```
-
-stacks/ue2/dev.yaml
+For example if your primary region is `us-east-1` and your alternate region is `us-west-2`, deploy another `tgw/hub` in `us-west-2`
+and peer the two with `tgw/cross-region-hub-connector` with the following stack config, imported into `us-west-2`
 
 ```yaml
 import:
-  - catalog/tgw/spoke
+  - catalog/tgw/hub
 
 components:
   terraform:
-    tgw/spoke:
+    # Cross region TGW requires additional hub in the alternate region
+    tgw/hub:
       vars:
-        # use when there is not an EKS cluster in the stack
-        expose_eks_sg: false
-        # override default connections
+        # These are all connections available for spokes in this region
+        # Defaults environment to this region
         connections:
+          # Hub for this region is always required
           - account:
               tenant: core
               stage: network
-            vpc_component_names:
-              - vpc-dev
+          # VPN source
+          - account:
+              tenant: core
+              stage: network
+              environment: use1
+          # Github Runners
           - account:
               tenant: core
               stage: auto
+              environment: use1
+            eks_component_names:
+              - eks/cluster
+          # All stacks where a spoke will be deployed
           - account:
               tenant: plat
               stage: dev
-            eks_component_names:
-              - eks/cluster
-          - account:
-              tenant: plat
-              stage: qa
-            eks_component_names:
-              - eks/cluster
-```
+            eks_component_names: [] # Add clusters here once deployed
 
-To provision the attachments for a spoke account:
-
-```sh
-atmos terraform plan tgw/spoke -s <tenant>-<environment>-<stage>
-atmos terraform apply tgw/spoke -s <tenant>-<environment>-<stage>
+    # This alternate hub needs to be connected to the primary region's hub
+    tgw/cross-region-hub-connector:
+      vars:
+        enabled: true
+        primary_tgw_hub_region: us-east-1
 ```
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
@@ -95,40 +61,49 @@ atmos terraform apply tgw/spoke -s <tenant>-<environment>-<stage>
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.1 |
+| <a name="requirement_utils"></a> [utils](#requirement\_utils) | >= 1.8.0 |
 
 ## Providers
 
-No providers.
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.1 |
+| <a name="provider_aws.primary_tgw_hub_region"></a> [aws.primary\_tgw\_hub\_region](#provider\_aws.primary\_tgw\_hub\_region) | >= 4.1 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_cross_region_hub_connector"></a> [cross\_region\_hub\_connector](#module\_cross\_region\_hub\_connector) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
+| <a name="module_account_map"></a> [account\_map](#module\_account\_map) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../../account-map/modules/iam-roles | n/a |
-| <a name="module_tgw_hub"></a> [tgw\_hub](#module\_tgw\_hub) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
-| <a name="module_tgw_hub_role"></a> [tgw\_hub\_role](#module\_tgw\_hub\_role) | ../../account-map/modules/iam-roles | n/a |
-| <a name="module_tgw_hub_routes"></a> [tgw\_hub\_routes](#module\_tgw\_hub\_routes) | cloudposse/transit-gateway/aws | 0.10.0 |
-| <a name="module_tgw_spoke_vpc_attachment"></a> [tgw\_spoke\_vpc\_attachment](#module\_tgw\_spoke\_vpc\_attachment) | ./modules/standard_vpc_attachment | n/a |
+| <a name="module_tgw_hub_primary_region"></a> [tgw\_hub\_primary\_region](#module\_tgw\_hub\_primary\_region) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
+| <a name="module_tgw_hub_this_region"></a> [tgw\_hub\_this\_region](#module\_tgw\_hub\_this\_region) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
+| <a name="module_utils"></a> [utils](#module\_utils) | cloudposse/utils/aws | 1.3.0 |
 
 ## Resources
 
-No resources.
+| Name | Type |
+|------|------|
+| [aws_ec2_transit_gateway_peering_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_peering_attachment) | resource |
+| [aws_ec2_transit_gateway_peering_attachment_accepter.primary_region](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_peering_attachment_accepter) | resource |
+| [aws_ec2_transit_gateway_route_table_association.primary_region](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_route_table_association) | resource |
+| [aws_ec2_transit_gateway_route_table_association.this_region](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_route_table_association) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_account_map_environment_name"></a> [account\_map\_environment\_name](#input\_account\_map\_environment\_name) | The name of the environment where `account_map` is provisioned | `string` | `"gbl"` | no |
+| <a name="input_account_map_stage_name"></a> [account\_map\_stage\_name](#input\_account\_map\_stage\_name) | The name of the stage where `account_map` is provisioned | `string` | `"root"` | no |
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br>This is for some rare cases where resources want additional configuration of tags<br>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
 | <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br>in the order they appear in the list. New attributes are appended to the<br>end of the list. The elements of the list are joined by the `delimiter`<br>and treated as a single ID element. | `list(string)` | `[]` | no |
-| <a name="input_connections"></a> [connections](#input\_connections) | A list of objects to define each TGW connections.<br><br>By default, each connection will look for only the default `vpc` component. | <pre>list(object({<br>    account = object({<br>      stage       = string<br>      environment = optional(string, "")<br>      tenant      = optional(string, "")<br>    })<br>    vpc_component_names = optional(list(string), ["vpc"])<br>    eks_component_names = optional(list(string), [])<br>  }))</pre> | `[]` | no |
 | <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "descriptor_formats": {},<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "labels_as_tags": [<br>    "unset"<br>  ],<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {},<br>  "tenant": null<br>}</pre> | no |
 | <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between ID elements.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
 | <a name="input_descriptor_formats"></a> [descriptor\_formats](#input\_descriptor\_formats) | Describe additional descriptors to be output in the `descriptors` output map.<br>Map of maps. Keys are names of descriptors. Values are maps of the form<br>`{<br>   format = string<br>   labels = list(string)<br>}`<br>(Type is `any` so the map values can later be enhanced to provide additional options.)<br>`format` is a Terraform format string to be passed to the `format()` function.<br>`labels` is a list of labels, in order, to pass to `format()` function.<br>Label values will be normalized before being passed to `format()` so they will be<br>identical to how they appear in `id`.<br>Default is `{}` (`descriptors` output will be empty). | `any` | `{}` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
+| <a name="input_env_naming_convention"></a> [env\_naming\_convention](#input\_env\_naming\_convention) | The cloudposse/utils naming convention used to translate environment name to AWS region name. Options are `to_short` and `to_fixed` | `string` | `"to_short"` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
-| <a name="input_expose_eks_sg"></a> [expose\_eks\_sg](#input\_expose\_eks\_sg) | Set true to allow EKS clusters to accept traffic from source accounts | `bool` | `true` | no |
 | <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for keep the existing setting, which defaults to `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
 | <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | Controls the letter case of the `tags` keys (label names) for tags generated by this module.<br>Does not affect keys of tags passed in via the `tags` input.<br>Possible values: `lower`, `title`, `upper`.<br>Default value: `title`. | `string` | `null` | no |
 | <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The order in which the labels (ID elements) appear in the `id`.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present. | `list(string)` | `null` | no |
@@ -136,25 +111,24 @@ No resources.
 | <a name="input_labels_as_tags"></a> [labels\_as\_tags](#input\_labels\_as\_tags) | Set of labels (ID elements) to include as tags in the `tags` output.<br>Default is to include all labels.<br>Tags with empty values will not be included in the `tags` output.<br>Set to `[]` to suppress all generated tags.<br>**Notes:**<br>  The value of the `name` tag, if included, will be the `id`, not the `name`.<br>  Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be<br>  changed in later chained modules. Attempts to change it will be silently ignored. | `set(string)` | <pre>[<br>  "default"<br>]</pre> | no |
 | <a name="input_name"></a> [name](#input\_name) | ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.<br>This is the only ID element not also included as a `tag`.<br>The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input. | `string` | `null` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique | `string` | `null` | no |
-| <a name="input_own_eks_component_names"></a> [own\_eks\_component\_names](#input\_own\_eks\_component\_names) | The name of the eks components in the owning account. | `list(string)` | `[]` | no |
-| <a name="input_own_vpc_component_name"></a> [own\_vpc\_component\_name](#input\_own\_vpc\_component\_name) | The name of the vpc component in the owning account. Defaults to "vpc" | `string` | `"vpc"` | no |
-| <a name="input_peered_region"></a> [peered\_region](#input\_peered\_region) | Set `true` if this region is not the primary region | `bool` | `false` | no |
+| <a name="input_primary_tgw_hub_region"></a> [primary\_tgw\_hub\_region](#input\_primary\_tgw\_hub\_region) | The name of the AWS region where the primary Transit Gateway hub is deployed. This value is used with `var.env_naming_convention` to determine the primary Transit Gateway hub's environment name. | `string` | n/a | yes |
+| <a name="input_primary_tgw_hub_stage"></a> [primary\_tgw\_hub\_stage](#input\_primary\_tgw\_hub\_stage) | The name of the stage where the primary Transit Gateway hub is deployed. Defaults to `module.this.stage` | `string` | `""` | no |
+| <a name="input_primary_tgw_hub_tenant"></a> [primary\_tgw\_hub\_tenant](#input\_primary\_tgw\_hub\_tenant) | The name of the tenant where the primary Transit Gateway hub is deployed. Only used if tenants are deployed and defaults to `module.this.tenant` | `string` | `""` | no |
 | <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br>Characters matching the regex will be removed from the ID elements.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS Region | `string` | n/a | yes |
 | <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
 | <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |
-| <a name="input_tgw_hub_component_name"></a> [tgw\_hub\_component\_name](#input\_tgw\_hub\_component\_name) | The name of the transit-gateway component | `string` | `"tgw/hub"` | no |
-| <a name="input_tgw_hub_stage_name"></a> [tgw\_hub\_stage\_name](#input\_tgw\_hub\_stage\_name) | The name of the stage where `tgw/hub` is provisioned | `string` | `"network"` | no |
-| <a name="input_tgw_hub_tenant_name"></a> [tgw\_hub\_tenant\_name](#input\_tgw\_hub\_tenant\_name) | The name of the tenant where `tgw/hub` is provisioned.<br><br>If the `tenant` label is not used, leave this as `null`. | `string` | `null` | no |
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+|------|-------------|
+| <a name="output_aws_ec2_transit_gateway_peering_attachment_id"></a> [aws\_ec2\_transit\_gateway\_peering\_attachment\_id](#output\_aws\_ec2\_transit\_gateway\_peering\_attachment\_id) | Transit Gateway Peering Attachment ID |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## References
 
-- [cloudposse/terraform-aws-components](https://github.com/cloudposse/terraform-aws-components/tree/master/modules/tgw) - Cloud Posse's upstream component
+- [cloudposse/terraform-aws-components](https://github.com/cloudposse/terraform-aws-components/tree/master/modules/tgw/cross-region-hub-connector) - Cloud Posse's upstream component
 
 [<img src="https://cloudposse.com/logo-300x69.svg" height="32" align="right"/>](https://cpco.io/component)

--- a/modules/tgw/cross-region-hub-connector/context.tf
+++ b/modules/tgw/cross-region-hub-connector/context.tf
@@ -1,0 +1,279 @@
+#
+# ONLY EDIT THIS FILE IN github.com/cloudposse/terraform-null-label
+# All other instances of this file should be a copy of that one
+#
+#
+# Copy this file from https://github.com/cloudposse/terraform-null-label/blob/master/exports/context.tf
+# and then place it in your Terraform module to automatically get
+# Cloud Posse's standard configuration inputs suitable for passing
+# to Cloud Posse modules.
+#
+# curl -sL https://raw.githubusercontent.com/cloudposse/terraform-null-label/master/exports/context.tf -o context.tf
+#
+# Modules should access the whole context as `module.this.context`
+# to get the input variables with nulls for defaults,
+# for example `context = module.this.context`,
+# and access individual variables as `module.this.<var>`,
+# with final values filled in.
+#
+# For example, when using defaults, `module.this.context.delimiter`
+# will be null, and `module.this.delimiter` will be `-` (hyphen).
+#
+
+module "this" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0" # requires Terraform >= 0.13.0
+
+  enabled             = var.enabled
+  namespace           = var.namespace
+  tenant              = var.tenant
+  environment         = var.environment
+  stage               = var.stage
+  name                = var.name
+  delimiter           = var.delimiter
+  attributes          = var.attributes
+  tags                = var.tags
+  additional_tag_map  = var.additional_tag_map
+  label_order         = var.label_order
+  regex_replace_chars = var.regex_replace_chars
+  id_length_limit     = var.id_length_limit
+  label_key_case      = var.label_key_case
+  label_value_case    = var.label_value_case
+  descriptor_formats  = var.descriptor_formats
+  labels_as_tags      = var.labels_as_tags
+
+  context = var.context
+}
+
+# Copy contents of cloudposse/terraform-null-label/variables.tf here
+
+variable "context" {
+  type = any
+  default = {
+    enabled             = true
+    namespace           = null
+    tenant              = null
+    environment         = null
+    stage               = null
+    name                = null
+    delimiter           = null
+    attributes          = []
+    tags                = {}
+    additional_tag_map  = {}
+    regex_replace_chars = null
+    label_order         = []
+    id_length_limit     = null
+    label_key_case      = null
+    label_value_case    = null
+    descriptor_formats  = {}
+    # Note: we have to use [] instead of null for unset lists due to
+    # https://github.com/hashicorp/terraform/issues/28137
+    # which was not fixed until Terraform 1.0.0,
+    # but we want the default to be all the labels in `label_order`
+    # and we want users to be able to prevent all tag generation
+    # by setting `labels_as_tags` to `[]`, so we need
+    # a different sentinel to indicate "default"
+    labels_as_tags = ["unset"]
+  }
+  description = <<-EOT
+    Single object for setting entire context at once.
+    See description of individual variables for details.
+    Leave string and numeric variables as `null` to use default value.
+    Individual variable settings (non-null) override settings in context object,
+    except for attributes, tags, and additional_tag_map, which are merged.
+  EOT
+
+  validation {
+    condition     = lookup(var.context, "label_key_case", null) == null ? true : contains(["lower", "title", "upper"], var.context["label_key_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+
+  validation {
+    condition     = lookup(var.context, "label_value_case", null) == null ? true : contains(["lower", "title", "upper", "none"], var.context["label_value_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+variable "enabled" {
+  type        = bool
+  default     = null
+  description = "Set to false to prevent the module from creating any resources"
+}
+
+variable "namespace" {
+  type        = string
+  default     = null
+  description = "ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique"
+}
+
+variable "tenant" {
+  type        = string
+  default     = null
+  description = "ID element _(Rarely used, not included by default)_. A customer identifier, indicating who this instance of a resource is for"
+}
+
+variable "environment" {
+  type        = string
+  default     = null
+  description = "ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT'"
+}
+
+variable "stage" {
+  type        = string
+  default     = null
+  description = "ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release'"
+}
+
+variable "name" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.
+    This is the only ID element not also included as a `tag`.
+    The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input.
+    EOT
+}
+
+variable "delimiter" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Delimiter to be used between ID elements.
+    Defaults to `-` (hyphen). Set to `""` to use no delimiter at all.
+  EOT
+}
+
+variable "attributes" {
+  type        = list(string)
+  default     = []
+  description = <<-EOT
+    ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,
+    in the order they appear in the list. New attributes are appended to the
+    end of the list. The elements of the list are joined by the `delimiter`
+    and treated as a single ID element.
+    EOT
+}
+
+variable "labels_as_tags" {
+  type        = set(string)
+  default     = ["default"]
+  description = <<-EOT
+    Set of labels (ID elements) to include as tags in the `tags` output.
+    Default is to include all labels.
+    Tags with empty values will not be included in the `tags` output.
+    Set to `[]` to suppress all generated tags.
+    **Notes:**
+      The value of the `name` tag, if included, will be the `id`, not the `name`.
+      Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be
+      changed in later chained modules. Attempts to change it will be silently ignored.
+    EOT
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+    Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).
+    Neither the tag keys nor the tag values will be modified by this module.
+    EOT
+}
+
+variable "additional_tag_map" {
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+    Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.
+    This is for some rare cases where resources want additional configuration of tags
+    and therefore take a list of maps with tag key, value, and additional configuration.
+    EOT
+}
+
+variable "label_order" {
+  type        = list(string)
+  default     = null
+  description = <<-EOT
+    The order in which the labels (ID elements) appear in the `id`.
+    Defaults to ["namespace", "environment", "stage", "name", "attributes"].
+    You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present.
+    EOT
+}
+
+variable "regex_replace_chars" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Terraform regular expression (regex) string.
+    Characters matching the regex will be removed from the ID elements.
+    If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits.
+  EOT
+}
+
+variable "id_length_limit" {
+  type        = number
+  default     = null
+  description = <<-EOT
+    Limit `id` to this many characters (minimum 6).
+    Set to `0` for unlimited length.
+    Set to `null` for keep the existing setting, which defaults to `0`.
+    Does not affect `id_full`.
+  EOT
+  validation {
+    condition     = var.id_length_limit == null ? true : var.id_length_limit >= 6 || var.id_length_limit == 0
+    error_message = "The id_length_limit must be >= 6 if supplied (not null), or 0 for unlimited length."
+  }
+}
+
+variable "label_key_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Controls the letter case of the `tags` keys (label names) for tags generated by this module.
+    Does not affect keys of tags passed in via the `tags` input.
+    Possible values: `lower`, `title`, `upper`.
+    Default value: `title`.
+  EOT
+
+  validation {
+    condition     = var.label_key_case == null ? true : contains(["lower", "title", "upper"], var.label_key_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+}
+
+variable "label_value_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Controls the letter case of ID elements (labels) as included in `id`,
+    set as tag values, and output by this module individually.
+    Does not affect values of tags passed in via the `tags` input.
+    Possible values: `lower`, `title`, `upper` and `none` (no transformation).
+    Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.
+    Default value: `lower`.
+  EOT
+
+  validation {
+    condition     = var.label_value_case == null ? true : contains(["lower", "title", "upper", "none"], var.label_value_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+variable "descriptor_formats" {
+  type        = any
+  default     = {}
+  description = <<-EOT
+    Describe additional descriptors to be output in the `descriptors` output map.
+    Map of maps. Keys are names of descriptors. Values are maps of the form
+    `{
+       format = string
+       labels = list(string)
+    }`
+    (Type is `any` so the map values can later be enhanced to provide additional options.)
+    `format` is a Terraform format string to be passed to the `format()` function.
+    `labels` is a list of labels, in order, to pass to `format()` function.
+    Label values will be normalized before being passed to `format()` so they will be
+    identical to how they appear in `id`.
+    Default is `{}` (`descriptors` output will be empty).
+    EOT
+}
+
+#### End of copy of cloudposse/terraform-null-label/variables.tf

--- a/modules/tgw/cross-region-hub-connector/main.tf
+++ b/modules/tgw/cross-region-hub-connector/main.tf
@@ -1,0 +1,50 @@
+locals {
+  enabled = module.this.enabled
+
+  primary_tgw_hub_tenant     = length(var.primary_tgw_hub_tenant) > 0 ? var.primary_tgw_hub_tenant : module.this.tenant
+  primary_tgw_hub_stage      = length(var.primary_tgw_hub_stage) > 0 ? var.primary_tgw_hub_stage : module.this.stage
+  primary_tgw_hub_account    = module.this.tenant != null ? format("%s-%s", local.primary_tgw_hub_tenant, local.primary_tgw_hub_stage) : local.primary_tgw_hub_stage
+  primary_tgw_hub_account_id = module.account_map.outputs.full_account_map[local.primary_tgw_hub_account]
+}
+
+# Connect two Transit Gateway Hubs across regions
+resource "aws_ec2_transit_gateway_peering_attachment" "this" {
+  count = local.enabled ? 1 : 0
+
+  peer_account_id         = local.primary_tgw_hub_account_id
+  peer_region             = var.primary_tgw_hub_region
+  peer_transit_gateway_id = module.tgw_hub_primary_region.outputs.transit_gateway_id
+  transit_gateway_id      = module.tgw_hub_this_region.outputs.transit_gateway_id
+
+  tags = module.this.tags
+}
+
+# Accept the peering attachment in the primary region
+resource "aws_ec2_transit_gateway_peering_attachment_accepter" "primary_region" {
+  count = local.enabled ? 1 : 0
+
+  provider = aws.primary_tgw_hub_region
+
+  transit_gateway_attachment_id = join("", aws_ec2_transit_gateway_peering_attachment.this[*].id)
+  tags                          = module.this.tags
+}
+
+resource "aws_ec2_transit_gateway_route_table_association" "this_region" {
+  count = local.enabled ? 1 : 0
+
+  transit_gateway_attachment_id  = join("", aws_ec2_transit_gateway_peering_attachment.this[*].id)
+  transit_gateway_route_table_id = module.tgw_hub_this_region.outputs.transit_gateway_route_table_id
+
+  depends_on = [aws_ec2_transit_gateway_peering_attachment_accepter.primary_region]
+}
+
+resource "aws_ec2_transit_gateway_route_table_association" "primary_region" {
+  count = local.enabled ? 1 : 0
+
+  provider = aws.primary_tgw_hub_region
+
+  transit_gateway_attachment_id  = join("", aws_ec2_transit_gateway_peering_attachment.this[*].id)
+  transit_gateway_route_table_id = module.tgw_hub_primary_region.outputs.transit_gateway_route_table_id
+
+  depends_on = [aws_ec2_transit_gateway_peering_attachment_accepter.primary_region]
+}

--- a/modules/tgw/cross-region-hub-connector/outputs.tf
+++ b/modules/tgw/cross-region-hub-connector/outputs.tf
@@ -1,0 +1,4 @@
+output "aws_ec2_transit_gateway_peering_attachment_id" {
+  value       = join("", aws_ec2_transit_gateway_peering_attachment.this[*].id)
+  description = "Transit Gateway Peering Attachment ID"
+}

--- a/modules/tgw/cross-region-hub-connector/provider-tgw.tf
+++ b/modules/tgw/cross-region-hub-connector/provider-tgw.tf
@@ -1,0 +1,15 @@
+provider "aws" {
+  alias  = "primary_tgw_hub_region"
+  region = var.primary_tgw_hub_region
+
+  # Profile is deprecated in favor of terraform_role_arn. When profiles are not in use, terraform_profile_name is null.
+  profile = module.iam_roles.terraform_profile_name
+
+  dynamic "assume_role" {
+    # module.iam_roles.terraform_role_arn may be null, in which case do not assume a role.
+    for_each = compact([module.iam_roles.terraform_role_arn])
+    content {
+      role_arn = assume_role.value
+    }
+  }
+}

--- a/modules/tgw/cross-region-hub-connector/providers.tf
+++ b/modules/tgw/cross-region-hub-connector/providers.tf
@@ -1,0 +1,19 @@
+provider "aws" {
+  region = var.region
+
+  # Profile is deprecated in favor of terraform_role_arn. When profiles are not in use, terraform_profile_name is null.
+  profile = module.iam_roles.terraform_profile_name
+
+  dynamic "assume_role" {
+    # module.iam_roles.terraform_role_arn may be null, in which case do not assume a role.
+    for_each = compact([module.iam_roles.terraform_role_arn])
+    content {
+      role_arn = assume_role.value
+    }
+  }
+}
+
+module "iam_roles" {
+  source  = "../../account-map/modules/iam-roles"
+  context = module.this.context
+}

--- a/modules/tgw/cross-region-hub-connector/remote-state.tf
+++ b/modules/tgw/cross-region-hub-connector/remote-state.tf
@@ -1,0 +1,42 @@
+locals {
+  primary_tgw_hub_environment = module.utils.region_az_alt_code_maps[var.env_naming_convention][var.primary_tgw_hub_region]
+}
+
+# Used to translate region to environment
+module "utils" {
+  source  = "cloudposse/utils/aws"
+  version = "1.3.0"
+  enabled = local.enabled
+}
+
+module "account_map" {
+  source  = "cloudposse/stack-config/yaml//modules/remote-state"
+  version = "1.5.0"
+
+  component   = "account-map"
+  environment = var.account_map_environment_name
+  stage       = var.account_map_stage_name
+
+  context = module.this.context
+}
+
+module "tgw_hub_this_region" {
+  source  = "cloudposse/stack-config/yaml//modules/remote-state"
+  version = "1.5.0"
+
+  component = "tgw/hub"
+
+  context = module.this.context
+}
+
+module "tgw_hub_primary_region" {
+  source  = "cloudposse/stack-config/yaml//modules/remote-state"
+  version = "1.5.0"
+
+  component   = "tgw/hub"
+  stage       = local.primary_tgw_hub_stage
+  environment = local.primary_tgw_hub_environment
+  tenant      = local.primary_tgw_hub_tenant
+
+  context = module.this.context
+}

--- a/modules/tgw/cross-region-hub-connector/variables.tf
+++ b/modules/tgw/cross-region-hub-connector/variables.tf
@@ -1,0 +1,44 @@
+variable "region" {
+  type        = string
+  description = "AWS Region"
+}
+
+variable "env_naming_convention" {
+  type        = string
+  description = "The cloudposse/utils naming convention used to translate environment name to AWS region name. Options are `to_short` and `to_fixed`"
+  default     = "to_short"
+
+  validation {
+    condition     = var.env_naming_convention != "to_short" || var.env_naming_convention != "to_fixed:"
+    error_message = "`var.env_naming_convention` must be either `to_short` or `to_fixed`."
+  }
+}
+
+variable "primary_tgw_hub_tenant" {
+  type        = string
+  description = "The name of the tenant where the primary Transit Gateway hub is deployed. Only used if tenants are deployed and defaults to `module.this.tenant`"
+  default     = ""
+}
+
+variable "primary_tgw_hub_stage" {
+  type        = string
+  description = "The name of the stage where the primary Transit Gateway hub is deployed. Defaults to `module.this.stage`"
+  default     = ""
+}
+
+variable "primary_tgw_hub_region" {
+  type        = string
+  description = "The name of the AWS region where the primary Transit Gateway hub is deployed. This value is used with `var.env_naming_convention` to determine the primary Transit Gateway hub's environment name."
+}
+
+variable "account_map_environment_name" {
+  type        = string
+  description = "The name of the environment where `account_map` is provisioned"
+  default     = "gbl"
+}
+
+variable "account_map_stage_name" {
+  type        = string
+  description = "The name of the stage where `account_map` is provisioned"
+  default     = "root"
+}

--- a/modules/tgw/cross-region-hub-connector/versions.tf
+++ b/modules/tgw/cross-region-hub-connector/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.0.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.1"
+    }
+    utils = {
+      source  = "cloudposse/utils"
+      version = ">= 1.8.0"
+    }
+  }
+}

--- a/modules/tgw/hub/README.md
+++ b/modules/tgw/hub/README.md
@@ -92,12 +92,12 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_account_map"></a> [account\_map](#module\_account\_map) | cloudposse/stack-config/yaml//modules/remote-state | 1.4.1 |
-| <a name="module_eks"></a> [eks](#module\_eks) | cloudposse/stack-config/yaml//modules/remote-state | 1.4.1 |
+| <a name="module_account_map"></a> [account\_map](#module\_account\_map) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
+| <a name="module_eks"></a> [eks](#module\_eks) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../../account-map/modules/iam-roles | n/a |
-| <a name="module_tgw_hub"></a> [tgw\_hub](#module\_tgw\_hub) | cloudposse/transit-gateway/aws | 0.9.1 |
+| <a name="module_tgw_hub"></a> [tgw\_hub](#module\_tgw\_hub) | cloudposse/transit-gateway/aws | 0.11.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | cloudposse/stack-config/yaml//modules/remote-state | 1.4.1 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
 
 ## Resources
 
@@ -112,7 +112,7 @@ No resources.
 | <a name="input_account_map_tenant_name"></a> [account\_map\_tenant\_name](#input\_account\_map\_tenant\_name) | The name of the tenant where `account_map` is provisioned.<br><br>If the `tenant` label is not used, leave this as `null`. | `string` | `null` | no |
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br>This is for some rare cases where resources want additional configuration of tags<br>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
 | <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br>in the order they appear in the list. New attributes are appended to the<br>end of the list. The elements of the list are joined by the `delimiter`<br>and treated as a single ID element. | `list(string)` | `[]` | no |
-| <a name="input_connections"></a> [connections](#input\_connections) | A list of objects to define each TGW connections.<br><br>By default, each connection will look for only the default `vpc` component. | <pre>list(object({<br>    account = object({<br>      stage  = string<br>      tenant = optional(string, "")<br>    })<br>    vpc_component_names = optional(list(string), ["vpc"])<br>    eks_component_names = optional(list(string), [])<br>  }))</pre> | `[]` | no |
+| <a name="input_connections"></a> [connections](#input\_connections) | A list of objects to define each TGW connections.<br><br>By default, each connection will look for only the default `vpc` component. | <pre>list(object({<br>    account = object({<br>      stage       = string<br>      environment = optional(string, "")<br>      tenant      = optional(string, "")<br>    })<br>    vpc_component_names = optional(list(string), ["vpc"])<br>    eks_component_names = optional(list(string), [])<br>  }))</pre> | `[]` | no |
 | <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "descriptor_formats": {},<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "labels_as_tags": [<br>    "unset"<br>  ],<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {},<br>  "tenant": null<br>}</pre> | no |
 | <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between ID elements.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
 | <a name="input_descriptor_formats"></a> [descriptor\_formats](#input\_descriptor\_formats) | Describe additional descriptors to be output in the `descriptors` output map.<br>Map of maps. Keys are names of descriptors. Values are maps of the form<br>`{<br>   format = string<br>   labels = list(string)<br>}`<br>(Type is `any` so the map values can later be enhanced to provide additional options.)<br>`format` is a Terraform format string to be passed to the `format()` function.<br>`labels` is a list of labels, in order, to pass to `format()` function.<br>Label values will be normalized before being passed to `format()` so they will be<br>identical to how they appear in `id`.<br>Default is `{}` (`descriptors` output will be empty). | `any` | `{}` | no |

--- a/modules/tgw/hub/main.tf
+++ b/modules/tgw/hub/main.tf
@@ -8,7 +8,7 @@
 
 module "tgw_hub" {
   source  = "cloudposse/transit-gateway/aws"
-  version = "0.9.1"
+  version = "0.11.0"
 
   ram_resource_share_enabled = true
   route_keys_enabled         = true

--- a/modules/tgw/hub/remote-state.tf
+++ b/modules/tgw/hub/remote-state.tf
@@ -1,17 +1,19 @@
 locals {
   vpc_connections = flatten([for connection in var.connections : [
     for vpc_component_name in connection.vpc_component_names : {
-      stage     = connection.account.stage
-      tenant    = lookup(connection.account, "tenant", null)
-      component = vpc_component_name
+      stage       = connection.account.stage
+      tenant      = connection.account.tenant # Defaults to empty string if tenant isnt defined
+      environment = length(connection.account.environment) > 0 ? connection.account.environment : module.this.environment
+      component   = vpc_component_name
     }]
   ])
 
   eks_connections = flatten([for connection in var.connections : [
     for eks_component_name in connection.eks_component_names : {
-      stage     = connection.account.stage
-      tenant    = lookup(connection.account, "tenant", null)
-      component = eks_component_name
+      stage       = connection.account.stage
+      tenant      = connection.account.tenant # Defaults to empty string if tenant isnt defined
+      environment = length(connection.account.environment) > 0 ? connection.account.environment : module.this.environment
+      component   = eks_component_name
     }]
   ])
 
@@ -19,7 +21,7 @@ locals {
 
 module "account_map" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "1.4.1"
+  version = "1.5.0"
 
   component   = "account-map"
   environment = var.account_map_environment_name
@@ -31,30 +33,38 @@ module "account_map" {
 
 module "vpc" {
   for_each = { for c in local.vpc_connections :
-    (length(c.tenant) > 0 ? "${c.tenant}-${c.stage}-${c.component}" : "${c.stage}-${c.component}")
+    (length(c.tenant) > 0 ? "${c.tenant}-${c.environment}-${c.stage}-${c.component}" : "${c.environment}-${c.stage}-${c.component}")
   => c }
 
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "1.4.1"
+  version = "1.5.0"
 
-  component = each.value.component
-  stage     = each.value.stage
-  tenant    = lookup(each.value, "tenant", null)
+  component   = each.value.component
+  stage       = each.value.stage
+  environment = each.value.environment
+  tenant      = lookup(each.value, "tenant", null)
+
+  defaults = {
+    stage       = each.value.stage
+    environment = each.value.environment
+    tenant      = lookup(each.value, "tenant", null)
+  }
 
   context = module.this.context
 }
 
 module "eks" {
   for_each = { for c in local.eks_connections :
-    (length(c.tenant) > 0 ? "${c.tenant}-${c.stage}-${c.component}" : "${c.stage}-${c.component}")
+    (length(c.tenant) > 0 ? "${c.tenant}-${c.environment}-${c.stage}-${c.component}" : "${c.environment}-${c.stage}-${c.component}")
   => c }
 
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "1.4.1"
+  version = "1.5.0"
 
-  component = each.value.component
-  stage     = each.value.stage
-  tenant    = lookup(each.value, "tenant", null)
+  component   = each.value.component
+  stage       = each.value.stage
+  environment = each.value.environment
+  tenant      = lookup(each.value, "tenant", null)
 
   defaults = {
     eks_cluster_managed_security_group_id = null

--- a/modules/tgw/hub/variables.tf
+++ b/modules/tgw/hub/variables.tf
@@ -12,8 +12,9 @@ variable "expose_eks_sg" {
 variable "connections" {
   type = list(object({
     account = object({
-      stage  = string
-      tenant = optional(string, "")
+      stage       = string
+      environment = optional(string, "")
+      tenant      = optional(string, "")
     })
     vpc_component_names = optional(list(string), ["vpc"])
     eks_component_names = optional(list(string), [])

--- a/modules/tgw/spoke/main.tf
+++ b/modules/tgw/spoke/main.tf
@@ -7,7 +7,7 @@
 # https://docs.aws.amazon.com/ram/latest/userguide/getting-started-sharing.html
 
 locals {
-  spoke_account = module.this.tenant != null ? format("%s-%s", module.this.tenant, module.this.stage) : module.this.stage
+  spoke_account = module.this.tenant != null ? format("%s-%s-%s", module.this.tenant, module.this.environment, module.this.stage) : format("%s-%s", module.this.environment, module.this.stage)
 }
 
 module "tgw_hub_routes" {
@@ -42,9 +42,12 @@ module "tgw_spoke_vpc_attachment" {
   own_vpc_component_name  = var.own_vpc_component_name
   own_eks_component_names = var.own_eks_component_names
 
-  tgw_config    = module.tgw_hub.outputs.tgw_config
-  connections   = var.connections
-  expose_eks_sg = var.expose_eks_sg
+  tgw_config           = module.tgw_hub.outputs.tgw_config
+  tgw_connector_config = module.cross_region_hub_connector
+  connections          = var.connections
+  expose_eks_sg        = var.expose_eks_sg
+  peered_region        = var.peered_region
+
 
   context = module.this.context
 }

--- a/modules/tgw/spoke/modules/standard_vpc_attachment/main.tf
+++ b/modules/tgw/spoke/modules/standard_vpc_attachment/main.tf
@@ -4,6 +4,7 @@ locals {
 
   own_account_vpc_key = "${var.owning_account}-${var.own_vpc_component_name}"
   own_vpc             = local.vpcs[local.own_account_vpc_key].outputs
+  is_network_hub      = (module.this.stage == var.network_account_stage_name) ? true : false
 
   # Create a list of all VPC component keys. Key includes stack + component
   #
@@ -17,6 +18,13 @@ locals {
   #    - account:
   #        tenant: core
   #        stage: auto
+  #    - account:
+  #        tenant: plat
+  #        stage: dev
+  #    - account:
+  #        tenant: plat
+  #        stage: dev
+  #        environment: usw2
   connected_vpc_component_keys = flatten(
     [
       for c in var.connections :
@@ -25,7 +33,14 @@ locals {
         for vpc in c.vpc_component_names :
         # This component key needs to match the key created by tgw/hub
         # See components/terraform/tgw/hub/remote-state.tf
-        length(c.account.tenant) > 0 ? "${c.account.tenant}-${c.account.stage}-${vpc}" : "${c.account.stage}-${vpc}"
+        length(c.account.environment) > 0 ?
+        (length(c.account.tenant) > 0 ?
+          "${c.account.tenant}-${c.account.environment}-${c.account.stage}-${vpc}" :
+        "${c.account.environment}-${c.account.stage}-${vpc}")
+        :
+        (length(c.account.tenant) > 0 ?
+          "${c.account.tenant}-${module.this.environment}-${c.account.stage}-${vpc}" :
+        "${module.this.environment}-${c.account.stage}-${vpc}")
       ]
     ]
   )
@@ -37,7 +52,14 @@ locals {
       for c in var.connections :
       [
         for eks in c.eks_component_names :
-        length(c.account.tenant) > 0 ? "${c.account.tenant}-${c.account.stage}-${eks}" : "${c.account.stage}-${eks}"
+        length(c.account.environment) > 0 ?
+        (length(c.account.tenant) > 0 ?
+          "${c.account.tenant}-${c.account.environment}-${c.account.stage}-${eks}" :
+        "${c.account.environment}-${c.account.stage}-${eks}")
+        :
+        (length(c.account.tenant) > 0 ?
+          "${c.account.tenant}-${module.this.environment}-${c.account.stage}-${eks}" :
+        "${module.this.environment}-${c.account.stage}-${eks}")
       ]
     ]
   )
@@ -48,7 +70,9 @@ locals {
   allowed_vpcs = {
     for vpc_key, vpc_remote_state in local.vpcs :
     vpc_key => {
-      cidr = vpc_remote_state.outputs.vpc_cidr
+      cidr         = vpc_remote_state.outputs.vpc_cidr
+      cross_region = (vpc_remote_state.outputs.environment != module.this.environment)
+      environment  = vpc_remote_state.outputs.environment
     } if vpc_key != local.own_account_vpc_key && contains(local.connected_vpc_component_keys, vpc_key)
   }
 
@@ -66,13 +90,35 @@ locals {
     }
   ]...)
 
+  cross_region_vpcs = flatten([
+    for vpc_key, vpc in local.allowed_vpcs : [
+      {
+        vpc_key     = vpc_key
+        cidr        = vpc.cidr
+        environment = vpc.environment
+      }
+    ] if vpc.cross_region
+  ])
+
+  cross_region_vpc_route_table_ids = flatten([
+    for vpc_key, vpc in local.allowed_vpcs : [
+      for route_table_key, route_table_id in local.own_vpc.private_route_table_ids : [
+        {
+          vpc_key        = vpc_key
+          rt_key         = route_table_key
+          cidr           = vpc.cidr
+          route_table_id = route_table_id
+        }
+      ]
+    ] if vpc.cross_region
+  ])
 }
 
 # Create a TGW attachment from this account's VPC to the TGW Hub
 # This includes a merged list of all CIDRs from allowed VPCs in connected accounts
 module "standard_vpc_attachment" {
   source  = "cloudposse/transit-gateway/aws"
-  version = "0.9.1"
+  version = "0.11.0"
 
   existing_transit_gateway_id             = var.tgw_config.existing_transit_gateway_id
   existing_transit_gateway_route_table_id = var.tgw_config.existing_transit_gateway_route_table_id
@@ -92,11 +138,39 @@ module "standard_vpc_attachment" {
       route_to                          = null
       static_routes                     = null
       transit_gateway_vpc_attachment_id = null
-      route_to_cidr_blocks              = [for vpc in local.allowed_vpcs : vpc.cidr]
+      route_to_cidr_blocks              = [for vpc in local.allowed_vpcs : vpc.cidr if !vpc.cross_region]
     }
   }
 
   context = module.this.context
+}
+
+# Create a TGW attachment for a Peering Connection
+# This in only necessary in the hub accounts
+resource "aws_ec2_transit_gateway_route" "peering_connection" {
+  for_each = local.is_network_hub ? {
+    for vpc in local.cross_region_vpcs : vpc.cidr => vpc
+  } : {}
+
+  # Use the TGW Attachment in the alternate, peered region
+  transit_gateway_attachment_id = var.peered_region ? var.tgw_connector_config[local.own_vpc.environment].outputs.aws_ec2_transit_gateway_peering_attachment_id : var.tgw_connector_config[each.value.environment].outputs.aws_ec2_transit_gateway_peering_attachment_id
+
+  blackhole                      = false
+  destination_cidr_block         = each.value.cidr
+  transit_gateway_route_table_id = var.tgw_config.existing_transit_gateway_route_table_id
+}
+
+# Route this VPC to the destination CIDR
+# This is only necessary in cross-region connections
+resource "aws_route" "peering_connection" {
+  for_each = {
+    for vpc_rt in local.cross_region_vpc_route_table_ids : "${vpc_rt.route_table_id}:${vpc_rt.cidr}" => vpc_rt
+  }
+
+  transit_gateway_id = var.tgw_config.existing_transit_gateway_id
+
+  route_table_id         = each.value.route_table_id
+  destination_cidr_block = each.value.cidr
 }
 
 # Define a Security Group Rule to allow traffic from

--- a/modules/tgw/spoke/modules/standard_vpc_attachment/variables.tf
+++ b/modules/tgw/spoke/modules/standard_vpc_attachment/variables.tf
@@ -26,11 +26,18 @@ variable "tgw_config" {
   description = "Object to pass common data from root module to this submodule. See root module for details"
 }
 
+variable "tgw_connector_config" {
+  type        = map(any)
+  description = "Map of output from all `tgw/cross-region-hub-connector` components. See root module for details"
+  default     = {}
+}
+
 variable "connections" {
   type = list(object({
     account = object({
-      stage  = string
-      tenant = optional(string, "")
+      stage       = string
+      environment = optional(string, "")
+      tenant      = optional(string, "")
     })
     vpc_component_names = optional(list(string), ["vpc"])
     eks_component_names = optional(list(string), [])
@@ -47,4 +54,16 @@ variable "expose_eks_sg" {
   type        = bool
   description = "Set true to allow EKS clusters to accept traffic from source accounts"
   default     = true
+}
+
+variable "peered_region" {
+  type        = bool
+  description = "Set `true` if this region is not the primary region"
+  default     = false
+}
+
+variable "network_account_stage_name" {
+  type        = string
+  description = "The name of the stage designated as the network hub"
+  default     = "network"
 }

--- a/modules/tgw/spoke/provider-hub.tf
+++ b/modules/tgw/spoke/provider-hub.tf
@@ -14,34 +14,11 @@ provider "aws" {
   }
 }
 
-variable "tgw_hub_environment_name" {
-  type        = string
-  description = "The name of the environment where `tgw/gateway` is provisioned"
-  default     = "ue2"
-}
-
-variable "tgw_hub_stage_name" {
-  type        = string
-  description = "The name of the stage where `tgw/gateway` is provisioned"
-  default     = "network"
-}
-
-variable "tgw_hub_tenant_name" {
-  type        = string
-  description = <<-EOT
-  The name of the tenant where `tgw/hub` is provisioned.
-
-  If the `tenant` label is not used, leave this as `null`.
-  EOT
-  default     = null
-}
-
 module "tgw_hub_role" {
   source = "../../account-map/modules/iam-roles"
 
-  stage       = var.tgw_hub_stage_name
-  environment = var.tgw_hub_environment_name
-  tenant      = var.tgw_hub_tenant_name
+  stage  = var.tgw_hub_stage_name
+  tenant = var.tgw_hub_tenant_name
 
   context = module.this.context
 }

--- a/modules/tgw/spoke/remote-state.tf
+++ b/modules/tgw/spoke/remote-state.tf
@@ -1,11 +1,34 @@
+locals {
+  # Any cross region connection requires a TGW Hub connector deployed
+  # If any connections given are cross-region, get the `tgw/cross-region-hub-connector` component from that region
+  connected_environments = distinct(compact(concat([for c in var.connections : c.account.environment], [module.this.environment])))
+}
+
 module "tgw_hub" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "1.4.1"
+  version = "1.5.0"
 
-  component   = var.tgw_hub_component_name
-  stage       = var.tgw_hub_stage_name
-  environment = var.tgw_hub_environment_name
-  tenant      = var.tgw_hub_tenant_name
+  component = var.tgw_hub_component_name
+  tenant    = length(var.tgw_hub_tenant_name) > 0 ? var.tgw_hub_tenant_name : module.this.tenant
+  stage     = length(var.tgw_hub_stage_name) > 0 ? var.tgw_hub_stage_name : module.this.stage
+
+  context = module.this.context
+}
+
+module "cross_region_hub_connector" {
+  source  = "cloudposse/stack-config/yaml//modules/remote-state"
+  version = "1.5.0"
+
+  for_each = toset(local.connected_environments)
+
+  component   = "tgw/cross-region-hub-connector"
+  tenant      = length(var.tgw_hub_tenant_name) > 0 ? var.tgw_hub_tenant_name : module.this.tenant
+  stage       = length(var.tgw_hub_stage_name) > 0 ? var.tgw_hub_stage_name : module.this.stage
+  environment = each.value
+
+  # Ignore if hub connector doesnt exist (it doesnt exist in primary region)
+  ignore_errors = true
+  defaults      = {}
 
   context = module.this.context
 }

--- a/modules/tgw/spoke/variables.tf
+++ b/modules/tgw/spoke/variables.tf
@@ -6,8 +6,9 @@ variable "region" {
 variable "connections" {
   type = list(object({
     account = object({
-      stage  = string
-      tenant = optional(string, "")
+      stage       = string
+      environment = optional(string, "")
+      tenant      = optional(string, "")
     })
     vpc_component_names = optional(list(string), ["vpc"])
     eks_component_names = optional(list(string), [])
@@ -26,6 +27,22 @@ variable "tgw_hub_component_name" {
   default     = "tgw/hub"
 }
 
+variable "tgw_hub_stage_name" {
+  type        = string
+  description = "The name of the stage where `tgw/hub` is provisioned"
+  default     = "network"
+}
+
+variable "tgw_hub_tenant_name" {
+  type        = string
+  description = <<-EOT
+  The name of the tenant where `tgw/hub` is provisioned.
+
+  If the `tenant` label is not used, leave this as `null`.
+  EOT
+  default     = null
+}
+
 variable "expose_eks_sg" {
   type        = bool
   description = "Set true to allow EKS clusters to accept traffic from source accounts"
@@ -42,4 +59,10 @@ variable "own_eks_component_names" {
   type        = list(string)
   default     = []
   description = "The name of the eks components in the owning account."
+}
+
+variable "peered_region" {
+  type        = bool
+  description = "Set `true` if this region is not the primary region"
+  default     = false
 }


### PR DESCRIPTION
## what
- Upgraded `tgw` components to support cross region connections
- Added back `tgw/cross-region-hub-connector` with overhaul to support updated `tgw/hub` component

## why
- Deploy `tgw/cross-region-hub-connector` to create peered TGW hubs
- Use `tgw/hub` both for in region and intra region connections

## references
- n/a
