### PR TITLE
Aurora Optional `vpc` Component Names

### DIFF
--- a/modules/aurora-mysql/README.md
+++ b/modules/aurora-mysql/README.md
@@ -198,7 +198,7 @@ Reploying the component should show no changes. For example, `atmos terraform ap
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br>This is for some rare cases where resources want additional configuration of tags<br>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
-| <a name="input_allow_ingress_from_vpc_accounts"></a> [allow\_ingress\_from\_vpc\_accounts](#input\_allow\_ingress\_from\_vpc\_accounts) | List of account contexts to pull VPC ingress CIDR and add to cluster security group.<br><br>e.g.<br><br>{<br>  environment = "ue2",<br>  stage       = "auto",<br>  tenant      = "core"<br>} | `any` | `[]` | no |
+| <a name="input_allow_ingress_from_vpc_accounts"></a> [allow\_ingress\_from\_vpc\_accounts](#input\_allow\_ingress\_from\_vpc\_accounts) | List of account contexts to pull VPC ingress CIDR and add to cluster security group.<br><br>e.g.<br>{<br>  environment = "ue2",<br>  stage       = "auto",<br>  tenant      = "core"<br>}<br><br>Defaults to the "vpc" component in the given account | <pre>list(object({<br>    vpc         = optional(string)<br>    environment = optional(string)<br>    stage       = optional(string)<br>    tenant      = optional(string)<br>  }))</pre> | `[]` | no |
 | <a name="input_allowed_cidr_blocks"></a> [allowed\_cidr\_blocks](#input\_allowed\_cidr\_blocks) | List of CIDR blocks to be allowed to connect to the RDS cluster | `list(string)` | `[]` | no |
 | <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br>in the order they appear in the list. New attributes are appended to the<br>end of the list. The elements of the list are joined by the `delimiter`<br>and treated as a single ID element. | `list(string)` | `[]` | no |
 | <a name="input_aurora_mysql_cluster_family"></a> [aurora\_mysql\_cluster\_family](#input\_aurora\_mysql\_cluster\_family) | DBParameterGroupFamily (e.g. `aurora5.6`, `aurora-mysql5.7` for Aurora MySQL databases). See https://stackoverflow.com/a/55819394 for help finding the right one to use. | `string` | n/a | yes |
@@ -247,6 +247,7 @@ Reploying the component should show no changes. For example, `atmos terraform ap
 | <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
 | <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |
+| <a name="input_vpc_component_name"></a> [vpc\_component\_name](#input\_vpc\_component\_name) | The name of the VPC component | `string` | `"vpc"` | no |
 
 ## Outputs
 

--- a/modules/aurora-mysql/remote-state.tf
+++ b/modules/aurora-mysql/remote-state.tf
@@ -27,7 +27,7 @@ module "vpc" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
   version = "1.5.0"
 
-  component = "vpc"
+  component = var.vpc_component_name
 
   context = module.this.context
 }
