### PR TITLE
`alb`: Set default SSL policy to AWS Recommendation

### DIFF
--- a/modules/alb/README.md
+++ b/modules/alb/README.md
@@ -84,7 +84,7 @@ No resources.
 | <a name="input_https_ingress_cidr_blocks"></a> [https\_ingress\_cidr\_blocks](#input\_https\_ingress\_cidr\_blocks) | List of CIDR blocks to allow in HTTPS security group | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
 | <a name="input_https_ingress_prefix_list_ids"></a> [https\_ingress\_prefix\_list\_ids](#input\_https\_ingress\_prefix\_list\_ids) | List of prefix list IDs for allowing access to HTTPS ingress security group | `list(string)` | `[]` | no |
 | <a name="input_https_port"></a> [https\_port](#input\_https\_port) | The port for the HTTPS listener | `number` | `443` | no |
-| <a name="input_https_ssl_policy"></a> [https\_ssl\_policy](#input\_https\_ssl\_policy) | The name of the SSL Policy for the listener | `string` | `"ELBSecurityPolicy-TLS-1-1-2017-01"` | no |
+| <a name="input_https_ssl_policy"></a> [https\_ssl\_policy](#input\_https\_ssl\_policy) | The name of the SSL Policy for the listener | `string` | `"ELBSecurityPolicy-TLS13-1-2-2021-06"` | no |
 | <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for keep the existing setting, which defaults to `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
 | <a name="input_idle_timeout"></a> [idle\_timeout](#input\_idle\_timeout) | The time in seconds that the connection is allowed to be idle | `number` | `60` | no |
 | <a name="input_internal"></a> [internal](#input\_internal) | A boolean flag to determine whether the ALB should be internal | `bool` | `false` | no |

--- a/modules/alb/variables.tf
+++ b/modules/alb/variables.tf
@@ -66,7 +66,7 @@ variable "https_ingress_prefix_list_ids" {
 variable "https_ssl_policy" {
   type        = string
   description = "The name of the SSL Policy for the listener"
-  default     = "ELBSecurityPolicy-TLS-1-1-2017-01"
+  default     = "ELBSecurityPolicy-TLS13-1-2-2021-06"
 }
 
 variable "access_logs_prefix" {


### PR DESCRIPTION
## what

- Set a default SSL policy with the `alb` component default annotations to `ELBSecurityPolicy-TLS13-1-2-2021-06`

## why

- For TLS listeners, we recommend using the `ELBSecurityPolicy-TLS13-1-2-2021-06` security policy. This is the default policy for listeners created using the AWS Management Console. This security policy includes TLS 1.3, which is optimized for security and performance, and is backward compatible with TLS 1.2. 

## references
- [AWS Recommendation](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/create-tls-listener.html)
