### PR TITLE
[eks/cluster] Proper handling of cold start and enabled=false

### DIFF
--- a/modules/eks/cluster/README.md
+++ b/modules/eks/cluster/README.md
@@ -424,12 +424,12 @@ If the new addon requires an EKS IAM Role for Kubernetes Service Account, perfor
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_aws_ebs_csi_driver_eks_iam_role"></a> [aws\_ebs\_csi\_driver\_eks\_iam\_role](#module\_aws\_ebs\_csi\_driver\_eks\_iam\_role) | cloudposse/eks-iam-role/aws | 2.1.0 |
+| <a name="module_aws_ebs_csi_driver_eks_iam_role"></a> [aws\_ebs\_csi\_driver\_eks\_iam\_role](#module\_aws\_ebs\_csi\_driver\_eks\_iam\_role) | cloudposse/eks-iam-role/aws | 2.1.1 |
 | <a name="module_aws_ebs_csi_driver_fargate_profile"></a> [aws\_ebs\_csi\_driver\_fargate\_profile](#module\_aws\_ebs\_csi\_driver\_fargate\_profile) | cloudposse/eks-fargate-profile/aws | 1.3.0 |
-| <a name="module_aws_efs_csi_driver_eks_iam_role"></a> [aws\_efs\_csi\_driver\_eks\_iam\_role](#module\_aws\_efs\_csi\_driver\_eks\_iam\_role) | cloudposse/eks-iam-role/aws | 2.1.0 |
+| <a name="module_aws_efs_csi_driver_eks_iam_role"></a> [aws\_efs\_csi\_driver\_eks\_iam\_role](#module\_aws\_efs\_csi\_driver\_eks\_iam\_role) | cloudposse/eks-iam-role/aws | 2.1.1 |
 | <a name="module_aws_efs_csi_driver_fargate_profile"></a> [aws\_efs\_csi\_driver\_fargate\_profile](#module\_aws\_efs\_csi\_driver\_fargate\_profile) | cloudposse/eks-fargate-profile/aws | 1.3.0 |
 | <a name="module_coredns_fargate_profile"></a> [coredns\_fargate\_profile](#module\_coredns\_fargate\_profile) | cloudposse/eks-fargate-profile/aws | 1.3.0 |
-| <a name="module_eks"></a> [eks](#module\_eks) | cloudposse/stack-config/yaml//modules/remote-state | 1.4.3 |
+| <a name="module_eks"></a> [eks](#module\_eks) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
 | <a name="module_eks_cluster"></a> [eks\_cluster](#module\_eks\_cluster) | cloudposse/eks-cluster/aws | 2.9.0 |
 | <a name="module_fargate_pod_execution_role"></a> [fargate\_pod\_execution\_role](#module\_fargate\_pod\_execution\_role) | cloudposse/eks-fargate-profile/aws | 1.3.0 |
 | <a name="module_fargate_profile"></a> [fargate\_profile](#module\_fargate\_profile) | cloudposse/eks-fargate-profile/aws | 1.3.0 |
@@ -439,9 +439,9 @@ If the new addon requires an EKS IAM Role for Kubernetes Service Account, perfor
 | <a name="module_region_node_group"></a> [region\_node\_group](#module\_region\_node\_group) | ./modules/node_group_by_region | n/a |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 | <a name="module_utils"></a> [utils](#module\_utils) | cloudposse/utils/aws | 1.3.0 |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | cloudposse/stack-config/yaml//modules/remote-state | 1.4.3 |
-| <a name="module_vpc_cni_eks_iam_role"></a> [vpc\_cni\_eks\_iam\_role](#module\_vpc\_cni\_eks\_iam\_role) | cloudposse/eks-iam-role/aws | 2.1.0 |
-| <a name="module_vpc_ingress"></a> [vpc\_ingress](#module\_vpc\_ingress) | cloudposse/stack-config/yaml//modules/remote-state | 1.4.3 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
+| <a name="module_vpc_cni_eks_iam_role"></a> [vpc\_cni\_eks\_iam\_role](#module\_vpc\_cni\_eks\_iam\_role) | cloudposse/eks-iam-role/aws | 2.1.1 |
+| <a name="module_vpc_ingress"></a> [vpc\_ingress](#module\_vpc\_ingress) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
 
 ## Resources
 

--- a/modules/eks/cluster/eks-node-groups.tf
+++ b/modules/eks/cluster/eks-node-groups.tf
@@ -40,7 +40,7 @@ module "region_node_group" {
     ami_type                   = each.value.ami_type == null ? var.node_group_defaults.ami_type : each.value.ami_type
     az_abbreviation_type       = var.availability_zone_abbreviation_type
     cluster_autoscaler_enabled = each.value.cluster_autoscaler_enabled == null ? var.node_group_defaults.cluster_autoscaler_enabled : each.value.cluster_autoscaler_enabled
-    cluster_name               = module.eks_cluster.eks_cluster_id
+    cluster_name               = local.eks_cluster_id
     create_before_destroy      = each.value.create_before_destroy == null ? var.node_group_defaults.create_before_destroy : each.value.create_before_destroy
     instance_types             = each.value.instance_types == null ? var.node_group_defaults.instance_types : each.value.instance_types
     kubernetes_labels          = each.value.kubernetes_labels == null ? var.node_group_defaults.kubernetes_labels : each.value.kubernetes_labels

--- a/modules/eks/cluster/fargate-profiles.tf
+++ b/modules/eks/cluster/fargate-profiles.tf
@@ -1,6 +1,6 @@
 locals {
   fargate_profiles                        = local.enabled ? var.fargate_profiles : {}
-  fargate_cluster_pod_execution_role_name = "${module.eks_cluster.eks_cluster_id}-fargate"
+  fargate_cluster_pod_execution_role_name = "${local.eks_cluster_id}-fargate"
   fargate_cluster_pod_execution_role_needed = local.enabled && (
     local.addons_require_fargate ||
     ((length(var.fargate_profiles) > 0) && !var.legacy_fargate_1_role_per_profile_enabled)
@@ -14,7 +14,7 @@ module "fargate_pod_execution_role" {
   version = "1.3.0"
 
   subnet_ids           = local.private_subnet_ids
-  cluster_name         = module.eks_cluster.eks_cluster_id
+  cluster_name         = local.eks_cluster_id
   permissions_boundary = var.fargate_profile_iam_role_permissions_boundary
 
   fargate_profile_enabled            = false
@@ -35,7 +35,7 @@ module "fargate_profile" {
   for_each = local.fargate_profiles
 
   subnet_ids                              = local.private_subnet_ids
-  cluster_name                            = module.eks_cluster.eks_cluster_id
+  cluster_name                            = local.eks_cluster_id
   kubernetes_namespace                    = each.value.kubernetes_namespace
   kubernetes_labels                       = each.value.kubernetes_labels
   permissions_boundary                    = var.fargate_profile_iam_role_permissions_boundary

--- a/modules/eks/cluster/main.tf
+++ b/modules/eks/cluster/main.tf
@@ -105,7 +105,7 @@ locals {
   local.vpc_outputs.private_subnet_ids)
 
   # Infer the availability zones from the private subnets if var.availability_zones is empty:
-  availability_zones = length(local.availability_zones_normalized) == 0 ? keys(local.vpc_outputs.az_private_subnets_map) : local.availability_zones_normalized
+  availability_zones = local.enabled ? (length(local.availability_zones_normalized) == 0 ? keys(local.vpc_outputs.az_private_subnets_map) : local.availability_zones_normalized) : []
 }
 
 data "aws_availability_zones" "default" {
@@ -151,7 +151,7 @@ module "eks_cluster" {
 
   allowed_security_groups      = var.allowed_security_groups
   allowed_cidr_blocks          = local.allowed_cidr_blocks
-  apply_config_map_aws_auth    = var.apply_config_map_aws_auth
+  apply_config_map_aws_auth    = local.enabled && var.apply_config_map_aws_auth
   cluster_log_retention_period = var.cluster_log_retention_period
   enabled_cluster_log_types    = var.enabled_cluster_log_types
   endpoint_private_access      = var.cluster_endpoint_private_access


### PR DESCRIPTION
## what

- Proper handling of cold start and `enabled=false`

## why

- Fixes #797 
- Supersedes and closes #798 
- Cloud Posse standard requires error-free operation and no resources created when `enabled` is `false`, but previously this component had several errors

