### PR TITLE
Variable names for `aurora-mysql`

### DIFF
--- a/modules/aurora-mysql/README.md
+++ b/modules/aurora-mysql/README.md
@@ -73,9 +73,9 @@ components:
           - aurora-mysql/defaults
       vars:
         instance_type: db.r5.large
-        cluster_size: 1
-        cluster_name: main
-        database_name: main
+        mysql_cluster_size: 1
+        mysql_name: main
+        mysql_db_name: main
 ```
 
 Example deployment with primary cluster deployed to us-east-1 in a `platform-dev` account: `atmos terraform apply aurora-mysql/dev -s platform-use1-dev`

--- a/modules/aurora-mysql/ssm.tf
+++ b/modules/aurora-mysql/ssm.tf
@@ -34,7 +34,7 @@ locals {
       overwrite   = true
     }
   ]
-  cluster_parameters = var.cluster_size > 0 ? [
+  cluster_parameters = var.mysql_cluster_size > 0 ? [
     {
       name        = format("%s/%s", local.ssm_path_prefix, "replicas_hostname")
       value       = module.aurora_mysql.replicas_host


### PR DESCRIPTION
## what
- Corrected variable names for the `aurora-mysql` component

## why
- `var.cluster_size` is used in `aurora-postgres`, not `aurora-mysql`. This should be `var.mysql_cluster_size`
- The Readme referred to incorrect variable names

## references
- JBI-153