@@ -38,7 +38,7 @@ module "vpc_ingress" {
 
   for_each = local.accounts_with_vpc
 
-  component   = "vpc"
+  component   = try(each.value.vpc, "vpc")
   environment = try(each.value.environment, module.this.environment)
   stage       = try(each.value.stage, module.this.environment)
   tenant      = try(each.value.tenant, module.this.tenant)

--- a/modules/aurora-mysql/variables.tf
+++ b/modules/aurora-mysql/variables.tf
@@ -199,17 +199,29 @@ variable "primary_cluster_component" {
 }
 
 variable "allow_ingress_from_vpc_accounts" {
-  type        = any
+  type = list(object({
+    vpc         = optional(string)
+    environment = optional(string)
+    stage       = optional(string)
+    tenant      = optional(string)
+  }))
   default     = []
   description = <<-EOF
     List of account contexts to pull VPC ingress CIDR and add to cluster security group.
 
     e.g.
-
     {
       environment = "ue2",
       stage       = "auto",
       tenant      = "core"
     }
+
+    Defaults to the "vpc" component in the given account
   EOF
+}
+
+variable "vpc_component_name" {
+  type        = string
+  default     = "vpc"
+  description = "The name of the VPC component"
 }

--- a/modules/aurora-postgres/README.md
+++ b/modules/aurora-postgres/README.md
@@ -132,7 +132,7 @@ components:
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br>This is for some rare cases where resources want additional configuration of tags<br>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
 | <a name="input_admin_password"></a> [admin\_password](#input\_admin\_password) | Postgres password for the admin user | `string` | `""` | no |
 | <a name="input_admin_user"></a> [admin\_user](#input\_admin\_user) | Postgres admin user name | `string` | `""` | no |
-| <a name="input_allow_ingress_from_vpc_accounts"></a> [allow\_ingress\_from\_vpc\_accounts](#input\_allow\_ingress\_from\_vpc\_accounts) | List of account contexts to pull VPC ingress CIDR and add to cluster security group.<br>e.g.<br>{<br>  environment = "ue2",<br>  stage       = "auto",<br>  tenant      = "core"<br>} | <pre>list(object({<br>    environment = optional(string)<br>    stage       = optional(string)<br>    tenant      = optional(string)<br>  }))</pre> | `[]` | no |
+| <a name="input_allow_ingress_from_vpc_accounts"></a> [allow\_ingress\_from\_vpc\_accounts](#input\_allow\_ingress\_from\_vpc\_accounts) | List of account contexts to pull VPC ingress CIDR and add to cluster security group.<br>e.g.<br>{<br>  environment = "ue2",<br>  stage       = "auto",<br>  tenant      = "core"<br>}<br><br>Defaults to the "vpc" component in the given account | <pre>list(object({<br>    vpc         = optional(string)<br>    environment = optional(string)<br>    stage       = optional(string)<br>    tenant      = optional(string)<br>  }))</pre> | `[]` | no |
 | <a name="input_allowed_cidr_blocks"></a> [allowed\_cidr\_blocks](#input\_allowed\_cidr\_blocks) | List of CIDRs allowed to access the database (in addition to security groups and subnets) | `list(string)` | `[]` | no |
 | <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br>in the order they appear in the list. New attributes are appended to the<br>end of the list. The elements of the list are joined by the `delimiter`<br>and treated as a single ID element. | `list(string)` | `[]` | no |
 | <a name="input_autoscaling_enabled"></a> [autoscaling\_enabled](#input\_autoscaling\_enabled) | Whether to enable cluster autoscaling | `bool` | `false` | no |
@@ -189,6 +189,7 @@ components:
 | <a name="input_storage_encrypted"></a> [storage\_encrypted](#input\_storage\_encrypted) | Specifies whether the DB cluster is encrypted | `bool` | `true` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
 | <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |
+| <a name="input_vpc_component_name"></a> [vpc\_component\_name](#input\_vpc\_component\_name) | The name of the VPC component | `string` | `"vpc"` | no |
 
 ## Outputs
 

--- a/modules/aurora-postgres/remote-state.tf
+++ b/modules/aurora-postgres/remote-state.tf
@@ -2,7 +2,7 @@ module "vpc" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
   version = "1.5.0"
 
-  component = "vpc"
+  component = var.vpc_component_name
 
   context = module.cluster.context
 }
@@ -17,7 +17,7 @@ module "vpc_ingress" {
     format("%s-%s", account.tenant, account.stage) : account.stage => account
   }
 
-  component   = "vpc"
+  component   = try(each.value.vpc, "vpc")
   tenant      = try(each.value.tenant, module.this.tenant)
   environment = try(each.value.environment, module.this.environment)
   stage       = try(each.value.stage, module.this.stage)

--- a/modules/aurora-postgres/variables.tf
+++ b/modules/aurora-postgres/variables.tf
@@ -274,6 +274,7 @@ variable "eks_component_names" {
 
 variable "allow_ingress_from_vpc_accounts" {
   type = list(object({
+    vpc         = optional(string)
     environment = optional(string)
     stage       = optional(string)
     tenant      = optional(string)
@@ -287,6 +288,8 @@ variable "allow_ingress_from_vpc_accounts" {
       stage       = "auto",
       tenant      = "core"
     }
+
+    Defaults to the "vpc" component in the given account
   EOF
 }
 
@@ -298,4 +301,10 @@ variable "ssm_password_source" {
     `var.ssm_password_source` and the database username. If this value is not set,
     a default path will be created using the SSM path prefix and ID of the associated Aurora Cluster.
     EOT
+}
+
+variable "vpc_component_name" {
+  type        = string
+  default     = "vpc"
+  description = "The name of the VPC component"
 }


### PR DESCRIPTION
## what
- Allow optional VPC component names in the aurora components

## why
- Support deploying the clusters for other VPC components than `"vpc"`

## references
- n/a
