### PR TITLE
Karpenter bugfix, EKS add-ons to mangaed node group

### DIFF
--- a/modules/eks/cluster/README.md
+++ b/modules/eks/cluster/README.md
@@ -130,6 +130,8 @@ components:
         # All Fargate Profiles will use the same IAM Role when `legacy_fargate_1_role_per_profile_enabled` is set to false.
         # Recommended for all new clusters, but will damage existing clusters provisioned with the legacy component.
         legacy_fargate_1_role_per_profile_enabled: false
+        # While it is possible to deploy add-ons to Fargate Profiles, it is not recommended. Use a managed node group instead.
+        deploy_addons_to_fargate: false
 
         # EKS addons
         # https://docs.aws.amazon.com/eks/latest/userguide/eks-add-ons.html
@@ -147,7 +149,10 @@ components:
           # https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html
           # https://github.com/kubernetes-sigs/aws-ebs-csi-driver
           aws-ebs-csi-driver:
-            addon_version: "v1.20.0-eksbuild.1"  # set `addon_version` to `null` to use the latest version          # Only install the EFS driver if you are using EFS and have already created an EFS file system.
+            addon_version: "v1.20.0-eksbuild.1"  # set `addon_version` to `null` to use the latest version
+          # Only install the EFS driver if you are using EFS.
+          # Create an EFS file system with the `efs` component.
+          # Create an EFS StorageClass with the `eks/storage-class` component.
           # https://docs.aws.amazon.com/eks/latest/userguide/efs-csi.html
           aws-efs-csi-driver:
             addon_version: "v1.5.8-eksbuild.1"
