### PR TITLE
Fixes typo in aws-shield

### DIFF
--- a/modules/aws-shield/main.tf
+++ b/modules/aws-shield/main.tf
@@ -7,7 +7,7 @@ locals {
   # Used to determine correct partition (i.e. - `aws`, `aws-gov`, `aws-cn`, etc.)
   partition = one(data.aws_partition.current[*].partition)
 
-  alb_protection_enabled                     = local.enabled && local.alb_protection_enabled
+  alb_protection_enabled                     = local.enabled && var.alb_protection_enabled
   cloudfront_distribution_protection_enabled = local.enabled && length(var.cloudfront_distribution_ids) > 0
   eip_protection_enabled                     = local.enabled && length(var.eips) > 0
   route53_protection_enabled                 = local.enabled && length(var.route53_zone_names) > 0


### PR DESCRIPTION
## what

- fixes typo in `aws-shield`

## why

- so it will work
