### PR TITLE
chore: Remove unused

### DIFF
--- a/modules/eks/cluster/main.tf
+++ b/modules/eks/cluster/main.tf
@@ -6,7 +6,6 @@ locals {
   attributes = flatten(concat(module.this.attributes, [var.color]))
 
   this_account_name     = module.iam_roles.current_account_account_name
-  identity_account_name = module.iam_roles.identity_account_account_name
 
   role_map = { (local.this_account_name) = var.aws_team_roles_rbac[*].aws_team_role }
 

--- a/modules/eks/cluster/variables.tf
+++ b/modules/eks/cluster/variables.tf
@@ -114,22 +114,6 @@ variable "map_additional_worker_roles" {
   nullable    = false
 }
 
-variable "aws_teams_rbac" {
-  type = list(object({
-    aws_team = string
-    groups   = list(string)
-  }))
-
-  description = <<-EOT
-    OBSOLETE: This feature never worked as intended, and this input is now ignored.
-    List of `aws-teams` to map to Kubernetes RBAC groups.
-    This gives teams direct access to Kubernetes without having to assume a team-role.
-    EOT
-
-  default  = []
-  nullable = false
-}
-
 variable "aws_team_roles_rbac" {
   type = list(object({
     aws_team_role = string


### PR DESCRIPTION
TFLint in components/terraform/eks/cluster/:
2 issue(s) found:

Warning: [Fixable] local.identity_account_name is declared but not used (terraform_unused_declarations)

  on main.tf line 9:
   9:   identity_account_name = module.iam_roles.identity_account_account_name

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.4.0/docs/rules/terraform_unused_declarations.md

Warning: [Fixable] variable "aws_teams_rbac" is declared but not used (terraform_unused_declarations)

  on variables.tf line 117:
 117: variable "aws_teams_rbac" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.4.0/docs/rules/terraform_unused_declarations.md

## what
* Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
* Use bullet points to be concise and to the point.

## why
* Provide the justifications for the changes (e.g. business case).
* Describe why these changes were made (e.g. why do these commits fix the problem?)
* Use bullet points to be concise and to the point.

## references
* Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow).
* Use `closes #123`, if this PR closes a GitHub issue `#123`
