### PR TITLE
Bring back ignore-differences option of argo cd

### DIFF
--- a/modules/argocd-repo/templates/applicationset.yaml.tpl
+++ b/modules/argocd-repo/templates/applicationset.yaml.tpl
@@ -74,3 +74,15 @@ spec:
 %{ endif ~}
         syncOptions:
           - CreateNamespace=true
+%{if length(ignore-differences) > 0 ~}
+          - RespectIgnoreDifferences=true
+      ignoreDifferences:
+%{for item in ignore-differences ~}
+        - group: "${item.group}"
+          kind: "${item.kind}"
+          jsonPointers:
+%{for pointer in item.json-pointers ~}
+            - ${pointer}
+%{ endfor ~}
+%{ endfor ~}
+%{ endif ~}

--- a/modules/argocd-repo/variables.tf
+++ b/modules/argocd-repo/variables.tf
@@ -15,11 +15,32 @@ variable "environments" {
     environment = string
     stage       = string
     auto-sync   = bool
+    ignore-differences = list(object({
+      group         = string,
+      kind          = string,
+      json-pointers = list(string)
+    }))
   }))
   description = <<-EOT
   Environments to populate `applicationset.yaml` files and repository deploy keys (for ArgoCD) for.
 
   `auto-sync` determines whether or not the ArgoCD application will be automatically synced.
+
+  `ignore-differences` determines whether or not the ArgoCD application will ignore the number of 
+  replicas in the deployment. Read more on ignore differences here: 
+  https://argo-cd.readthedocs.io/en/stable/user-guide/sync-options/#respect-ignore-difference-configs
+  Example:
+  ```
+  tenant: plat
+  environment: use1
+  stage: sandbox
+  auto-sync: true
+  ignore-differences:
+    - group: apps
+      kind: Deployment
+      json-pointers:
+        - /spec/replicas
+  ```
   EOT
   default     = []
 }


### PR DESCRIPTION
## what

Bring back ignore-differences flag

## why

Removed by mistake

## references

https://github.com/CareCloud/cch-infra/commit/fa5bd0a55933e590c5939087337d2e11e8be5fdf#diff-9f85b02ba204dac955d260022e2730f4a782607ef81db5f662cc0584281b0926L88-L99
