### PR TITLE
Added Enabled Parameter to aws-saml/okta-user and datadog-synthetics-private-location

### DIFF
--- a/modules/aws-saml/modules/okta-user/main.tf
+++ b/modules/aws-saml/modules/okta-user/main.tf
@@ -1,4 +1,10 @@
+locals {
+  enabled = module.this.enabled
+}
+
 resource "aws_iam_user" "default" {
+  count = local.enabled ? 1 : 0
+
   name          = module.this.id
   tags          = module.this.tags
   force_destroy = true

--- a/modules/datadog-private-location-ecs/main.tf
+++ b/modules/datadog-private-location-ecs/main.tf
@@ -17,6 +17,8 @@ module "roles_to_principals" {
 }
 
 resource "datadog_synthetics_private_location" "private_location" {
+  count = local.enabled ? 1 : 0
+
   name        = module.this.id
   description = coalesce(var.private_location_description, format("Private location for %s", module.this.id))
   tags        = module.datadog_configuration.datadog_tags


### PR DESCRIPTION
## What:

- Added `enabled` parameter for `modules/aws-saml/modules/okta-user/main.tf` and `modules/datadog-private-location-ecs/main.tf`

## Why:

- No support for disabling the creation of the resources

