### PR TITLE
Handle `enabled: false` with Deprecated `eks/efs-controller`

### DIFF
--- a/deprecated/eks/efs-controller/main.tf
+++ b/deprecated/eks/efs-controller/main.tf
@@ -50,7 +50,7 @@ module "efs_controller" {
         # annotations:
         #   storageclass.kubernetes.io/is-default-class: "true"
         parameters = {
-          fileSystemId     = module.efs.outputs.efs_id
+          fileSystemId     = local.enabled ? module.efs.outputs.efs_id : ""
           provisioningMode = "efs-ap"
           directoryPerms   = "700"
           basePath         = "/efs_controller"


### PR DESCRIPTION
## what
- The `eks/efs-controller` is now deprecated and replaced by `eks/storage-class`, yet this is a simple fix.
- Conditionally get the `efs` ID only if the component is enabled

## why
- If no condition is set, the output lookup will fail if EFS is not deployed (with both `enabled: false`)

## references
```
Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: Unsupported attribute
│ 
│   on main.tf line 53, in module "efs_controller":
│   53:           fileSystemId     = module.efs.outputs.efs_id
│     ├────────────────
│     │ module.efs.outputs is object with 1 attribute "efs_host"
│ 
│ This object does not have an attribute named "efs_id".
╵
[01HCJ1RR2820WGGN828BCZPDTK] Unexpected exit code when planning changes: 1
```