### PR TITLE
TGW FAQ and Spoke Alternate VPC Support

### DIFF
--- a/modules/tgw/README.md
+++ b/modules/tgw/README.md
@@ -341,6 +341,12 @@ tgw/spoke:
           environment: usw2
 ```
 
+## Destruction
+
+When destroying Transit Gateway components, order of operations matters. Always destroy any removed `tgw/spoke` components before removing a connection from the `tgw/hub` component.
+
+The `tgw/hub` component creates map of VPC resources that each `tgw/spoke` component references. If the required reference is removed before the `tgw/spoke` is destroyed, Terraform will fail to destroy the given `tgw/spoke` component.
+
 # FAQ
 
 ## `tgw/spoke` Fails to Recreate VPC Attachment with `DuplicateTransitGatewayAttachment` Error

--- a/modules/tgw/README.md
+++ b/modules/tgw/README.md
@@ -340,3 +340,23 @@ tgw/spoke:
           stage: prod
           environment: usw2
 ```
+
+# FAQ
+
+## `tgw/spoke` Fails to Recreate VPC Attachment with `DuplicateTransitGatewayAttachment` Error
+
+```bash
+╷
+│ Error: creating EC2 Transit Gateway VPC Attachment: DuplicateTransitGatewayAttachment: tgw-0xxxxxxxxxxxxxxxx has non-deleted Transit Gateway Attachments with same VPC ID.
+│ 	status code: 400, request id: aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee
+│
+│   with module.tgw_spoke_vpc_attachment.module.standard_vpc_attachment.aws_ec2_transit_gateway_vpc_attachment.default["core-use2-network"],
+│   on .terraform/modules/tgw_spoke_vpc_attachment.standard_vpc_attachment/main.tf line 43, in resource "aws_ec2_transit_gateway_vpc_attachment" "default":
+│   43: resource "aws_ec2_transit_gateway_vpc_attachment" "default" {
+│
+╵
+Releasing state lock. This may take a few moments...
+exit status 1
+```
+
+This is caused by Terraform attempting to create the replacement VPC attachment before the original is completed destroyed. Simply retry the apply. Now you should see only "create" actions.

--- a/modules/tgw/README.md
+++ b/modules/tgw/README.md
@@ -359,4 +359,4 @@ Releasing state lock. This may take a few moments...
 exit status 1
 ```
 
-This is caused by Terraform attempting to create the replacement VPC attachment before the original is completed destroyed. Simply retry the apply. Now you should see only "create" actions.
+This is caused by Terraform attempting to create the replacement VPC attachment before the original is completely destroyed. Retry the apply. Now you should see only "create" actions.

--- a/modules/tgw/README.md
+++ b/modules/tgw/README.md
@@ -347,6 +347,34 @@ When destroying Transit Gateway components, order of operations matters. Always 
 
 The `tgw/hub` component creates map of VPC resources that each `tgw/spoke` component references. If the required reference is removed before the `tgw/spoke` is destroyed, Terraform will fail to destroy the given `tgw/spoke` component.
 
+:::info Pro Tip!
+
+[Atmos Workflows](https://atmos.tools/core-concepts/workflows/) make applying and destroying Transit Gateway much easier! For example, to destroy components in the correct order, use a workflow similiar to the following:
+
+```yaml
+# stacks/workflows/network.yaml
+workflows:
+  destroy/tgw:
+    description: Destroy the Transit Gateway "hub" and "spokes" for connecting VPCs.
+    steps:
+      - command: echo 'Destroying platform spokes for Transit Gateway'
+        type: shell
+        name: plat-spokes
+      - command: terraform destroy tgw/spoke -s plat-use1-sandbox --auto-approve
+      - command: terraform destroy tgw/spoke -s plat-use1-dev --auto-approve
+      - command: terraform destroy tgw/spoke -s plat-use1-staging --auto-approve
+      - command: terraform destroy tgw/spoke -s plat-use1-prod --auto-approve
+      - command: echo 'Destroying core spokes for Transit Gateway'
+        type: shell
+        name: core-spokes
+      - command: terraform destroy tgw/spoke -s core-use1-auto --auto-approve
+      - command: terraform destroy tgw/spoke -s core-use1-network --auto-approve
+      - command: terraform destroy tgw/hub -s core-use1-network --auto-approve
+        name: hub
+```
+
+:::
+
 # FAQ
 
 ## `tgw/spoke` Fails to Recreate VPC Attachment with `DuplicateTransitGatewayAttachment` Error

--- a/modules/tgw/README.md
+++ b/modules/tgw/README.md
@@ -370,8 +370,8 @@ workflows:
       - command: terraform destroy tgw/spoke -s core-use1-auto --auto-approve
       - command: terraform destroy tgw/spoke -s core-use1-network --auto-approve
       - command: echo 'Destroying Transit Gateway Hub'
-         type: shell
-         name: hub
+        type: shell
+        name: hub
       - command: terraform destroy tgw/hub -s core-use1-network --auto-approve
 ```
 

