### PR TITLE
Update helm-release to v0.10.0

### DIFF
--- a/modules/datadog-synthetics-private-location/README.md
+++ b/modules/datadog-synthetics-private-location/README.md
@@ -146,7 +146,7 @@ Environment variables:
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_datadog_configuration"></a> [datadog\_configuration](#module\_datadog\_configuration) | ../datadog-configuration/modules/datadog_keys | n/a |
-| <a name="module_datadog_synthetics_private_location"></a> [datadog\_synthetics\_private\_location](#module\_datadog\_synthetics\_private\_location) | cloudposse/helm-release/aws | 0.9.3 |
+| <a name="module_datadog_synthetics_private_location"></a> [datadog\_synthetics\_private\_location](#module\_datadog\_synthetics\_private\_location) | cloudposse/helm-release/aws | 0.10.0 |
 | <a name="module_eks"></a> [eks](#module\_eks) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |

--- a/modules/datadog-synthetics-private-location/main.tf
+++ b/modules/datadog-synthetics-private-location/main.tf
@@ -16,7 +16,7 @@ resource "datadog_synthetics_private_location" "this" {
 
 module "datadog_synthetics_private_location" {
   source  = "cloudposse/helm-release/aws"
-  version = "0.9.3"
+  version = "0.10.0"
 
   name          = module.this.name
   chart         = var.chart

--- a/modules/eks/actions-runner-controller/README.md
+++ b/modules/eks/actions-runner-controller/README.md
@@ -414,8 +414,8 @@ Consult [actions-runner-controller](https://github.com/actions-runner-controller
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_actions_runner"></a> [actions\_runner](#module\_actions\_runner) | cloudposse/helm-release/aws | 0.9.1 |
-| <a name="module_actions_runner_controller"></a> [actions\_runner\_controller](#module\_actions\_runner\_controller) | cloudposse/helm-release/aws | 0.9.1 |
+| <a name="module_actions_runner"></a> [actions\_runner](#module\_actions\_runner) | cloudposse/helm-release/aws | 0.10.0 |
+| <a name="module_actions_runner_controller"></a> [actions\_runner\_controller](#module\_actions\_runner\_controller) | cloudposse/helm-release/aws | 0.10.0 |
 | <a name="module_eks"></a> [eks](#module\_eks) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../../account-map/modules/iam-roles | n/a |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |

--- a/modules/eks/actions-runner-controller/main.tf
+++ b/modules/eks/actions-runner-controller/main.tf
@@ -110,7 +110,7 @@ data "aws_ssm_parameter" "docker_config_json" {
 
 module "actions_runner_controller" {
   source  = "cloudposse/helm-release/aws"
-  version = "0.9.1"
+  version = "0.10.0"
 
   name            = "" # avoids hitting length restrictions on IAM Role names
   chart           = var.chart
@@ -200,7 +200,7 @@ module "actions_runner" {
   for_each = local.enabled ? var.runners : {}
 
   source  = "cloudposse/helm-release/aws"
-  version = "0.9.1"
+  version = "0.10.0"
 
   name  = each.key
   chart = "${path.module}/charts/actions-runner"

--- a/modules/eks/alb-controller/README.md
+++ b/modules/eks/alb-controller/README.md
@@ -77,7 +77,7 @@ components:
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_alb_controller"></a> [alb\_controller](#module\_alb\_controller) | cloudposse/helm-release/aws | 0.9.3 |
+| <a name="module_alb_controller"></a> [alb\_controller](#module\_alb\_controller) | cloudposse/helm-release/aws | 0.10.0 |
 | <a name="module_eks"></a> [eks](#module\_eks) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../../account-map/modules/iam-roles | n/a |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |

--- a/modules/eks/alb-controller/main.tf
+++ b/modules/eks/alb-controller/main.tf
@@ -1,6 +1,6 @@
 module "alb_controller" {
   source  = "cloudposse/helm-release/aws"
-  version = "0.9.3"
+  version = "0.10.0"
 
   chart           = var.chart
   repository      = var.chart_repository

--- a/modules/eks/argocd/README.md
+++ b/modules/eks/argocd/README.md
@@ -393,8 +393,8 @@ components:
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_argocd"></a> [argocd](#module\_argocd) | cloudposse/helm-release/aws | 0.11.0 |
-| <a name="module_argocd_apps"></a> [argocd\_apps](#module\_argocd\_apps) | cloudposse/helm-release/aws | 0.9.1 |
+| <a name="module_argocd"></a> [argocd](#module\_argocd) | cloudposse/helm-release/aws | 0.10.0 |
+| <a name="module_argocd_apps"></a> [argocd\_apps](#module\_argocd\_apps) | cloudposse/helm-release/aws | 0.10.0 |
 | <a name="module_argocd_repo"></a> [argocd\_repo](#module\_argocd\_repo) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
 | <a name="module_dns_gbl_delegated"></a> [dns\_gbl\_delegated](#module\_dns\_gbl\_delegated) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
 | <a name="module_eks"></a> [eks](#module\_eks) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |

--- a/modules/eks/argocd/main.tf
+++ b/modules/eks/argocd/main.tf
@@ -139,7 +139,7 @@ locals {
 
 module "argocd" {
   source  = "cloudposse/helm-release/aws"
-  version = "0.11.0"
+  version = "0.10.0"
 
   name                   = "argocd" # avoids hitting length restrictions on IAM Role names
   chart                  = var.chart
@@ -253,7 +253,7 @@ data "kubernetes_resources" "crd" {
 
 module "argocd_apps" {
   source  = "cloudposse/helm-release/aws"
-  version = "0.9.1"
+  version = "0.10.0"
 
   name                        = "" # avoids hitting length restrictions on IAM Role names
   chart                       = var.argocd_apps_chart

--- a/modules/eks/aws-node-termination-handler/README.md
+++ b/modules/eks/aws-node-termination-handler/README.md
@@ -59,7 +59,7 @@ components:
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_aws_node_termination_handler"></a> [aws\_node\_termination\_handler](#module\_aws\_node\_termination\_handler) | cloudposse/helm-release/aws | 0.9.1 |
+| <a name="module_aws_node_termination_handler"></a> [aws\_node\_termination\_handler](#module\_aws\_node\_termination\_handler) | cloudposse/helm-release/aws | 0.10.0 |
 | <a name="module_eks"></a> [eks](#module\_eks) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../../account-map/modules/iam-roles | n/a |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |

--- a/modules/eks/aws-node-termination-handler/main.tf
+++ b/modules/eks/aws-node-termination-handler/main.tf
@@ -14,7 +14,7 @@ resource "kubernetes_namespace" "default" {
 
 module "aws_node_termination_handler" {
   source  = "cloudposse/helm-release/aws"
-  version = "0.9.1"
+  version = "0.10.0"
 
   name                 = "" # avoids hitting length restrictions on IAM Role names
   chart                = var.chart

--- a/modules/eks/cert-manager/README.md
+++ b/modules/eks/cert-manager/README.md
@@ -69,8 +69,8 @@ The default catalog values `e.g. stacks/catalog/eks/cert-manager.yaml`
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_cert_manager"></a> [cert\_manager](#module\_cert\_manager) | cloudposse/helm-release/aws | 0.9.1 |
-| <a name="module_cert_manager_issuer"></a> [cert\_manager\_issuer](#module\_cert\_manager\_issuer) | cloudposse/helm-release/aws | 0.9.1 |
+| <a name="module_cert_manager"></a> [cert\_manager](#module\_cert\_manager) | cloudposse/helm-release/aws | 0.10.0 |
+| <a name="module_cert_manager_issuer"></a> [cert\_manager\_issuer](#module\_cert\_manager\_issuer) | cloudposse/helm-release/aws | 0.10.0 |
 | <a name="module_dns_gbl_delegated"></a> [dns\_gbl\_delegated](#module\_dns\_gbl\_delegated) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
 | <a name="module_eks"></a> [eks](#module\_eks) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../../account-map/modules/iam-roles | n/a |

--- a/modules/eks/cert-manager/main.tf
+++ b/modules/eks/cert-manager/main.tf
@@ -9,7 +9,7 @@ data "aws_partition" "current" {
 
 module "cert_manager" {
   source  = "cloudposse/helm-release/aws"
-  version = "0.9.1"
+  version = "0.10.0"
 
   name            = "" # avoids hitting length restrictions on IAM Role names
   chart           = var.cert_manager_chart
@@ -108,7 +108,7 @@ module "cert_manager" {
 
 module "cert_manager_issuer" {
   source  = "cloudposse/helm-release/aws"
-  version = "0.9.1"
+  version = "0.10.0"
 
   # Only install the issuer if either letsencrypt_installed or selfsigned_installed is true
   enabled = local.enabled && (var.letsencrypt_enabled || var.cert_manager_issuer_selfsigned_enabled)

--- a/modules/eks/datadog-agent/README.md
+++ b/modules/eks/datadog-agent/README.md
@@ -182,7 +182,7 @@ https-checks:
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_datadog_agent"></a> [datadog\_agent](#module\_datadog\_agent) | cloudposse/helm-release/aws | 0.9.1 |
+| <a name="module_datadog_agent"></a> [datadog\_agent](#module\_datadog\_agent) | cloudposse/helm-release/aws | 0.10.0 |
 | <a name="module_datadog_cluster_check_yaml_config"></a> [datadog\_cluster\_check\_yaml\_config](#module\_datadog\_cluster\_check\_yaml\_config) | cloudposse/config/yaml | 1.0.2 |
 | <a name="module_datadog_configuration"></a> [datadog\_configuration](#module\_datadog\_configuration) | ../../datadog-configuration/modules/datadog_keys | n/a |
 | <a name="module_eks"></a> [eks](#module\_eks) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |

--- a/modules/eks/datadog-agent/main.tf
+++ b/modules/eks/datadog-agent/main.tf
@@ -86,7 +86,7 @@ module "values_merge" {
 
 module "datadog_agent" {
   source  = "cloudposse/helm-release/aws"
-  version = "0.9.1"
+  version = "0.10.0"
 
   name          = module.this.name
   chart         = var.chart

--- a/modules/eks/echo-server/README.md
+++ b/modules/eks/echo-server/README.md
@@ -89,7 +89,7 @@ components:
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_alb"></a> [alb](#module\_alb) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
-| <a name="module_echo_server"></a> [echo\_server](#module\_echo\_server) | cloudposse/helm-release/aws | 0.9.1 |
+| <a name="module_echo_server"></a> [echo\_server](#module\_echo\_server) | cloudposse/helm-release/aws | 0.10.0 |
 | <a name="module_eks"></a> [eks](#module\_eks) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../../account-map/modules/iam-roles | n/a |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |

--- a/modules/eks/echo-server/main.tf
+++ b/modules/eks/echo-server/main.tf
@@ -5,7 +5,7 @@ locals {
 
 module "echo_server" {
   source  = "cloudposse/helm-release/aws"
-  version = "0.9.1"
+  version = "0.10.0"
 
   name  = module.this.name
   chart = "${path.module}/charts/echo-server"

--- a/modules/eks/external-dns/README.md
+++ b/modules/eks/external-dns/README.md
@@ -68,7 +68,7 @@ components:
 | <a name="module_dns_gbl_delegated"></a> [dns\_gbl\_delegated](#module\_dns\_gbl\_delegated) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
 | <a name="module_dns_gbl_primary"></a> [dns\_gbl\_primary](#module\_dns\_gbl\_primary) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
 | <a name="module_eks"></a> [eks](#module\_eks) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
-| <a name="module_external_dns"></a> [external\_dns](#module\_external\_dns) | cloudposse/helm-release/aws | 0.9.1 |
+| <a name="module_external_dns"></a> [external\_dns](#module\_external\_dns) | cloudposse/helm-release/aws | 0.10.0 |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../../account-map/modules/iam-roles | n/a |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 

--- a/modules/eks/external-dns/main.tf
+++ b/modules/eks/external-dns/main.tf
@@ -19,7 +19,7 @@ data "aws_partition" "current" {
 
 module "external_dns" {
   source  = "cloudposse/helm-release/aws"
-  version = "0.9.1"
+  version = "0.10.0"
 
   name            = module.this.name
   chart           = var.chart

--- a/modules/eks/external-secrets-operator/README.md
+++ b/modules/eks/external-secrets-operator/README.md
@@ -111,8 +111,8 @@ components:
 |------|--------|---------|
 | <a name="module_account_map"></a> [account\_map](#module\_account\_map) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
 | <a name="module_eks"></a> [eks](#module\_eks) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
-| <a name="module_external_secrets_operator"></a> [external\_secrets\_operator](#module\_external\_secrets\_operator) | cloudposse/helm-release/aws | 0.9.1 |
-| <a name="module_external_ssm_secrets"></a> [external\_ssm\_secrets](#module\_external\_ssm\_secrets) | cloudposse/helm-release/aws | 0.9.1 |
+| <a name="module_external_secrets_operator"></a> [external\_secrets\_operator](#module\_external\_secrets\_operator) | cloudposse/helm-release/aws | 0.10.0 |
+| <a name="module_external_ssm_secrets"></a> [external\_ssm\_secrets](#module\_external\_ssm\_secrets) | cloudposse/helm-release/aws | 0.10.0 |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../../account-map/modules/iam-roles | n/a |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 

--- a/modules/eks/external-secrets-operator/main.tf
+++ b/modules/eks/external-secrets-operator/main.tf
@@ -18,7 +18,7 @@ resource "kubernetes_namespace" "default" {
 # https://external-secrets.io/v0.5.9/guides-getting-started/
 module "external_secrets_operator" {
   source  = "cloudposse/helm-release/aws"
-  version = "0.9.1"
+  version = "0.10.0"
 
   name        = "" # avoid redundant release name in IAM role: ...-ekc-cluster-external-secrets-operator-external-secrets-operator@secrets
   description = var.chart_description
@@ -78,7 +78,7 @@ module "external_secrets_operator" {
 
 module "external_ssm_secrets" {
   source  = "cloudposse/helm-release/aws"
-  version = "0.9.1"
+  version = "0.10.0"
 
   name        = "ssm" # distinguish from external_secrets_operator
   description = "This Chart uses creates a SecretStore and ExternalSecret to pull variables (under a given path) from AWS SSM Parameter Store into a Kubernetes secret."

--- a/modules/eks/idp-roles/README.md
+++ b/modules/eks/idp-roles/README.md
@@ -43,7 +43,7 @@ components:
 |------|--------|---------|
 | <a name="module_eks"></a> [eks](#module\_eks) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../../account-map/modules/iam-roles | n/a |
-| <a name="module_idp_roles"></a> [idp\_roles](#module\_idp\_roles) | cloudposse/helm-release/aws | 0.9.1 |
+| <a name="module_idp_roles"></a> [idp\_roles](#module\_idp\_roles) | cloudposse/helm-release/aws | 0.10.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 
 ## Resources

--- a/modules/eks/idp-roles/main.tf
+++ b/modules/eks/idp-roles/main.tf
@@ -4,7 +4,7 @@ locals {
 
 module "idp_roles" {
   source  = "cloudposse/helm-release/aws"
-  version = "0.9.1"
+  version = "0.10.0"
 
   # Required arguments
   name                 = module.this.name

--- a/modules/eks/karpenter/README.md
+++ b/modules/eks/karpenter/README.md
@@ -319,7 +319,7 @@ For more details, refer to:
 |------|--------|---------|
 | <a name="module_eks"></a> [eks](#module\_eks) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../../account-map/modules/iam-roles | n/a |
-| <a name="module_karpenter"></a> [karpenter](#module\_karpenter) | cloudposse/helm-release/aws | 0.9.1 |
+| <a name="module_karpenter"></a> [karpenter](#module\_karpenter) | cloudposse/helm-release/aws | 0.10.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 
 ## Resources

--- a/modules/eks/karpenter/main.tf
+++ b/modules/eks/karpenter/main.tf
@@ -28,7 +28,7 @@ resource "aws_iam_instance_profile" "default" {
 # Deploy Karpenter helm chart
 module "karpenter" {
   source  = "cloudposse/helm-release/aws"
-  version = "0.9.1"
+  version = "0.10.0"
 
   chart           = var.chart
   repository      = var.chart_repository

--- a/modules/eks/keda/README.md
+++ b/modules/eks/keda/README.md
@@ -55,7 +55,7 @@ components:
 |------|--------|---------|
 | <a name="module_eks"></a> [eks](#module\_eks) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../../account-map/modules/iam-roles | n/a |
-| <a name="module_keda"></a> [keda](#module\_keda) | cloudposse/helm-release/aws | 0.9.3 |
+| <a name="module_keda"></a> [keda](#module\_keda) | cloudposse/helm-release/aws | 0.10.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 
 ## Resources

--- a/modules/eks/keda/main.tf
+++ b/modules/eks/keda/main.tf
@@ -1,6 +1,6 @@
 module "keda" {
   source  = "cloudposse/helm-release/aws"
-  version = "0.9.3"
+  version = "0.10.0"
 
   name        = module.this.name
   description = var.description

--- a/modules/eks/metrics-server/README.md
+++ b/modules/eks/metrics-server/README.md
@@ -60,7 +60,7 @@ components:
 |------|--------|---------|
 | <a name="module_eks"></a> [eks](#module\_eks) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../../account-map/modules/iam-roles | n/a |
-| <a name="module_metrics_server"></a> [metrics\_server](#module\_metrics\_server) | cloudposse/helm-release/aws | 0.9.1 |
+| <a name="module_metrics_server"></a> [metrics\_server](#module\_metrics\_server) | cloudposse/helm-release/aws | 0.10.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 
 ## Resources

--- a/modules/eks/metrics-server/main.tf
+++ b/modules/eks/metrics-server/main.tf
@@ -14,7 +14,7 @@ resource "kubernetes_namespace" "default" {
 
 module "metrics_server" {
   source  = "cloudposse/helm-release/aws"
-  version = "0.9.1"
+  version = "0.10.0"
 
   name                 = "" # avoids hitting length restrictions on IAM Role names
   chart                = var.chart

--- a/modules/eks/redis-operator/README.md
+++ b/modules/eks/redis-operator/README.md
@@ -88,7 +88,7 @@ components:
 |------|--------|---------|
 | <a name="module_eks"></a> [eks](#module\_eks) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../../account-map/modules/iam-roles | n/a |
-| <a name="module_redis_operator"></a> [redis\_operator](#module\_redis\_operator) | cloudposse/helm-release/aws | 0.9.1 |
+| <a name="module_redis_operator"></a> [redis\_operator](#module\_redis\_operator) | cloudposse/helm-release/aws | 0.10.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 
 ## Resources

--- a/modules/eks/redis-operator/main.tf
+++ b/modules/eks/redis-operator/main.tf
@@ -14,7 +14,7 @@ resource "kubernetes_namespace" "default" {
 
 module "redis_operator" {
   source  = "cloudposse/helm-release/aws"
-  version = "0.9.1"
+  version = "0.10.0"
 
   chart                = var.chart
   repository           = var.chart_repository

--- a/modules/eks/redis/README.md
+++ b/modules/eks/redis/README.md
@@ -94,7 +94,7 @@ components:
 |------|--------|---------|
 | <a name="module_eks"></a> [eks](#module\_eks) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../../account-map/modules/iam-roles | n/a |
-| <a name="module_redis"></a> [redis](#module\_redis) | cloudposse/helm-release/aws | 0.9.1 |
+| <a name="module_redis"></a> [redis](#module\_redis) | cloudposse/helm-release/aws | 0.10.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 
 ## Resources

--- a/modules/eks/redis/main.tf
+++ b/modules/eks/redis/main.tf
@@ -14,7 +14,7 @@ resource "kubernetes_namespace" "default" {
 
 module "redis" {
   source  = "cloudposse/helm-release/aws"
-  version = "0.9.1"
+  version = "0.10.0"
 
   chart                = var.chart
   repository           = var.chart_repository


### PR DESCRIPTION
## what

- Update all components using `terraform-aws-helm-release` to version 0.10.0

## why

- Earlier PRs updated `helm-release` without testing. For components supplying `helm-release` with `iam_policy_statements` in the form of a `list` (rather than a `map`), `helm-release` v0.8.2 broke them by refusing to accept a list. This update to v0.10.0 restores the ability to accept a list and brings other improvements.

## references

- `helm-release` [v0.8.2 release notes](https://github.com/cloudposse/terraform-aws-helm-release/releases/tag/0.8.2)
- Breaking updates in #729 among others
- Supersedes and closes #843 
- Supersedes #836 


