### PR TITLE
chore: update aws-sso for tfstate safety

### DIFF
--- a/modules/aws-sso/README.md
+++ b/modules/aws-sso/README.md
@@ -176,10 +176,10 @@ components:
 | <a name="module_account_map"></a> [account\_map](#module\_account\_map) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
 | <a name="module_iam_roles_root"></a> [iam\_roles\_root](#module\_iam\_roles\_root) | ../account-map/modules/iam-roles | n/a |
-| <a name="module_permission_sets"></a> [permission\_sets](#module\_permission\_sets) | cloudposse/sso/aws//modules/permission-sets | 1.1.1 |
+| <a name="module_permission_sets"></a> [permission\_sets](#module\_permission\_sets) | cloudposse/sso/aws//modules/permission-sets | 1.2.0 |
 | <a name="module_role_map"></a> [role\_map](#module\_role\_map) | ../account-map/modules/roles-to-principals | n/a |
-| <a name="module_sso_account_assignments"></a> [sso\_account\_assignments](#module\_sso\_account\_assignments) | cloudposse/sso/aws//modules/account-assignments | 1.1.1 |
-| <a name="module_sso_account_assignments_root"></a> [sso\_account\_assignments\_root](#module\_sso\_account\_assignments\_root) | cloudposse/sso/aws//modules/account-assignments | 1.1.1 |
+| <a name="module_sso_account_assignments"></a> [sso\_account\_assignments](#module\_sso\_account\_assignments) | cloudposse/sso/aws//modules/account-assignments | 1.2.0 |
+| <a name="module_sso_account_assignments_root"></a> [sso\_account\_assignments\_root](#module\_sso\_account\_assignments\_root) | cloudposse/sso/aws//modules/account-assignments | 1.2.0 |
 | <a name="module_tfstate"></a> [tfstate](#module\_tfstate) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 

--- a/modules/aws-sso/main.tf
+++ b/modules/aws-sso/main.tf
@@ -1,6 +1,6 @@
 module "permission_sets" {
   source  = "cloudposse/sso/aws//modules/permission-sets"
-  version = "1.1.1"
+  version = "1.2.0"
 
   permission_sets = concat(
     local.overridable_additional_permission_sets,
@@ -19,7 +19,7 @@ module "permission_sets" {
 
 module "sso_account_assignments" {
   source  = "cloudposse/sso/aws//modules/account-assignments"
-  version = "1.1.1"
+  version = "1.2.0"
 
   account_assignments = local.account_assignments
   context             = module.this.context
@@ -27,7 +27,7 @@ module "sso_account_assignments" {
 
 module "sso_account_assignments_root" {
   source  = "cloudposse/sso/aws//modules/account-assignments"
-  version = "1.1.1"
+  version = "1.2.0"
 
   providers = {
     aws = aws.root


### PR DESCRIPTION
## what

- update aws-sso modules to `1.2.0`

## why

- TFState can be corrupted if an empty path is specified for customer managed
policies
- Latest module prevents corruption
