### PR TITLE
[eks/cluster] Bug fixes for add-ons

### DIFF
--- a/modules/eks/cluster/CHANGELOG.md
+++ b/modules/eks/cluster/CHANGELOG.md
@@ -1,3 +1,26 @@
+## Components PR [#852](https://github.com/cloudposse/terraform-aws-components/pull/852)
+
+This is a bug fix and feature enhancement update. No action is necessary to upgrade.
+
+### Bug Fixes
+
+- Timeouts for Add-Ons are now honored (they were being ignored)
+- If you supply a service account role ARN for an Add-On, it will be used, and
+  no new role will be created. Previously it was used, but the component created
+  a new role anyway.
+- The EKS EFS controller add-on cannot be deployed to Fargate, and enabling it
+  along with `deploy_addons_to_fargate` will no longer attempt to deploy EFS
+  to Fargate. Note that this means to use the EFS Add-On, you must create
+  a managed node group. Track the status of this feature with [this issue](https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/1100).
+- If you are using an old VPC component that does not supply `az_private_subnets_map`,
+  this module will now use the older the `private_subnet_ids` output.
+
+### Add-Ons have `enabled` option
+
+The EKS Add-Ons now have an optional "enabled" flag (defaults to `true`) so
+that you can selectively disable them in a stack where the inherited configuration
+has them enabled.
+
 ## Upgrading to `v1.270.0`
 
 Components PR [#795](https://github.com/cloudposse/terraform-aws-components/pull/795)

--- a/modules/eks/cluster/README.md
+++ b/modules/eks/cluster/README.md
@@ -135,6 +135,7 @@ components:
 
         # EKS addons
         # https://docs.aws.amazon.com/eks/latest/userguide/eks-add-ons.html
+        # Configuring EKS addons: https://aws.amazon.com/blogs/containers/amazon-eks-add-ons-advanced-configuration/
         addons:
           # https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html
           vpc-cni:
@@ -151,7 +152,7 @@ components:
           aws-ebs-csi-driver:
             addon_version: "v1.20.0-eksbuild.1"  # set `addon_version` to `null` to use the latest version
             # If you are not using [volume snapshots](https://kubernetes.io/blog/2020/12/10/kubernetes-1.20-volume-snapshot-moves-to-ga/#how-to-use-volume-snapshots)
-            # (and you probably are not), disable it the EBS Snapshotter with:
+            # (and you probably are not), disable the EBS Snapshotter with:
             configuration_values: '{"sidecars":{"snapshotter":{"forceEnable":false}}}'
           # Only install the EFS driver if you are using EFS.
           # Create an EFS file system with the `efs` component.
@@ -302,6 +303,7 @@ Configure the addons like the following example:
 ```yaml
 # https://docs.aws.amazon.com/eks/latest/userguide/eks-add-ons.html
 # https://docs.aws.amazon.com/eks/latest/userguide/managing-add-ons.html#creating-an-add-on
+# https://aws.amazon.com/blogs/containers/amazon-eks-add-ons-advanced-configuration/
 addons:
   # https://docs.aws.amazon.com/eks/latest/userguide/cni-iam-role.html
   # https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html
@@ -315,6 +317,8 @@ addons:
   # https://docs.aws.amazon.com/eks/latest/userguide/managing-coredns.html
   coredns:
     addon_version: "v1.9.3-eksbuild.2"  # set `addon_version` to `null` to use the latest version
+    # Uncomment to override default replica count of 2
+    # configuration_values: '{"replicaCount": 3}'
   # https://docs.aws.amazon.com/eks/latest/userguide/csi-iam-role.html
   # https://aws.amazon.com/blogs/containers/amazon-ebs-csi-driver-is-now-generally-available-in-amazon-eks-add-ons
   # https://docs.aws.amazon.com/eks/latest/userguide/managing-ebs-csi.html#csi-iam-role
@@ -322,7 +326,7 @@ addons:
   aws-ebs-csi-driver:
     addon_version: "v1.19.0-eksbuild.2"  # set `addon_version` to `null` to use the latest version
     # If you are not using [volume snapshots](https://kubernetes.io/blog/2020/12/10/kubernetes-1.20-volume-snapshot-moves-to-ga/#how-to-use-volume-snapshots)
-    # (and you probably are not), disable it the EBS Snapshotter with:
+    # (and you probably are not), disable the EBS Snapshotter with:
     configuration_values: '{"sidecars":{"snapshotter":{"forceEnable":false}}}'
 ```
 
@@ -439,11 +443,11 @@ If the new addon requires an EKS IAM Role for Kubernetes Service Account, perfor
 | <a name="module_aws_ebs_csi_driver_fargate_profile"></a> [aws\_ebs\_csi\_driver\_fargate\_profile](#module\_aws\_ebs\_csi\_driver\_fargate\_profile) | cloudposse/eks-fargate-profile/aws | 1.3.0 |
 | <a name="module_aws_efs_csi_driver_eks_iam_role"></a> [aws\_efs\_csi\_driver\_eks\_iam\_role](#module\_aws\_efs\_csi\_driver\_eks\_iam\_role) | cloudposse/eks-iam-role/aws | 2.1.1 |
 | <a name="module_coredns_fargate_profile"></a> [coredns\_fargate\_profile](#module\_coredns\_fargate\_profile) | cloudposse/eks-fargate-profile/aws | 1.3.0 |
-| <a name="module_delegated_roles"></a> [delegated\_roles](#module\_delegated\_roles) | cloudposse/stack-config/yaml//modules/remote-state | 1.4.1 |
 | <a name="module_eks"></a> [eks](#module\_eks) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
 | <a name="module_eks_cluster"></a> [eks\_cluster](#module\_eks\_cluster) | cloudposse/eks-cluster/aws | 2.9.0 |
 | <a name="module_fargate_pod_execution_role"></a> [fargate\_pod\_execution\_role](#module\_fargate\_pod\_execution\_role) | cloudposse/eks-fargate-profile/aws | 1.3.0 |
 | <a name="module_fargate_profile"></a> [fargate\_profile](#module\_fargate\_profile) | cloudposse/eks-fargate-profile/aws | 1.3.0 |
+| <a name="module_iam_arns"></a> [iam\_arns](#module\_iam\_arns) | ../../account-map/modules/roles-to-principals | n/a |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../../account-map/modules/iam-roles | n/a |
 | <a name="module_karpenter_label"></a> [karpenter\_label](#module\_karpenter\_label) | cloudposse/label/null | 0.25.0 |
 | <a name="module_region_node_group"></a> [region\_node\_group](#module\_region\_node\_group) | ./modules/node_group_by_region | n/a |

--- a/modules/eks/cluster/README.md
+++ b/modules/eks/cluster/README.md
@@ -150,6 +150,9 @@ components:
           # https://github.com/kubernetes-sigs/aws-ebs-csi-driver
           aws-ebs-csi-driver:
             addon_version: "v1.20.0-eksbuild.1"  # set `addon_version` to `null` to use the latest version
+            # If you are not using [volume snapshots](https://kubernetes.io/blog/2020/12/10/kubernetes-1.20-volume-snapshot-moves-to-ga/#how-to-use-volume-snapshots)
+            # (and you probably are not), disable it the EBS Snapshotter with:
+            configuration_values: '{"sidecars":{"snapshotter":{"forceEnable":false}}}'
           # Only install the EFS driver if you are using EFS.
           # Create an EFS file system with the `efs` component.
           # Create an EFS StorageClass with the `eks/storage-class` component.
@@ -318,6 +321,9 @@ addons:
   # https://github.com/kubernetes-sigs/aws-ebs-csi-driver
   aws-ebs-csi-driver:
     addon_version: "v1.19.0-eksbuild.2"  # set `addon_version` to `null` to use the latest version
+    # If you are not using [volume snapshots](https://kubernetes.io/blog/2020/12/10/kubernetes-1.20-volume-snapshot-moves-to-ga/#how-to-use-volume-snapshots)
+    # (and you probably are not), disable it the EBS Snapshotter with:
+    configuration_values: '{"sidecars":{"snapshotter":{"forceEnable":false}}}'
 ```
 
 Some addons, such as CoreDNS, require at least one node to be fully provisioned first.
@@ -432,13 +438,12 @@ If the new addon requires an EKS IAM Role for Kubernetes Service Account, perfor
 | <a name="module_aws_ebs_csi_driver_eks_iam_role"></a> [aws\_ebs\_csi\_driver\_eks\_iam\_role](#module\_aws\_ebs\_csi\_driver\_eks\_iam\_role) | cloudposse/eks-iam-role/aws | 2.1.1 |
 | <a name="module_aws_ebs_csi_driver_fargate_profile"></a> [aws\_ebs\_csi\_driver\_fargate\_profile](#module\_aws\_ebs\_csi\_driver\_fargate\_profile) | cloudposse/eks-fargate-profile/aws | 1.3.0 |
 | <a name="module_aws_efs_csi_driver_eks_iam_role"></a> [aws\_efs\_csi\_driver\_eks\_iam\_role](#module\_aws\_efs\_csi\_driver\_eks\_iam\_role) | cloudposse/eks-iam-role/aws | 2.1.1 |
-| <a name="module_aws_efs_csi_driver_fargate_profile"></a> [aws\_efs\_csi\_driver\_fargate\_profile](#module\_aws\_efs\_csi\_driver\_fargate\_profile) | cloudposse/eks-fargate-profile/aws | 1.3.0 |
 | <a name="module_coredns_fargate_profile"></a> [coredns\_fargate\_profile](#module\_coredns\_fargate\_profile) | cloudposse/eks-fargate-profile/aws | 1.3.0 |
+| <a name="module_delegated_roles"></a> [delegated\_roles](#module\_delegated\_roles) | cloudposse/stack-config/yaml//modules/remote-state | 1.4.1 |
 | <a name="module_eks"></a> [eks](#module\_eks) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
 | <a name="module_eks_cluster"></a> [eks\_cluster](#module\_eks\_cluster) | cloudposse/eks-cluster/aws | 2.9.0 |
 | <a name="module_fargate_pod_execution_role"></a> [fargate\_pod\_execution\_role](#module\_fargate\_pod\_execution\_role) | cloudposse/eks-fargate-profile/aws | 1.3.0 |
 | <a name="module_fargate_profile"></a> [fargate\_profile](#module\_fargate\_profile) | cloudposse/eks-fargate-profile/aws | 1.3.0 |
-| <a name="module_iam_arns"></a> [iam\_arns](#module\_iam\_arns) | ../../account-map/modules/roles-to-principals | n/a |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../../account-map/modules/iam-roles | n/a |
 | <a name="module_karpenter_label"></a> [karpenter\_label](#module\_karpenter\_label) | cloudposse/label/null | 0.25.0 |
 | <a name="module_region_node_group"></a> [region\_node\_group](#module\_region\_node\_group) | ./modules/node_group_by_region | n/a |
@@ -475,7 +480,7 @@ If the new addon requires an EKS IAM Role for Kubernetes Service Account, perfor
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br>This is for some rare cases where resources want additional configuration of tags<br>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
-| <a name="input_addons"></a> [addons](#input\_addons) | Manages [EKS addons](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon) resources | <pre>map(object({<br>    addon_version = optional(string, null)<br>    # configuration_values is a JSON string, such as '{"computeType": "Fargate"}'.<br>    configuration_values = optional(string, null)<br>    # Set default resolve_conflicts to OVERWRITE because it is required on initial installation of<br>    # add-ons that have self-managed versions installed by default (e.g. vpc-cni, coredns), and<br>    # because any custom configuration that you would want to preserve should be managed by Terraform.<br>    resolve_conflicts        = optional(string, "OVERWRITE")<br>    service_account_role_arn = optional(string, null)<br>    create_timeout           = optional(string, null)<br>    update_timeout           = optional(string, null)<br>    delete_timeout           = optional(string, null)<br>  }))</pre> | `{}` | no |
+| <a name="input_addons"></a> [addons](#input\_addons) | Manages [EKS addons](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon) resources | <pre>map(object({<br>    enabled       = optional(bool, true)<br>    addon_version = optional(string, null)<br>    # configuration_values is a JSON string, such as '{"computeType": "Fargate"}'.<br>    configuration_values = optional(string, null)<br>    # Set default resolve_conflicts to OVERWRITE because it is required on initial installation of<br>    # add-ons that have self-managed versions installed by default (e.g. vpc-cni, coredns), and<br>    # because any custom configuration that you would want to preserve should be managed by Terraform.<br>    resolve_conflicts        = optional(string, "OVERWRITE")<br>    service_account_role_arn = optional(string, null)<br>    create_timeout           = optional(string, null)<br>    update_timeout           = optional(string, null)<br>    delete_timeout           = optional(string, null)<br>  }))</pre> | `{}` | no |
 | <a name="input_addons_depends_on"></a> [addons\_depends\_on](#input\_addons\_depends\_on) | If set `true` (recommended), all addons will depend on managed node groups provisioned by this component and therefore not be installed until nodes are provisioned.<br>See [issue #170](https://github.com/cloudposse/terraform-aws-eks-cluster/issues/170) for more details. | `bool` | `true` | no |
 | <a name="input_allow_ingress_from_vpc_accounts"></a> [allow\_ingress\_from\_vpc\_accounts](#input\_allow\_ingress\_from\_vpc\_accounts) | List of account contexts to pull VPC ingress CIDR and add to cluster security group.<br><br>e.g.<br><br>{<br>  environment = "ue2",<br>  stage       = "auto",<br>  tenant      = "core"<br>} | `any` | `[]` | no |
 | <a name="input_allowed_cidr_blocks"></a> [allowed\_cidr\_blocks](#input\_allowed\_cidr\_blocks) | List of CIDR blocks to be allowed to connect to the EKS cluster | `list(string)` | `[]` | no |

--- a/modules/eks/cluster/addons.tf
+++ b/modules/eks/cluster/addons.tf
@@ -5,14 +5,18 @@ locals {
   eks_cluster_oidc_issuer_url = local.enabled ? replace(module.eks_cluster.eks_cluster_identity_oidc_issuer, "https://", "") : ""
   eks_cluster_id              = local.enabled ? module.eks_cluster.eks_cluster_id : ""
 
-  addon_names                = keys(var.addons)
+  addon_names                = [for k, v in var.addons : k if v.enabled]
   vpc_cni_addon_enabled      = local.enabled && contains(local.addon_names, "vpc-cni")
   aws_ebs_csi_driver_enabled = local.enabled && contains(local.addon_names, "aws-ebs-csi-driver")
   aws_efs_csi_driver_enabled = local.enabled && contains(local.addon_names, "aws-efs-csi-driver")
   coredns_enabled            = local.enabled && contains(local.addon_names, "coredns")
 
   # The `vpc-cni`, `aws-ebs-csi-driver`, and `aws-efs-csi-driver` addons are special as they always require an
-  # IAM role for Kubernetes Service Account (IRSA). The roles are created by this component.
+  # IAM role for Kubernetes Service Account (IRSA). The roles are created by this component unless ARNs are provided.
+  # Use "?" operator to avoid evaluating map lookup when entry is missing
+  vpc_cni_sa_needed = local.vpc_cni_addon_enabled ? lookup(var.addons["vpc-cni"], "service_account_role_arn", null) == null : false
+  ebs_csi_sa_needed = local.aws_ebs_csi_driver_enabled ? lookup(var.addons["aws-ebs-csi-driver"], "service_account_role_arn", null) == null : false
+  efs_csi_sa_needed = local.aws_efs_csi_driver_enabled ? lookup(var.addons["aws-efs-csi-driver"], "service_account_role_arn", null) == null : false
   addon_service_account_role_arn_map = {
     vpc-cni            = module.vpc_cni_eks_iam_role.service_account_role_arn
     aws-ebs-csi-driver = module.aws_ebs_csi_driver_eks_iam_role.service_account_role_arn
@@ -28,19 +32,26 @@ locals {
       configuration_values     = lookup(v, "configuration_values", null)
       resolve_conflicts        = lookup(v, "resolve_conflicts", null)
       service_account_role_arn = try(coalesce(lookup(v, "service_account_role_arn", null), lookup(local.final_addon_service_account_role_arn_map, k, null)), null)
-    }
+      create_timeout           = lookup(v, "create_timeout", null)
+      update_timeout           = lookup(v, "update_timeout", null)
+      delete_timeout           = lookup(v, "delete_timeout", null)
+
+    } if v.enabled
   ]
 
   addons_depends_on = concat([
+    module.vpc_cni_eks_iam_role,
     module.coredns_fargate_profile,
+    module.aws_ebs_csi_driver_eks_iam_role,
     module.aws_ebs_csi_driver_fargate_profile,
-    module.aws_efs_csi_driver_fargate_profile,
+    module.aws_efs_csi_driver_eks_iam_role,
   ], local.overridable_addons_depends_on)
 
   addons_require_fargate = var.deploy_addons_to_fargate && (
     local.coredns_enabled ||
     local.aws_ebs_csi_driver_enabled ||
-    local.aws_efs_csi_driver_enabled ||
+    # as of EFS add-on v1.5.8, it cannot be deployed to Fargate
+    # local.aws_efs_csi_driver_enabled ||
     local.overridable_deploy_additional_addons_to_fargate
   )
   addon_fargate_profiles = merge(
@@ -50,9 +61,11 @@ locals {
     (local.aws_ebs_csi_driver_enabled && var.deploy_addons_to_fargate ? {
       aws_ebs_csi_driver = one(module.aws_ebs_csi_driver_fargate_profile[*])
     } : {}),
-    (local.aws_efs_csi_driver_enabled && var.deploy_addons_to_fargate ? {
-      aws_efs_csi_driver = one(module.aws_efs_csi_driver_fargate_profile[*])
-    } : {}),
+    # as of EFS add-on v1.5.8, it cannot be deployed to Fargate
+    # See https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/1100
+    #    (local.aws_efs_csi_driver_enabled && var.deploy_addons_to_fargate ? {
+    #      aws_efs_csi_driver = one(module.aws_efs_csi_driver_fargate_profile[*])
+    #    } : {}),
     local.overridable_additional_addon_fargate_profiles
   )
 }
@@ -63,7 +76,7 @@ locals {
 # https://docs.aws.amazon.com/eks/latest/userguide/cni-iam-role.html#cni-iam-role-create-role
 # https://aws.github.io/aws-eks-best-practices/networking/vpc-cni/#deploy-vpc-cni-managed-add-on
 data "aws_iam_policy_document" "vpc_cni_ipv6" {
-  count = local.vpc_cni_addon_enabled ? 1 : 0
+  count = local.vpc_cni_sa_needed ? 1 : 0
 
   # See https://docs.aws.amazon.com/eks/latest/userguide/cni-iam-role.html#cni-iam-role-create-ipv6-policy
   statement {
@@ -89,7 +102,7 @@ data "aws_iam_policy_document" "vpc_cni_ipv6" {
 }
 
 resource "aws_iam_role_policy_attachment" "vpc_cni" {
-  count = local.vpc_cni_addon_enabled ? 1 : 0
+  count = local.vpc_cni_sa_needed ? 1 : 0
 
   role       = module.vpc_cni_eks_iam_role.service_account_role_name
   policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
@@ -99,7 +112,7 @@ module "vpc_cni_eks_iam_role" {
   source  = "cloudposse/eks-iam-role/aws"
   version = "2.1.1"
 
-  enabled = local.vpc_cni_addon_enabled
+  enabled = local.vpc_cni_sa_needed
 
   eks_cluster_oidc_issuer_url = local.eks_cluster_oidc_issuer_url
 
@@ -138,7 +151,7 @@ module "coredns_fargate_profile" {
 # https://docs.aws.amazon.com/eks/latest/userguide/managing-ebs-csi.html#csi-iam-role
 # https://github.com/kubernetes-sigs/aws-ebs-csi-driver
 resource "aws_iam_role_policy_attachment" "aws_ebs_csi_driver" {
-  count = local.aws_ebs_csi_driver_enabled ? 1 : 0
+  count = local.ebs_csi_sa_needed ? 1 : 0
 
   role       = module.aws_ebs_csi_driver_eks_iam_role.service_account_role_name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
@@ -148,7 +161,7 @@ module "aws_ebs_csi_driver_eks_iam_role" {
   source  = "cloudposse/eks-iam-role/aws"
   version = "2.1.1"
 
-  enabled = local.aws_ebs_csi_driver_enabled
+  enabled = local.ebs_csi_sa_needed
 
   eks_cluster_oidc_issuer_url = local.eks_cluster_oidc_issuer_url
 
@@ -184,7 +197,7 @@ module "aws_ebs_csi_driver_fargate_profile" {
 # https://docs.aws.amazon.com/eks/latest/userguide/efs-csi.html
 # https://github.com/kubernetes-sigs/aws-efs-csi-driver
 resource "aws_iam_role_policy_attachment" "aws_efs_csi_driver" {
-  count = local.aws_efs_csi_driver_enabled ? 1 : 0
+  count = local.efs_csi_sa_needed ? 1 : 0
 
   role       = module.aws_efs_csi_driver_eks_iam_role.service_account_role_name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEFSCSIDriverPolicy"
@@ -194,7 +207,7 @@ module "aws_efs_csi_driver_eks_iam_role" {
   source  = "cloudposse/eks-iam-role/aws"
   version = "2.1.1"
 
-  enabled = local.aws_efs_csi_driver_enabled
+  enabled = local.efs_csi_sa_needed
 
   eks_cluster_oidc_issuer_url = local.eks_cluster_oidc_issuer_url
 
@@ -204,26 +217,4 @@ module "aws_efs_csi_driver_eks_iam_role" {
   ]
 
   context = module.this.context
-}
-
-module "aws_efs_csi_driver_fargate_profile" {
-  count = local.aws_efs_csi_driver_enabled && var.deploy_addons_to_fargate ? 1 : 0
-
-  source  = "cloudposse/eks-fargate-profile/aws"
-  version = "1.3.0"
-
-  subnet_ids           = local.private_subnet_ids
-  cluster_name         = local.eks_cluster_id
-  kubernetes_namespace = "kube-system"
-  kubernetes_labels    = { app = "efs-csi-controller" } # Only deploy the controller to Fargate, not the node driver
-  permissions_boundary = var.fargate_profile_iam_role_permissions_boundary
-
-  iam_role_kubernetes_namespace_delimiter = var.fargate_profile_iam_role_kubernetes_namespace_delimiter
-
-  fargate_profile_name               = "${local.eks_cluster_id}-efs-csi"
-  fargate_pod_execution_role_enabled = false
-  fargate_pod_execution_role_arn     = one(module.fargate_pod_execution_role[*].eks_fargate_pod_execution_role_arn)
-
-  attributes = ["efs-csi"]
-  context    = module.this.context
 }

--- a/modules/eks/cluster/main.tf
+++ b/modules/eks/cluster/main.tf
@@ -91,15 +91,13 @@ locals {
 
   # Get only the public subnets that correspond to the AZs provided in `var.availability_zones`
   # `az_public_subnets_map` is a map of AZ names to list of public subnet IDs in the AZs
-  # LEGACY PATCH: for legacy VPC with no az_public_subnets_map
-  # public_subnet_ids = flatten([for k, v in local.vpc_outputs.az_public_subnets_map : v if contains(var.availability_zones, k) || length(var.availability_zones) == 0])
+  # LEGACY SUPPORT for legacy VPC with no az_public_subnets_map
   public_subnet_ids = try(flatten([for k, v in local.vpc_outputs.az_public_subnets_map : v if contains(var.availability_zones, k) || length(var.availability_zones) == 0]),
   local.vpc_outputs.public_subnet_ids)
 
   # Get only the private subnets that correspond to the AZs provided in `var.availability_zones`
   # `az_private_subnets_map` is a map of AZ names to list of private subnet IDs in the AZs
-  # LEGACY PATCH: for legacy VPC with no az_public_subnets_map
-  # private_subnet_ids = flatten([for k, v in local.vpc_outputs.az_private_subnets_map : v if contains(var.availability_zones, k) || length(var.availability_zones) == 0])
+  # LEGACY SUPPORT for legacy VPC with no az_public_subnets_map
   private_subnet_ids = try(flatten([for k, v in local.vpc_outputs.az_private_subnets_map : v if contains(var.availability_zones, k) || length(var.availability_zones) == 0]),
   local.vpc_outputs.private_subnet_ids)
 

--- a/modules/eks/cluster/remote-state.tf
+++ b/modules/eks/cluster/remote-state.tf
@@ -4,22 +4,10 @@ locals {
   } : {}
 }
 
-# LEGACY PATCH: legacy account-map does not have `principals_map` output
-# replace with legacy delegated_roles module
-#module "iam_arns" {
-#  source = "../../account-map/modules/roles-to-principals"
-#
-#  role_map = local.role_map
-#
-#  context = module.this.context
-#}
-module "delegated_roles" {
-  source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "1.4.1"
+module "iam_arns" {
+  source = "../../account-map/modules/roles-to-principals"
 
-  component = "aws-team-roles"
-
-  environment = module.iam_roles.global_environment_name
+  role_map = local.role_map
 
   context = module.this.context
 }

--- a/modules/eks/cluster/remote-state.tf
+++ b/modules/eks/cluster/remote-state.tf
@@ -4,10 +4,22 @@ locals {
   } : {}
 }
 
-module "iam_arns" {
-  source = "../../account-map/modules/roles-to-principals"
+# LEGACY PATCH: legacy account-map does not have `principals_map` output
+# replace with legacy delegated_roles module
+#module "iam_arns" {
+#  source = "../../account-map/modules/roles-to-principals"
+#
+#  role_map = local.role_map
+#
+#  context = module.this.context
+#}
+module "delegated_roles" {
+  source  = "cloudposse/stack-config/yaml//modules/remote-state"
+  version = "1.4.1"
 
-  role_map = local.role_map
+  component = "aws-team-roles"
+
+  environment = module.iam_roles.global_environment_name
 
   context = module.this.context
 }
@@ -20,10 +32,8 @@ module "vpc" {
   component = var.vpc_component_name
 
   defaults = {
-    az_public_subnets_map  = {}
-    az_private_subnets_map = {}
-    public_subnet_ids      = []
-    private_subnet_ids     = []
+    public_subnet_ids  = []
+    private_subnet_ids = []
     vpc = {
       subnet_type_tag_key = ""
     }

--- a/modules/eks/cluster/variables.tf
+++ b/modules/eks/cluster/variables.tf
@@ -510,6 +510,7 @@ variable "fargate_profile_iam_role_permissions_boundary" {
 
 variable "addons" {
   type = map(object({
+    enabled       = optional(bool, true)
     addon_version = optional(string, null)
     # configuration_values is a JSON string, such as '{"computeType": "Fargate"}'.
     configuration_values = optional(string, null)


### PR DESCRIPTION
## what && why

Changes to `eks/cluster`:
- Timeouts for Add-Ons are now honored (they were being ignored)
- If you supply a service account role ARN for an Add-On, it will be used, and
  no new role will be created. Previously it was used, but the component created
  a new role anyway.
- The EKS EFS controller add-on cannot be deployed to Fargate, and enabling it
  along with `deploy_addons_to_fargate` will no longer attempt to deploy EFS
  to Fargate. Note that this means to use the EFS Add-On, you must create
  a managed node group. Track the status of this feature with [this issue](https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/1100).
- If you are using an old VPC component that does not supply `az_private_subnets_map`,
  this module will now use the older the `private_subnet_ids` output.
- The EKS Add-Ons now have an optional "enabled" flag (defaults to `true`) so
that you can selectively disable them in a stack where the inherited configuration
has them enabled.

## references

- EFS Controller [cannot be deployed to Fargate](https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/1100)
