### PR TITLE
fix: aws-saml/okta-user should handle enable flag

### DIFF
--- a/modules/aws-saml/modules/okta-user/main.tf
+++ b/modules/aws-saml/modules/okta-user/main.tf
@@ -30,13 +30,15 @@ resource "aws_iam_policy" "default" {
 }
 
 resource "aws_iam_user_policy_attachment" "default" {
-  user       = aws_iam_user.default.name
+  count      = local.enabled ? 1 : 0
+  user       = one(aws_iam_user.default[*].name)
   policy_arn = aws_iam_policy.default.arn
 }
 
 # Generate API credentials
 resource "aws_iam_access_key" "default" {
-  user = aws_iam_user.default.name
+  count = local.enabled ? 1 : 0
+  user  = one(aws_iam_user.default[*].name)
 }
 
 resource "aws_ssm_parameter" "okta_user_access_key_id" {

--- a/modules/aws-saml/modules/okta-user/outputs.tf
+++ b/modules/aws-saml/modules/okta-user/outputs.tf
@@ -1,14 +1,14 @@
 output "user_name" {
-  value       = aws_iam_user.default.name
+  value       = one(aws_iam_user.default[*].name)
   description = "User name"
 }
 
 output "user_arn" {
-  value       = aws_iam_user.default.arn
+  value       = one(aws_iam_user.default[*].arn)
   description = "User ARN"
 }
 
 output "ssm_prefix" {
-  value       = "AWS Key for ${aws_iam_user.default.name} is in Systems Manager Parameter Store under ${aws_ssm_parameter.okta_user_access_key_id.name} and ${aws_ssm_parameter.okta_user_secret_access_key.name}"
+  value       = "AWS Key for ${join("", aws_iam_user.default[*].name)} is in Systems Manager Parameter Store under ${aws_ssm_parameter.okta_user_access_key_id.name} and ${aws_ssm_parameter.okta_user_secret_access_key.name}"
   description = "Where to find the AWS API key information for the user"
 }


### PR DESCRIPTION
## what

- make sure references to potentially disabled resources are handled

## why

- aws-saml/okta-user was erroring out on references that didn't handle the
`count` updates from #805
