### PR TITLE
Upgrade aws-config and conformance pack modules to 1.1.0

### DIFF
--- a/modules/aws-config/README.md
+++ b/modules/aws-config/README.md
@@ -130,11 +130,11 @@ atmos terraform plan aws-config-{each region} --stack {each region}-{each stage}
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_account_map"></a> [account\_map](#module\_account\_map) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
-| <a name="module_aws_config"></a> [aws\_config](#module\_aws\_config) | cloudposse/config/aws | 0.17.0 |
+| <a name="module_aws_config"></a> [aws\_config](#module\_aws\_config) | cloudposse/config/aws | 1.1.0 |
 | <a name="module_aws_config_label"></a> [aws\_config\_label](#module\_aws\_config\_label) | cloudposse/label/null | 0.25.0 |
 | <a name="module_aws_team_roles"></a> [aws\_team\_roles](#module\_aws\_team\_roles) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
 | <a name="module_config_bucket"></a> [config\_bucket](#module\_config\_bucket) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
-| <a name="module_conformance_pack"></a> [conformance\_pack](#module\_conformance\_pack) | cloudposse/config/aws//modules/conformance-pack | 0.17.0 |
+| <a name="module_conformance_pack"></a> [conformance\_pack](#module\_conformance\_pack) | cloudposse/config/aws//modules/conformance-pack | 1.1.0 |
 | <a name="module_global_collector_region"></a> [global\_collector\_region](#module\_global\_collector\_region) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |

--- a/modules/aws-config/main.tf
+++ b/modules/aws-config/main.tf
@@ -42,7 +42,7 @@ module "utils" {
 
 module "conformance_pack" {
   source  = "cloudposse/config/aws//modules/conformance-pack"
-  version = "0.17.0"
+  version = "1.1.0"
 
   count = local.enabled ? length(var.conformance_packs) : 0
 
@@ -59,7 +59,7 @@ module "conformance_pack" {
 
 module "aws_config" {
   source  = "cloudposse/config/aws"
-  version = "0.17.0"
+  version = "1.1.0"
 
   s3_bucket_id     = local.s3_bucket.config_bucket_id
   s3_bucket_arn    = local.s3_bucket.config_bucket_arn


### PR DESCRIPTION
## what
* Upgrade aws-config and conformance pack modules to 1.1.0

## why
* They're outdated.

## references
