### PR TITLE
fix(aws-shield would fail plan if disabled)

### DIFF
--- a/modules/aws-shield/remote-state.tf
+++ b/modules/aws-shield/remote-state.tf
@@ -1,5 +1,5 @@
 module "alb" {
-  count   = length(var.alb_names) > 0 ? 0 : 1
+  count   = local.alb_protection_enabled == false ? 0 : length(var.alb_names) > 0 ? 0 : 1
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
   version = "1.5.0"
 


### PR DESCRIPTION
## what

- `aws-shield` would fail plan if disabled

## why

- allow workflows to disable `aws-shield` without failure
