### PR TITLE
Argocd hostname must not depend on ingress name

### DIFF
--- a/modules/eks/argocd/main.tf
+++ b/modules/eks/argocd/main.tf
@@ -46,7 +46,7 @@ locals {
     ] : []
   ))
   regional_service_discovery_domain = "${module.this.environment}.${module.dns_gbl_delegated.outputs.default_domain_name}"
-  host                              = var.host != "" ? var.host : format("%s.%s", coalesce(var.alb_name, var.name), local.regional_service_discovery_domain)
+  host                              = var.host != "" ? var.host : format("%s.%s", var.name, local.regional_service_discovery_domain)
   url                               = format("https://%s", local.host)
 
   oidc_config_map = local.oidc_enabled ? {


### PR DESCRIPTION
## what
hostname for argocd does not depend on the ingress name

## why
We are using a shared alb for our services, so we need to define the name for the alb. With that alb name defined the hostname of argocd changes, but we wanted it still the same.