### PR TITLE
`eks/external-secrets-operator` Overridable Additional Policy Statements

### DIFF
--- a/modules/eks/external-secrets-operator/README.md
+++ b/modules/eks/external-secrets-operator/README.md
@@ -111,8 +111,8 @@ components:
 |------|--------|---------|
 | <a name="module_account_map"></a> [account\_map](#module\_account\_map) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
 | <a name="module_eks"></a> [eks](#module\_eks) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
-| <a name="module_external_secrets_operator"></a> [external\_secrets\_operator](#module\_external\_secrets\_operator) | cloudposse/helm-release/aws | 0.10.0 |
-| <a name="module_external_ssm_secrets"></a> [external\_ssm\_secrets](#module\_external\_ssm\_secrets) | cloudposse/helm-release/aws | 0.10.0 |
+| <a name="module_external_secrets_operator"></a> [external\_secrets\_operator](#module\_external\_secrets\_operator) | cloudposse/helm-release/aws | 0.10.1 |
+| <a name="module_external_ssm_secrets"></a> [external\_ssm\_secrets](#module\_external\_ssm\_secrets) | cloudposse/helm-release/aws | 0.10.1 |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../../account-map/modules/iam-roles | n/a |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 

--- a/modules/eks/external-secrets-operator/additional-iam-policy-statements.tf
+++ b/modules/eks/external-secrets-operator/additional-iam-policy-statements.tf
@@ -1,0 +1,17 @@
+locals {
+  # If you have custom policy statements, override this declaration by creating
+  # a file called `additional-iam-policy-statements_override.tf`.
+  # Then add the custom policy statements to the overridable_additional_iam_policy_statements in that file.
+  overridable_additional_iam_policy_statements = [
+    #  {
+    #    sid    = "UseKMS"
+    #    effect = "Allow"
+    #    actions = [
+    #      "kms:Decrypt"
+    #    ]
+    #    resources = [
+    #      "*"
+    #    ]
+    #  }
+  ]
+}

--- a/modules/eks/external-secrets-operator/remote-state.tf
+++ b/modules/eks/external-secrets-operator/remote-state.tf
@@ -8,11 +8,13 @@ module "eks" {
 }
 
 module "account_map" {
-  source      = "cloudposse/stack-config/yaml//modules/remote-state"
-  version     = "1.5.0"
+  source  = "cloudposse/stack-config/yaml//modules/remote-state"
+  version = "1.5.0"
+
   component   = "account-map"
   tenant      = module.iam_roles.global_tenant_name
   environment = module.iam_roles.global_environment_name
   stage       = module.iam_roles.global_stage_name
-  context     = module.this.context
+
+  context = module.this.context
 }


### PR DESCRIPTION
## what
- Update module versions
- Add optional override for additional policies for `eks/external-secrets-operator`

## why
- We may want to grant additional access to the operator. With the override pattern, we can grant whatever we need for specific use-case and avoid conflicts with upstream

## references
- override pattern reference: https://github.com/cloudposse/terraform-aws-components/blob/main/modules/aws-teams/additional-policy-map.tf
