### PR TITLE
ECS Cluster ALB Subnet decision per ALB

### DIFF
--- a/modules/ecs/main.tf
+++ b/modules/ecs/main.tf
@@ -167,7 +167,7 @@ module "alb" {
   for_each = local.enabled ? var.alb_configuration : {}
 
   vpc_id          = module.vpc.outputs.vpc_id
-  subnet_ids      = var.internal_enabled ? module.vpc.outputs.private_subnet_ids : module.vpc.outputs.public_subnet_ids
+  subnet_ids      = lookup(each.value, "internal_enabled", var.internal_enabled) ? module.vpc.outputs.private_subnet_ids : module.vpc.outputs.public_subnet_ids
   ip_address_type = lookup(each.value, "ip_address_type", "ipv4")
 
   internal = lookup(each.value, "internal_enabled", var.internal_enabled)


### PR DESCRIPTION
## what

Currently the subnets of the alb are configured by `internal_enabled` variable which is at the var level. this means both albs are deployed to the same set of subnets, either public or private.

This PR changes that logic to deploy any loadbalancer with `internal_enabled` which is nested under the `alb_configuration.<LB_Name>` key to the appropriate subnet.

- alb subnets determined by `internal_enabled` flag on each LB

## why
- ALBs are intended to be deployed based on it's configuration, e.g.:
```yaml
internal_enabled: false # (default value) # this now is the default incase not defined per LB below
alb_configuration:
  public:
    internal_enabled: false # redundant but means public LB in public subnets
    route53_record_name: "*.public-platform"
  private:
    internal_enabled: true # specifies this should be placed in private subnets
    route53_record_name: "*.private-platform"
```

## references
 - N/A