--- a/modules/tgw/README.md
+++ b/modules/tgw/README.md
@@ -369,8 +369,10 @@ workflows:
         name: core-spokes
       - command: terraform destroy tgw/spoke -s core-use1-auto --auto-approve
       - command: terraform destroy tgw/spoke -s core-use1-network --auto-approve
+      - command: echo 'Destroying Transit Gateway Hub'
+         type: shell
+         name: hub
       - command: terraform destroy tgw/hub -s core-use1-network --auto-approve
-        name: hub
 ```
 
 :::

--- a/modules/tgw/spoke/README.md
+++ b/modules/tgw/spoke/README.md
@@ -139,6 +139,7 @@ No resources.
 | <a name="input_own_eks_component_names"></a> [own\_eks\_component\_names](#input\_own\_eks\_component\_names) | The name of the eks components in the owning account. | `list(string)` | `[]` | no |
 | <a name="input_own_vpc_component_name"></a> [own\_vpc\_component\_name](#input\_own\_vpc\_component\_name) | The name of the vpc component in the owning account. Defaults to "vpc" | `string` | `"vpc"` | no |
 | <a name="input_peered_region"></a> [peered\_region](#input\_peered\_region) | Set `true` if this region is not the primary region | `bool` | `false` | no |
+| <a name="input_primary_vpc"></a> [primary\_vpc](#input\_primary\_vpc) | Set `false` if this region is not the primary VPC in this region | `bool` | `true` | no |
 | <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br>Characters matching the regex will be removed from the ID elements.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS Region | `string` | n/a | yes |
 | <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |

--- a/modules/tgw/spoke/main.tf
+++ b/modules/tgw/spoke/main.tf
@@ -21,10 +21,13 @@ module "tgw_hub_routes" {
   ram_resource_share_enabled = false
   route_keys_enabled         = false
 
-  create_transit_gateway                                         = false
-  create_transit_gateway_route_table                             = false
-  create_transit_gateway_vpc_attachment                          = false
-  create_transit_gateway_route_table_association_and_propagation = true
+  create_transit_gateway                = false
+  create_transit_gateway_route_table    = false
+  create_transit_gateway_vpc_attachment = false
+
+  # Only create transit gateway route table association and propogation
+  # if this is the primary VPC in this given region
+  create_transit_gateway_route_table_association_and_propagation = var.primary_vpc
 
   config = {
     (local.spoke_account) = module.tgw_spoke_vpc_attachment.tg_config,

--- a/modules/tgw/spoke/variables.tf
+++ b/modules/tgw/spoke/variables.tf
@@ -66,3 +66,9 @@ variable "peered_region" {
   description = "Set `true` if this region is not the primary region"
   default     = false
 }
+
+variable "primary_vpc" {
+  type        = bool
+  description = "Set `false` if this region is not the primary VPC in this region"
+  default     = true
+}


### PR DESCRIPTION
## what
- Added FAQ to the TGW upgrade guide for replacing attachments
- Added note about destroying TGW components
- Added option to not create TGW propagation and association when connecting an alternate VPC

## why
- When connecting an alternate VPC in the same region as the primary VPC, we do not want to create a duplicate TGW propagation and association

## references
- n/a
