### PR TITLE
All DD monitor names must be namespaced

### DIFF
--- a/modules/datadog-monitor/catalog/monitors/lambda.yaml
+++ b/modules/datadog-monitor/catalog/monitors/lambda.yaml
@@ -2,7 +2,7 @@
 # https://docs.datadoghq.com/api/v1/monitors/#create-a-monitor
 
 lambda-errors:
-  name: AWS Lambda [{{functionname.name}}] has errors
+  name: "(Lambda) ${tenant} ${ stage } - Lambda [{{functionname.name}}] has errors
   type: query alert
   query: sum(last_5m):sum:aws.lambda.errors{*} by {stage,tenant,environment,functionname}.as_count() > 0
   message: |

--- a/modules/datadog-monitor/catalog/monitors/lambda.yaml
+++ b/modules/datadog-monitor/catalog/monitors/lambda.yaml
@@ -2,7 +2,7 @@
 # https://docs.datadoghq.com/api/v1/monitors/#create-a-monitor
 
 lambda-errors:
-  name: "(Lambda) ${tenant} ${ stage } - Lambda [{{functionname.name}}] has errors
+  name: "(Lambda) ${tenant} ${ stage } - Lambda [{{functionname.name}}] has errors"
   type: query alert
   query: sum(last_5m):sum:aws.lambda.errors{*} by {stage,tenant,environment,functionname}.as_count() > 0
   message: |


### PR DESCRIPTION
## what

All DD monitor names must be namespaced

## why

Otherwise it will not deploy to a multi-stage env

