### PR TITLE
Fix fetching setting for plat and dev spacelift stacks

### DIFF
--- a/modules/spacelift/admin-stack/child-stacks.tf
+++ b/modules/spacelift/admin-stack/child-stacks.tf
@@ -121,10 +121,10 @@ module "child_stack" {
   bitbucket_cloud      = try(each.value.bitbucket_cloud, null)
   bitbucket_datacenter = try(each.value.bitbucket_datacenter, null)
   cloudformation       = try(each.value.cloudformation, null)
-  github_enterprise    = try(local.root_admin_stack_config.settings.spacelift.github_enterprise, null)
-  gitlab               = try(local.root_admin_stack_config.settings.spacelift.gitlab, null)
-  pulumi               = try(local.root_admin_stack_config.settings.spacelift.pulumi, null)
-  showcase             = try(local.root_admin_stack_config.settings.spacelift.showcase, null)
+  github_enterprise    = try(each.value.settings.spacelift.github_enterprise, null)
+  gitlab               = try(each.value.settings.spacelift.gitlab, null)
+  pulumi               = try(each.value.settings.spacelift.pulumi, null)
+  showcase             = try(each.value.settings.spacelift.showcase, null)
 
   context = module.this.context
 }


### PR DESCRIPTION
## why
for the plat and core spacelift modules the variable `root_admin_stack_config` is not set. Therefore the stack config null, but in our case we need `github_enterprise` to be set.

## what
Read the config from the stack config as it is there also available.