### PR TITLE
Bug fix: Multiple `eks/arc` Runners with Docker Login

### DIFF
--- a/modules/eks/actions-runner-controller/charts/actions-runner/templates/runnerdeployment.yaml
+++ b/modules/eks/actions-runner-controller/charts/actions-runner/templates/runnerdeployment.yaml
@@ -23,7 +23,7 @@ spec:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: regcred
+  name: {{ .Values.release_name }}-regcred
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ .Values.docker_config_json }}
@@ -117,7 +117,7 @@ spec:
       imagePullPolicy: IfNotPresent
       {{- if  .Values.docker_config_json_enabled }}
       imagePullSecrets:
-        - name: regcred
+        - name: {{ .Values.release_name }}-regcred
       {{- end }}
       serviceAccountName: {{ .Values.service_account_name }}
       resources:
@@ -171,7 +171,7 @@ spec:
         {{- if .Values.docker_config_json_enabled }}
         - name: docker-secret
           secret:
-            secretName: regcred
+            secretName: {{ .Values.release_name }}-regcred
             items:
               - key: .dockerconfigjson
                 path: config.json


### PR DESCRIPTION
## what
- Add `{{ .Values.release_name }}` to Docker creds kubernetes secret

## why
- When deploying multiple runners, each runner should have its own secrets. Otherwise, deployment fails with the following:
```bash
│ Error: release infra-runner-amd64-medium failed, and has been rolled back due to atomic being set: failed to create resource: secrets "regcred" already exists
│
│   with module.actions_runner["infra-runner-amd64-medium"].helm_release.this[0],
│   on .terraform/modules/actions_runner/main.tf line 65, in resource "helm_release" "this":
│   65: resource "helm_release" "this" {
│
╵
╷
│ Error: release infra-runner-amd64-large failed, and has been rolled back due to atomic being set: no Secret with the name "regcred" found
│
│   with module.actions_runner["infra-runner-amd64-large"].helm_release.this[0],
│   on .terraform/modules/actions_runner/main.tf line 65, in resource "helm_release" "this":
│   65: resource "helm_release" "this" {
│
╵
╷
│ Error: release infra-runner-amd64-small failed, and has been rolled back due to atomic being set: no Secret with the name "regcred" found
│
│   with module.actions_runner["infra-runner-amd64-small"].helm_release.this[0],
│   on .terraform/modules/actions_runner/main.tf line 65, in resource "helm_release" "this":
│   65: resource "helm_release" "this" {
│
╵
Releasing state lock. This may take a few moments...
exit status 1
```

## references
- internal repo
