### PR TITLE
Aurora Upstream: Serverless, Tags, Enabled: False

### DIFF
--- a/modules/aurora-mysql-resources/provider-mysql.tf
+++ b/modules/aurora-mysql-resources/provider-mysql.tf
@@ -9,11 +9,11 @@ locals {
 
   mysql_admin_user         = module.aurora_mysql.outputs.aurora_mysql_master_username
   mysql_admin_password_key = module.aurora_mysql.outputs.aurora_mysql_master_password_ssm_key
-  mysql_admin_password     = length(var.mysql_admin_password) > 0 ? var.mysql_admin_password : data.aws_ssm_parameter.admin_password[0].value
+  mysql_admin_password     = local.enabled ? (length(var.mysql_admin_password) > 0 ? var.mysql_admin_password : data.aws_ssm_parameter.mysql_admin_password[0].value) : ""
 }
 
 data "aws_ssm_parameter" "admin_password" {
-  count = length(var.mysql_admin_password) > 0 ? 0 : 1
+  count = local.enabled && !(length(var.mysql_admin_password) > 0) ? 1 : 0
 
   name = local.mysql_admin_password_key
 

--- a/modules/aurora-mysql/ssm.tf
+++ b/modules/aurora-mysql/ssm.tf
@@ -27,13 +27,6 @@ locals {
       overwrite   = true
     },
     {
-      name        = format("%s/%s", local.ssm_path_prefix, "replicas_hostname")
-      value       = module.aurora_mysql.replicas_host
-      description = "Aurora MySQL DB Replicas hostname"
-      type        = "String"
-      overwrite   = true
-    },
-    {
       name        = format("%s/%s", local.ssm_path_prefix, "cluster_name")
       value       = module.aurora_mysql.cluster_identifier
       description = "Aurora MySQL DB Cluster Identifier"
@@ -41,6 +34,15 @@ locals {
       overwrite   = true
     }
   ]
+  cluster_parameters = var.cluster_size > 0 ? [
+    {
+      name        = format("%s/%s", local.ssm_path_prefix, "replicas_hostname")
+      value       = module.aurora_mysql.replicas_host
+      description = "Aurora MySQL DB Replicas hostname"
+      type        = "String"
+      overwrite   = true
+    },
+  ] : []
   admin_user_parameters = [
     {
       name        = local.mysql_admin_user_key
@@ -58,7 +60,7 @@ locals {
     }
   ]
 
-  parameter_write = local.mysql_db_enabled ? concat(local.default_parameters, local.admin_user_parameters) : local.default_parameters
+  parameter_write = local.mysql_db_enabled ? concat(local.default_parameters, local.cluster_parameters, local.admin_user_parameters) : concat(local.default_parameters, local.cluster_parameters)
 }
 
 data "aws_ssm_parameter" "password" {
@@ -78,5 +80,5 @@ module "parameter_store_write" {
 
   parameter_write = local.parameter_write
 
-  context = module.this.context
+  context = module.cluster.context
 }

--- a/modules/aurora-postgres-resources/provider-postgres.tf
+++ b/modules/aurora-postgres-resources/provider-postgres.tf
@@ -3,11 +3,11 @@ locals {
   admin_user         = module.aurora_postgres.outputs.config_map.username
   admin_password_key = module.aurora_postgres.outputs.config_map.password_ssm_key
 
-  admin_password = length(var.admin_password) > 0 ? var.admin_password : data.aws_ssm_parameter.admin_password[0].value
+  admin_password = local.enabled ? (length(var.admin_password) > 0 ? var.admin_password : data.aws_ssm_parameter.admin_password[0].value) : ""
 }
 
 data "aws_ssm_parameter" "admin_password" {
-  count = length(var.admin_password) > 0 ? 0 : 1
+  count = local.enabled && !(length(var.admin_password) > 0) ? 1 : 0
 
   name = local.admin_password_key
 

--- a/modules/aurora-postgres/ssm.tf
+++ b/modules/aurora-postgres/ssm.tf
@@ -31,13 +31,6 @@ locals {
       overwrite   = true
     },
     {
-      name        = format("%s/%s", local.ssm_path_prefix, "replicas_hostname")
-      value       = module.aurora_postgres_cluster.replicas_host
-      description = "Aurora Postgres DB Replicas hostname"
-      type        = "String"
-      overwrite   = true
-    },
-    {
       name        = format("%s/%s", local.ssm_path_prefix, "cluster_name")
       value       = module.aurora_postgres_cluster.cluster_identifier
       description = "Aurora Postgres DB Cluster Identifier"
@@ -45,6 +38,15 @@ locals {
       overwrite   = true
     }
   ]
+  cluster_parameters = var.cluster_size > 0 ? [
+    {
+      name        = format("%s/%s", local.ssm_path_prefix, "replicas_hostname")
+      value       = module.aurora_postgres_cluster.replicas_host
+      description = "Aurora Postgres DB Replicas hostname"
+      type        = "String"
+      overwrite   = true
+    },
+  ] : []
   admin_user_parameters = [
     {
       name        = local.admin_user_key
@@ -62,7 +64,7 @@ locals {
     }
   ]
 
-  parameter_write = concat(local.default_parameters, local.admin_user_parameters)
+  parameter_write = concat(local.default_parameters, local.cluster_parameters, local.admin_user_parameters)
 }
 
 data "aws_ssm_parameter" "password" {
@@ -82,5 +84,5 @@ module "parameter_store_write" {
 
   parameter_write = local.parameter_write
 
-  context = module.this.context
+  context = module.cluster.context
 }


### PR DESCRIPTION
## what
- Set `module.context` to `module.cluster` across all resources
- Only set parameter for replica if cluster size is > 0
- `enabled: false` support

## why
- Missing tags for SSM parameters for cluster attributes
- Serverless clusters set `cluster_size: 0`, which will break the SSM parameter for replica hostname (since it does not exist)
- Support enabled false for `aurora-*-resources` components

## references
- n/a