### PR TITLE
Placeholder for `upgrade-guide.md`

### DIFF
--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -1,0 +1,9 @@
+# Upgrade Guide
+
+
+:::info
+
+Upgrade steps are included with any given component if required. We will be adding overarching upgrades to this file in the future,
+but those changes are in progress now (August 2023). Expect to see this page and component pages updated soon.
+
+:::


### PR DESCRIPTION
## what
- Added a placeholder file for `docs/upgrade-guide.md` with a basic explanation of what is to come

## why
- With #811 we moved the contents of this upgrade-guide file to the individual component. We plan to continue adding upgrade guides for individual components, and in addition, create a higher-level upgrade guide here
- However, the build steps for refarch-scaffold expect `docs/upgrade-guide.md` to exist and are failing without it. We need a placeholder until the `account-map`, etc changes are added to this file

## references
- Example of failing release: https://github.com/cloudposse/refarch-scaffold/actions/runs/5885022872
