### PR TITLE
chore: update vpc flow logs bucket to 1.0.1

### DIFF
--- a/modules/vpc-flow-logs-bucket/README.md
+++ b/modules/vpc-flow-logs-bucket/README.md
@@ -39,7 +39,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_flow_logs_s3_bucket"></a> [flow\_logs\_s3\_bucket](#module\_flow\_logs\_s3\_bucket) | cloudposse/vpc-flow-logs-s3-bucket/aws | 0.18.0 |
+| <a name="module_flow_logs_s3_bucket"></a> [flow\_logs\_s3\_bucket](#module\_flow\_logs\_s3\_bucket) | cloudposse/vpc-flow-logs-s3-bucket/aws | 1.0.1 |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 

--- a/modules/vpc-flow-logs-bucket/main.tf
+++ b/modules/vpc-flow-logs-bucket/main.tf
@@ -1,6 +1,6 @@
 module "flow_logs_s3_bucket" {
   source  = "cloudposse/vpc-flow-logs-s3-bucket/aws"
-  version = "0.18.0"
+  version = "1.0.1"
 
   lifecycle_prefix                   = var.lifecycle_prefix
   lifecycle_tags                     = var.lifecycle_tags


### PR DESCRIPTION
## what

- update the `vpc-flow-logs-s3-bucket` module to 1.0.1 in `vpc-flow-logs-bucket`

## why

- the new aws provider complains about iam policies
