### PR TITLE
Updated bucket-policy

### DIFF
--- a/modules/datadog-logs-archive/main.tf
+++ b/modules/datadog-logs-archive/main.tf
@@ -138,7 +138,7 @@ data "aws_iam_policy_document" "default" {
 
 module "bucket_policy" {
   source  = "cloudposse/iam-policy/aws"
-  version = "0.3.0"
+  version = "v1.0.1"
 
   iam_policy_statements = try(lookup(local.policy, "Statement"), null)
 


### PR DESCRIPTION
Fixes issue with outdated bucket-policy module.



## what
- upgraded the bucket-policy

`atmos terraform plan datadog-logs-archive -s core-gbl-auto` throws an error due to outdated bucket-policy module. 

<img width="1079" alt="CleanShot 2023-08-28 at 20 16 26@2x" src="https://github.com/cloudposse/terraform-aws-components/assets/383052/49ed98b6-9e05-4a08-a08e-487ef2a55975">


## why
- When using datadog-logs-archive module, which inturn uses bucket-policy module version 0.3.0 - getting  `An argument named "source_json" is not expected here.`
- fixes the outdated version of https://github.com/cloudposse/terraform-aws-iam-policy/releases

## references

- https://github.com/cloudposse/terraform-aws-iam-policy/releases
- https://github.com/cloudposse/terraform-aws-components/blob/main/modules/datadog-logs-archive/main.tf#L141