### PR TITLE
ref: spacelift/admin-stack supports custom spaces components

### DIFF
--- a/modules/spacelift/admin-stack/README.md
+++ b/modules/spacelift/admin-stack/README.md
@@ -237,6 +237,7 @@ components:
 | <a name="input_showcase"></a> [showcase](#input\_showcase) | Showcase settings | `map(any)` | `null` | no |
 | <a name="input_space_id"></a> [space\_id](#input\_space\_id) | Place the stack in the specified space\_id. | `string` | `"root"` | no |
 | <a name="input_spacelift_run_enabled"></a> [spacelift\_run\_enabled](#input\_spacelift\_run\_enabled) | Enable/disable creation of the `spacelift_run` resource | `bool` | `false` | no |
+| <a name="input_spacelift_spaces_component_name"></a> [spacelift\_spaces\_component\_name](#input\_spacelift\_spaces\_component\_name) | The component name of the spacelift spaces component | `string` | `"spacelift/spaces"` | no |
 | <a name="input_spacelift_spaces_environment_name"></a> [spacelift\_spaces\_environment\_name](#input\_spacelift\_spaces\_environment\_name) | The environment name of the spacelift spaces component | `string` | `null` | no |
 | <a name="input_spacelift_spaces_stage_name"></a> [spacelift\_spaces\_stage\_name](#input\_spacelift\_spaces\_stage\_name) | The stage name of the spacelift spaces component | `string` | `null` | no |
 | <a name="input_spacelift_spaces_tenant_name"></a> [spacelift\_spaces\_tenant\_name](#input\_spacelift\_spaces\_tenant\_name) | The tenant name of the spacelift spaces component | `string` | `null` | no |

--- a/modules/spacelift/admin-stack/remote-state.tf
+++ b/modules/spacelift/admin-stack/remote-state.tf
@@ -2,7 +2,7 @@ module "spaces" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
   version = "1.5.0"
 
-  component   = "spacelift/spaces"
+  component   = var.spacelift_spaces_component_name
   environment = try(var.spacelift_spaces_environment_name, module.this.environment)
   stage       = try(var.spacelift_spaces_stage_name, module.this.stage)
   tenant      = try(var.spacelift_spaces_tenant_name, module.this.tenant)

--- a/modules/spacelift/admin-stack/variables.tf
+++ b/modules/spacelift/admin-stack/variables.tf
@@ -278,6 +278,12 @@ variable "spacelift_spaces_tenant_name" {
   default     = null
 }
 
+variable "spacelift_spaces_component_name" {
+  type        = string
+  description = "The component name of the spacelift spaces component"
+  default     = "spacelift/spaces"
+}
+
 variable "spacelift_stack_dependency_enabled" {
   type        = bool
   description = "If enabled, the `spacelift_stack_dependency` Spacelift resource will be used to create dependencies between stacks instead of using the `depends-on` labels. The `depends-on` labels will be removed from the stacks and the trigger policies for dependencies will be detached"


### PR DESCRIPTION
## what

- add variable `spacelift_spaces_component_name`

## why

- allows configuration of alternative names and implementations of
`spacelift/spaces`
