### PR TITLE
fix: Karpenter resources

### DIFF
--- a/modules/eks/karpenter/main.tf
+++ b/modules/eks/karpenter/main.tf
@@ -129,7 +129,9 @@ module "karpenter" {
       serviceAccount = {
         name = module.this.name
       }
-      resources = var.resources
+      controller = {
+        resources = var.resources
+      }
       rbac = {
         create = var.rbac_enabled
       }


### PR DESCRIPTION
## what

Fix karpenter resources specification

## why

var.resources not picked up by underlying chart

## references

https://github.com/aws/karpenter/blob/00b2f4dc086723645f0f15e2c4dd549996eeaa07/charts/karpenter/values.yaml#L96-L110

```
√ . [cdb-core-gbl-identity-admins] (HOST) infrastructure ⨠ helm get values karpenter
USER-SUPPLIED VALUES:
aws:
  enableENILimitedPodDensity: false
controller:
  env:
  - name: LEADER_ELECT
    value: "false"
  resources:
    limits:
      cpu: "1"
      memory: 1536Mi
    requests:
      cpu: 800m
      memory: 1536Mi


 ⧉  cdb (plat-use1-dev:karpenter)
 √ . [cdb-core-gbl-identity-admins] (HOST) infrastructure ⨠ k get -o yaml pods | grep resources -A 6
      resources:
        limits:
          cpu: "1"
          memory: 1536Mi
        requests:
          cpu: 800m
          memory: 1536Mi
```