@@ -471,7 +476,7 @@ If the new addon requires an EKS IAM Role for Kubernetes Service Account, perfor
 |------|-------------|------|---------|:--------:|
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br>This is for some rare cases where resources want additional configuration of tags<br>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
 | <a name="input_addons"></a> [addons](#input\_addons) | Manages [EKS addons](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon) resources | <pre>map(object({<br>    addon_version = optional(string, null)<br>    # configuration_values is a JSON string, such as '{"computeType": "Fargate"}'.<br>    configuration_values = optional(string, null)<br>    # Set default resolve_conflicts to OVERWRITE because it is required on initial installation of<br>    # add-ons that have self-managed versions installed by default (e.g. vpc-cni, coredns), and<br>    # because any custom configuration that you would want to preserve should be managed by Terraform.<br>    resolve_conflicts        = optional(string, "OVERWRITE")<br>    service_account_role_arn = optional(string, null)<br>    create_timeout           = optional(string, null)<br>    update_timeout           = optional(string, null)<br>    delete_timeout           = optional(string, null)<br>  }))</pre> | `{}` | no |
-| <a name="input_addons_depends_on"></a> [addons\_depends\_on](#input\_addons\_depends\_on) | If set `true`, all addons will depend on managed node groups provisioned by this component and therefore not be installed until nodes are provisioned.<br>See [issue #170](https://github.com/cloudposse/terraform-aws-eks-cluster/issues/170) for more details. | `bool` | `false` | no |
+| <a name="input_addons_depends_on"></a> [addons\_depends\_on](#input\_addons\_depends\_on) | If set `true` (recommended), all addons will depend on managed node groups provisioned by this component and therefore not be installed until nodes are provisioned.<br>See [issue #170](https://github.com/cloudposse/terraform-aws-eks-cluster/issues/170) for more details. | `bool` | `true` | no |
 | <a name="input_allow_ingress_from_vpc_accounts"></a> [allow\_ingress\_from\_vpc\_accounts](#input\_allow\_ingress\_from\_vpc\_accounts) | List of account contexts to pull VPC ingress CIDR and add to cluster security group.<br><br>e.g.<br><br>{<br>  environment = "ue2",<br>  stage       = "auto",<br>  tenant      = "core"<br>} | `any` | `[]` | no |
 | <a name="input_allowed_cidr_blocks"></a> [allowed\_cidr\_blocks](#input\_allowed\_cidr\_blocks) | List of CIDR blocks to be allowed to connect to the EKS cluster | `list(string)` | `[]` | no |
 | <a name="input_allowed_security_groups"></a> [allowed\_security\_groups](#input\_allowed\_security\_groups) | List of Security Group IDs to be allowed to connect to the EKS cluster | `list(string)` | `[]` | no |
@@ -499,7 +504,7 @@ If the new addon requires an EKS IAM Role for Kubernetes Service Account, perfor
 | <a name="input_color"></a> [color](#input\_color) | The cluster stage represented by a color; e.g. blue, green | `string` | `""` | no |
 | <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "descriptor_formats": {},<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "labels_as_tags": [<br>    "unset"<br>  ],<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {},<br>  "tenant": null<br>}</pre> | no |
 | <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between ID elements.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
-| <a name="input_deploy_addons_to_fargate"></a> [deploy\_addons\_to\_fargate](#input\_deploy\_addons\_to\_fargate) | Set to `true` to deploy addons to Fargate instead of initial node pool | `bool` | `true` | no |
+| <a name="input_deploy_addons_to_fargate"></a> [deploy\_addons\_to\_fargate](#input\_deploy\_addons\_to\_fargate) | Set to `true` (not recommended) to deploy addons to Fargate instead of initial node pool | `bool` | `false` | no |
 | <a name="input_descriptor_formats"></a> [descriptor\_formats](#input\_descriptor\_formats) | Describe additional descriptors to be output in the `descriptors` output map.<br>Map of maps. Keys are names of descriptors. Values are maps of the form<br>`{<br>   format = string<br>   labels = list(string)<br>}`<br>(Type is `any` so the map values can later be enhanced to provide additional options.)<br>`format` is a Terraform format string to be passed to the `format()` function.<br>`labels` is a list of labels, in order, to pass to `format()` function.<br>Label values will be normalized before being passed to `format()` so they will be<br>identical to how they appear in `id`.<br>Default is `{}` (`descriptors` output will be empty). | `any` | `{}` | no |
 | <a name="input_eks_component_name"></a> [eks\_component\_name](#input\_eks\_component\_name) | The name of the eks component | `string` | `"eks/cluster"` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |

--- a/modules/eks/cluster/variables.tf
+++ b/modules/eks/cluster/variables.tf
@@ -355,6 +355,8 @@ variable "node_group_defaults" {
 
   default = {
     desired_group_size = 1
+    # t3.medium is kept as the default for backward compatibility.
+    # Recommendation as of 2023-08-08 is c6a.large to provide reserve HA capacity regardless of Karpenter behavoir.
     instance_types     = ["t3.medium"]
     kubernetes_version = null # set to null to use cluster_kubernetes_version
     max_group_size     = 100
@@ -544,8 +546,8 @@ variable "addons" {
 
 variable "deploy_addons_to_fargate" {
   type        = bool
-  description = "Set to `true` to deploy addons to Fargate instead of initial node pool"
-  default     = true
+  description = "Set to `true` (not recommended) to deploy addons to Fargate instead of initial node pool"
+  default     = false
   nullable    = false
 }
 
@@ -553,11 +555,11 @@ variable "addons_depends_on" {
   type = bool
 
   description = <<-EOT
-    If set `true`, all addons will depend on managed node groups provisioned by this component and therefore not be installed until nodes are provisioned.
+    If set `true` (recommended), all addons will depend on managed node groups provisioned by this component and therefore not be installed until nodes are provisioned.
     See [issue #170](https://github.com/cloudposse/terraform-aws-eks-cluster/issues/170) for more details.
     EOT
 
-  default  = false
+  default  = true
   nullable = false
 }
 

--- a/modules/eks/karpenter/main.tf
+++ b/modules/eks/karpenter/main.tf
@@ -139,7 +139,7 @@ module "karpenter" {
       settings = {
         # This configuration of settings requires Karpenter chart v0.19.0 or later
         aws = {
-          defaultInstanceProfile = one(aws_iam_instance_profile.default[*].name)
+          defaultInstanceProfile = local.karpenter_iam_role_name # instance profile name === role name
           clusterName            = local.eks_cluster_id
           # clusterEndpoint not needed as of v0.25.0
           clusterEndpoint = local.eks_cluster_endpoint


### PR DESCRIPTION
## what

- [eks/karpenter] use Instance Profile name from EKS output
- Clarify recommendation and fix defaults regarding deploying add-ons to managed node group

## why

- Bug fix: Karpenter did not work when legacy mode disabled
- Originally we expected to use Karpenter-only clusters and the documentation and defaults aligned with this. Now we recommend all Add-Ons be deployed to a managed node group, but the defaults and documentation did not reflect this.

