### PR TITLE
Fix naming convention of overridable local variable

### DIFF
--- a/modules/eks/alb-controller/CHANGELOG.md
+++ b/modules/eks/alb-controller/CHANGELOG.md
@@ -20,5 +20,5 @@ Actually, the project releases 3 policy documents, one for each of the
 three AWS partitions: `aws`, `aws-cn`, and `aws-us-gov`. For simplicity,
 this module only uses the `aws` partition policy. If you are in another
 partition, you can create a `distributed-iam-policy_override.tf` file in your
-directory and override the `distributed_iam_policy_overridable` local
+directory and override the `overridable_distributed_iam_policy` local
 variable with the policy document for your partition.

--- a/modules/eks/alb-controller/distributed-iam-policy.tf
+++ b/modules/eks/alb-controller/distributed-iam-policy.tf
@@ -16,8 +16,8 @@ locals {
   # To update, just replace everything between the two "EOT"s with the contents of the downloaded JSON file.
   # Below is the policy as of version 2.6.0, downloaded from
   # https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.6.0/docs/install/iam_policy.json
-  # This policy is for the `aws` partition. Override distributed_iam_policy_overridable for other partitions.
-  distributed_iam_policy_overridable = <<EOT
+  # This policy is for the `aws` partition. Override overridable_distributed_iam_policy for other partitions.
+  overridable_distributed_iam_policy = <<EOT
 {
     "Version": "2012-10-17",
     "Statement": [

--- a/modules/eks/alb-controller/main.tf
+++ b/modules/eks/alb-controller/main.tf
@@ -22,7 +22,7 @@ module "alb_controller" {
 
   iam_role_enabled = true
   # See distributed-iam-policy.tf
-  iam_source_policy_documents = [local.distributed_iam_policy_overridable]
+  iam_source_policy_documents = [local.overridable_distributed_iam_policy]
 
   values = compact([
     # standard k8s object settings


### PR DESCRIPTION
## what

- Change name of local variable from `distributed_iam_policy_overridable` to `overridable_distributed_iam_policy`

## why

- Cloud Posse style guide requires `overridable` as prefix, not suffix. 