### PR TITLE
[opgenie-team] Bugfix: add members to teams

### DIFF
--- a/modules/opsgenie-team/CHANGELOG.md
+++ b/modules/opsgenie-team/CHANGELOG.md
@@ -1,0 +1,16 @@
+## Changes in PR #889, expected Component version ~1.334.0
+
+### `team` replaced with `team_options`
+
+The `team` variable has been replaced with `team_options` to reduce confusion.
+The component only ever creates at most one team, with the name
+specified in the `name` variable. The `team` variable was introduced to
+provide a single object to specify other options, but was not implemented
+properly.
+
+### Team membership now managed by this component by default
+
+Previously, the default behavior was to not manage team membership,
+allowing users to be managed via the Opsgenie UI. Now the default is to manage
+via the `members` input. To restore the previous behavior, set
+`team_options.ignore_members` to `true`.

--- a/modules/opsgenie-team/README.md
+++ b/modules/opsgenie-team/README.md
@@ -7,12 +7,12 @@ This component is responsible for provisioning Opsgenie teams and related servic
 #### Pre-requisites
 You need an API Key stored in `/opsgenie/opsgenie_api_key` of SSM, this is configurable using the `ssm_parameter_name_format` and `ssm_path` variables.
 
-Generate an API Key by going [here](https://id.atlassian.com/manage-profile/security/api-tokens) and Clicking **Create API Token**.
+Generate an API Key by going [here](https://1898andco.app.opsgenie.com/settings/api-key-management) and Clicking **Create API Token**.
 
 Once you have the key, you'll need to test it with a curl to verify that you are at least
 on a Standard plan with OpsGenie:
 ```
-curl -X GET 'https://api.opsgenie.com/v2/account'
+curl -X GET 'https://api.opsgenie.com/v2/account' \
     --header "Authorization: GenieKey $API_KEY"
 ```
 
@@ -28,7 +28,7 @@ The result should be something similar to below:
 }
 ```
 
-If you see anything other than `Standard` or `Enterprise` in the plan, then you won't be able
+If you see `Free` or `Essentials` in the plan, then you won't be able
 to use this component. You can see more details here:
 [OpsGenie pricing/features](https://www.atlassian.com/software/opsgenie/pricing#)
 
@@ -199,7 +199,7 @@ AWS_PROFILE=foo chamber list opsgenie-team/<team>
 ```
 
 ### ClickOps Work
- - After deploying the opsgenie-team component the created team will have a schedule named after the team. This is purposely left to be clickOps’d so the UI can be used to set who is on call, as that is the usual way (not through code). Additionally We do not want a re-apply of the terraform to delete or shuffle who is planned to be on call, thus we left who is on-call on a schedule out of the component.
+ - After deploying the opsgenie-team component the created team will have a schedule named after the team. This is purposely left to be clickOps’d so the UI can be used to set who is on call, as that is the usual way (not through code). Additionally, we do not want a re-apply of the Terraform to delete or shuffle who is planned to be on call, thus we left who is on-call on a schedule out of the component.
 
 ## Known Issues
 
@@ -210,6 +210,10 @@ The problem is there are 3 different api endpoints in use
 - `/v2/` - robust with some differences from `webapp`
 - `/v1/` - the oldest and furthest from the live UI.
 
+### Cannot create users
+
+This module does not create users. Users must have already been created to be added to a team.
+
 ### Cannot Add dependent Services
 
 - Api Currently doesn't support Multiple ServiceIds for incident Rules
@@ -217,10 +221,6 @@ The problem is there are 3 different api endpoints in use
 ### Cannot Add Stakeholders
 
  - Track the issue: https://github.com/opsgenie/terraform-provider-opsgenie/issues/278
-
-### There isn’t a resource for datadog to create an opsgenie integration so this has to be done manually via ClickOps
-
- - Track the issue: x
 
 ### No Resource to create Slack Integration
 
@@ -271,7 +271,7 @@ Track the issue: https://github.com/opsgenie/terraform-provider-opsgenie/issues/
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9.0 |
 | <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.3.0 |
 | <a name="requirement_opsgenie"></a> [opsgenie](#requirement\_opsgenie) | >= 0.6.7 |
@@ -343,9 +343,9 @@ Track the issue: https://github.com/opsgenie/terraform-provider-opsgenie/issues/
 | <a name="input_ssm_path"></a> [ssm\_path](#input\_ssm\_path) | SSM path | `string` | `"opsgenie"` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
-| <a name="input_team"></a> [team](#input\_team) | Configure the team inputs | `map(any)` | `{}` | no |
 | <a name="input_team_name"></a> [team\_name](#input\_team\_name) | Current OpsGenie Team Name | `string` | `null` | no |
 | <a name="input_team_naming_format"></a> [team\_naming\_format](#input\_team\_naming\_format) | OpsGenie Team Naming Format | `string` | `"%s_%s"` | no |
+| <a name="input_team_options"></a> [team\_options](#input\_team\_options) | Configure the team options.<br>See `opsgenie_team` Terraform resource [documentation](https://registry.terraform.io/providers/opsgenie/opsgenie/latest/docs/resources/team#argument-reference) for more details. | <pre>object({<br>    description              = optional(string)<br>    ignore_members           = optional(bool, false)<br>    delete_default_resources = optional(bool, false)<br>  })</pre> | `{}` | no |
 | <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |
 
 ## Outputs

--- a/modules/opsgenie-team/README.md
+++ b/modules/opsgenie-team/README.md
@@ -7,7 +7,18 @@ This component is responsible for provisioning Opsgenie teams and related servic
 #### Pre-requisites
 You need an API Key stored in `/opsgenie/opsgenie_api_key` of SSM, this is configurable using the `ssm_parameter_name_format` and `ssm_path` variables.
 
-Generate an API Key by going [here](https://1898andco.app.opsgenie.com/settings/api-key-management) and Clicking **Create API Token**.
+Opsgenie is now part of Atlassian, so you need to make sure you are creating
+an Opsgenie API Key, which looks like `abcdef12-3456-7890-abcd-ef0123456789`
+and not an Atlassian API key, which looks like
+
+```shell
+ATAfT3xFfGF0VFXAfl8EmQNPVv1Hlazp3wsJgTmM8Ph7iP-RtQyiEfw-fkDS2LvymlyUOOhc5XiSx46vQWnznCJolq-GMX4KzdvOSPhEWr-BF6LEkJQC4CSjDJv0N7d91-0gVekNmCD2kXY9haUHUSpO4H7X6QxyImUb9VmOKIWTbQi8rf4CF28=63CB21B9
+```
+
+Generate an API Key by going to Settings -> API key management on your Opsgenie
+control panel, which will have an address like `https://<your-org>.app.opsgenie.com/settings/api-key-management`,
+and click the "Add new API key" button. For more information, see the
+[Opsgenie API key management documentation](https://support.atlassian.com/opsgenie/docs/api-key-management/).
 
 Once you have the key, you'll need to test it with a curl to verify that you are at least
 on a Standard plan with OpsGenie:

--- a/modules/opsgenie-team/modules/escalation/main.tf
+++ b/modules/opsgenie-team/modules/escalation/main.tf
@@ -1,19 +1,20 @@
 locals {
-  lookup_teams = distinct(flatten([
+  enabled = module.this.enabled && var.escalation != null && length(var.escalation.rules) > 0
+  lookup_teams = local.enabled ? distinct(flatten([
     for rule in var.escalation.rules :
     rule.recipient.name
     if rule.recipient.type == "team"
-  ]))
-  lookup_users = distinct(flatten([
+  ])) : []
+  lookup_users = local.enabled ? distinct(flatten([
     for rule in var.escalation.rules :
     rule.recipient.name
     if rule.recipient.type == "user"
-  ]))
-  lookup_schedules = distinct(flatten([
+  ])) : []
+  lookup_schedules = local.enabled ? distinct(flatten([
     for rule in var.escalation.rules :
     format(var.team_naming_format, var.team_name, rule.recipient.name)
     if rule.recipient.type == "schedule" && module.this.enabled
-  ]))
+  ])) : []
 }
 
 data "opsgenie_team" "recipient" {

--- a/modules/opsgenie-team/outputs.tf
+++ b/modules/opsgenie-team/outputs.tf
@@ -4,7 +4,7 @@ output "team_members" {
 }
 
 output "team_name" {
-  value       = local.team_name
+  value       = local.enabled ? local.team_name : null
   description = "Team Name"
 }
 
@@ -14,16 +14,16 @@ output "team_id" {
 }
 
 output "integration" {
-  value       = module.integration
+  value       = local.enabled ? module.integration : null
   description = "Integrations created"
 }
 
 output "routing" {
-  value       = module.routing
+  value       = local.enabled ? module.routing : null
   description = "Routing rules created"
 }
 
 output "escalation" {
-  value       = module.escalation
+  value       = local.enabled ? module.escalation : null
   description = "Escalation rules created"
 }

--- a/modules/opsgenie-team/variables.tf
+++ b/modules/opsgenie-team/variables.tf
@@ -46,10 +46,18 @@ variable "integrations_enabled" {
   description = "Whether to enable the integrations submodule or not"
 }
 
-variable "team" {
-  type        = map(any)
+variable "team_options" {
+  type = object({
+    description              = optional(string)
+    ignore_members           = optional(bool, false)
+    delete_default_resources = optional(bool, false)
+  })
+  description = <<-EOT
+    Configure the team options.
+    See `opsgenie_team` Terraform resource [documentation](https://registry.terraform.io/providers/opsgenie/opsgenie/latest/docs/resources/team#argument-reference) for more details.
+    EOT
   default     = {}
-  description = "Configure the team inputs"
+  nullable    = false
 }
 
 variable "escalations" {

--- a/modules/opsgenie-team/versions.tf
+++ b/modules/opsgenie-team/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.3.0"
 
   required_providers {
     aws = {


### PR DESCRIPTION
## what

- Changes to `opsgenie-team`
  - BREAKING CHANGE: `team` replaced with `team_options`
  - Bugfix/breaking change: add members to teams unless explicitly instructed otherwise. Previously the default was to delete all members from the team. 

  
## why

- The `team` input was not properly implemented, so maintaining compatibility is not desirable
- The point of the component is to create a team, and the team's name comes from the `name` input, not the `team` input, so the name of the input was confusing on more than one level
- The intended default was to manage team members via this component

