### PR TITLE
Bugfix: Okta Submodule in `aws-saml`

### DIFF
--- a/modules/aws-saml/modules/okta-user/main.tf
+++ b/modules/aws-saml/modules/okta-user/main.tf
@@ -30,13 +30,13 @@ resource "aws_iam_policy" "default" {
 }
 
 resource "aws_iam_user_policy_attachment" "default" {
-  user       = aws_iam_user.default.name
+  user       = one(aws_iam_user.default[*].name)
   policy_arn = aws_iam_policy.default.arn
 }
 
 # Generate API credentials
 resource "aws_iam_access_key" "default" {
-  user = aws_iam_user.default.name
+  user = one(aws_iam_user.default[*].name)
 }
 
 resource "aws_ssm_parameter" "okta_user_access_key_id" {

--- a/modules/aws-saml/modules/okta-user/outputs.tf
+++ b/modules/aws-saml/modules/okta-user/outputs.tf
@@ -1,14 +1,14 @@
 output "user_name" {
-  value       = aws_iam_user.default.name
+  value       = one(aws_iam_user.default[*].name)
   description = "User name"
 }
 
 output "user_arn" {
-  value       = aws_iam_user.default.arn
+  value       = one(aws_iam_user.default[*].arn)
   description = "User ARN"
 }
 
 output "ssm_prefix" {
-  value       = "AWS Key for ${aws_iam_user.default.name} is in Systems Manager Parameter Store under ${aws_ssm_parameter.okta_user_access_key_id.name} and ${aws_ssm_parameter.okta_user_secret_access_key.name}"
+  value       = "AWS Key for ${one(aws_iam_user.default[*].name)} is in Systems Manager Parameter Store under ${aws_ssm_parameter.okta_user_access_key_id.name} and ${aws_ssm_parameter.okta_user_secret_access_key.name}"
   description = "Where to find the AWS API key information for the user"
 }


### PR DESCRIPTION
## what

 - Bugfix: `aws-saml` component without okta giving issue about not picking a member of the array since enabled flag was added with count in #805 

## why

- deploy component whether or not okta is used

## references

 - #805 