### PR TITLE
New Component: `philips-labs-github-runners`

### DIFF
--- a/modules/philips-labs-github-runners/README.md
+++ b/modules/philips-labs-github-runners/README.md
@@ -1,0 +1,141 @@
+# Component: `philips-labs-github-runners`
+
+This component is responsible for provisioning the surrounding infrastructure for the github runners.
+
+## Prerequisites
+
+* Github App installed on the organization
+  * For more details see [Philips Lab's Setting up a Github App](https://github.com/philips-labs/terraform-aws-github-runner/tree/main#setup-github-app-part-1)
+  * Ensure you create a **PRIVATE KEY** and store it in SSM, **NOT** to be confused with a **Client Secret**. Private Keys are created in the GitHub App Configuration and scrolling to the bottom.
+* Github App ID and private key stored in SSM under `/pl-github-runners/id` (or the value of `var.github_app_id_ssm_path`)
+* Github App Private Key stored in SSM (base64 encoded) under `/pl-github-runners/key` (or the value of `var.github_app_key_ssm_path`)
+
+## Usage
+
+**Stack Level**: Regional
+
+Here's an example snippet for how to use this component.
+
+The following will create
+
+- An API Gateway
+- Lambdas
+- SQS Queue
+- EC2 Launch Template instances
+
+The API Gateway is registered as a webhook within the GitHub app. Which scales up or down, via lambdas, the EC2 Launch Template
+by the number of messages in the SQS queue.
+
+![Architecture](https://github.com/philips-labs/terraform-aws-github-runner/blob/main/docs/component-overview.svg)
+
+```yaml
+components:
+  terraform:
+    philips-labs-github-runners:
+      vars:
+        enabled: true
+```
+
+## Modules
+
+### `webhook-github-app`
+
+This is a fork of https://github.com/philips-labs/terraform-aws-github-runner/tree/main/modules/webhook-github-app.
+
+We customized it until this PR is resolved as it does not update the github app webhook until this is merged.
+* https://github.com/philips-labs/terraform-aws-github-runner/pull/3625
+
+This module also requires an environment variable
+* `GH_TOKEN` - a github token be set
+
+This module also requires the `gh` cli to be installed. Your Dockerfile can be updated to include the following to install it:
+```dockerfile
+ARG GH_CLI_VERSION=2.39.1
+# ...
+ARG GH_CLI_VERSION
+RUN apt-get update && apt-get install -y --allow-downgrades \
+    gh="${GH_CLI_VERSION}-*"
+```
+
+You can disable this module with `enable_update_github_app_webhook` set to `false`. This means you must manually
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9.0 |
+| <a name="requirement_local"></a> [local](#requirement\_local) | >= 2.4.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_fetch_lambdas"></a> [fetch\_lambdas](#module\_fetch\_lambdas) | philips-labs/github-runner/aws//modules/download-lambda | 5.4.0 |
+| <a name="module_github_runner"></a> [github\_runner](#module\_github\_runner) | philips-labs/github-runner/aws | 5.4.0 |
+| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
+| <a name="module_store_read"></a> [store\_read](#module\_store\_read) | cloudposse/ssm-parameter-store/aws | 0.11.0 |
+| <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
+| <a name="module_webhook_github_app"></a> [webhook\_github\_app](#module\_webhook\_github\_app) | ./modules/webhook-github-app | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [random_id.webhook_secret](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br>This is for some rare cases where resources want additional configuration of tags<br>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
+| <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br>in the order they appear in the list. New attributes are appended to the<br>end of the list. The elements of the list are joined by the `delimiter`<br>and treated as a single ID element. | `list(string)` | `[]` | no |
+| <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "descriptor_formats": {},<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "labels_as_tags": [<br>    "unset"<br>  ],<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {},<br>  "tenant": null<br>}</pre> | no |
+| <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between ID elements.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
+| <a name="input_descriptor_formats"></a> [descriptor\_formats](#input\_descriptor\_formats) | Describe additional descriptors to be output in the `descriptors` output map.<br>Map of maps. Keys are names of descriptors. Values are maps of the form<br>`{<br>   format = string<br>   labels = list(string)<br>}`<br>(Type is `any` so the map values can later be enhanced to provide additional options.)<br>`format` is a Terraform format string to be passed to the `format()` function.<br>`labels` is a list of labels, in order, to pass to `format()` function.<br>Label values will be normalized before being passed to `format()` so they will be<br>identical to how they appear in `id`.<br>Default is `{}` (`descriptors` output will be empty). | `any` | `{}` | no |
+| <a name="input_enable_update_github_app_webhook"></a> [enable\_update\_github\_app\_webhook](#input\_enable\_update\_github\_app\_webhook) | Enable updating the github app webhook | `bool` | `false` | no |
+| <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
+| <a name="input_github_app_id_ssm_path"></a> [github\_app\_id\_ssm\_path](#input\_github\_app\_id\_ssm\_path) | Path to the github app id in SSM | `string` | `"/pl-github-runners/id"` | no |
+| <a name="input_github_app_key_ssm_path"></a> [github\_app\_key\_ssm\_path](#input\_github\_app\_key\_ssm\_path) | Path to the github key in SSM | `string` | `"/pl-github-runners/key"` | no |
+| <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for keep the existing setting, which defaults to `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
+| <a name="input_instance_types"></a> [instance\_types](#input\_instance\_types) | List of instance types for the action runner. Defaults are based on runner\_os (al2023 for linux and Windows Server Core for win). | `list(string)` | <pre>[<br>  "m5.large",<br>  "c5.large"<br>]</pre> | no |
+| <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | Controls the letter case of the `tags` keys (label names) for tags generated by this module.<br>Does not affect keys of tags passed in via the `tags` input.<br>Possible values: `lower`, `title`, `upper`.<br>Default value: `title`. | `string` | `null` | no |
+| <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The order in which the labels (ID elements) appear in the `id`.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present. | `list(string)` | `null` | no |
+| <a name="input_label_value_case"></a> [label\_value\_case](#input\_label\_value\_case) | Controls the letter case of ID elements (labels) as included in `id`,<br>set as tag values, and output by this module individually.<br>Does not affect values of tags passed in via the `tags` input.<br>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br>Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.<br>Default value: `lower`. | `string` | `null` | no |
+| <a name="input_labels_as_tags"></a> [labels\_as\_tags](#input\_labels\_as\_tags) | Set of labels (ID elements) to include as tags in the `tags` output.<br>Default is to include all labels.<br>Tags with empty values will not be included in the `tags` output.<br>Set to `[]` to suppress all generated tags.<br>**Notes:**<br>  The value of the `name` tag, if included, will be the `id`, not the `name`.<br>  Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be<br>  changed in later chained modules. Attempts to change it will be silently ignored. | `set(string)` | <pre>[<br>  "default"<br>]</pre> | no |
+| <a name="input_lambda_repo_url"></a> [lambda\_repo\_url](#input\_lambda\_repo\_url) | URL of the lambda repository | `string` | `"https://github.com/philips-labs/terraform-aws-github-runner"` | no |
+| <a name="input_name"></a> [name](#input\_name) | ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.<br>This is the only ID element not also included as a `tag`.<br>The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input. | `string` | `null` | no |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique | `string` | `null` | no |
+| <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br>Characters matching the regex will be removed from the ID elements.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
+| <a name="input_region"></a> [region](#input\_region) | AWS region | `string` | n/a | yes |
+| <a name="input_release_version"></a> [release\_version](#input\_release\_version) | Version of the application | `string` | `"v5.4.0"` | no |
+| <a name="input_repository_white_list"></a> [repository\_white\_list](#input\_repository\_white\_list) | List of github repository full names (owner/repo\_name) that will be allowed to use the github app. Leave empty for no filtering. | `list(string)` | `[]` | no |
+| <a name="input_runner_extra_labels"></a> [runner\_extra\_labels](#input\_runner\_extra\_labels) | Extra (custom) labels for the runners (GitHub). Labels checks on the webhook can be enforced by setting `enable_workflow_job_labels_check`. GitHub read-only labels should not be provided. | `list(string)` | <pre>[<br>  "default"<br>]</pre> | no |
+| <a name="input_scale_up_reserved_concurrent_executions"></a> [scale\_up\_reserved\_concurrent\_executions](#input\_scale\_up\_reserved\_concurrent\_executions) | Amount of reserved concurrent executions for the scale-up lambda function. A value of 0 disables lambda from being triggered and -1 removes any concurrency limitations. | `number` | `-1` | no |
+| <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
+| <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_github_runners"></a> [github\_runners](#output\_github\_runners) | n/a |
+| <a name="output_queues"></a> [queues](#output\_queues) | n/a |
+| <a name="output_ssm_parameters"></a> [ssm\_parameters](#output\_ssm\_parameters) | n/a |
+| <a name="output_webhook"></a> [webhook](#output\_webhook) | Information about the webhook to use to register the runner. |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+## References
+* [cloudposse/terraform-aws-components](https://github.com/cloudposse/terraform-aws-components/tree/master/modules/ecs) - Cloud Posse's upstream component
+
+[<img src="https://cloudposse.com/logo-300x69.svg" height="32" align="right"/>](https://cpco.io/component)

--- a/modules/philips-labs-github-runners/README.md
+++ b/modules/philips-labs-github-runners/README.md
@@ -16,6 +16,14 @@ This component is responsible for provisioning the surrounding infrastructure fo
 
 Here's an example snippet for how to use this component.
 
+```yaml
+components:
+  terraform:
+    philips-labs-github-runners:
+      vars:
+        enabled: true
+```
+
 The following will create
 
 - An API Gateway
@@ -27,14 +35,6 @@ The API Gateway is registered as a webhook within the GitHub app. Which scales u
 by the number of messages in the SQS queue.
 
 ![Architecture](https://github.com/philips-labs/terraform-aws-github-runner/blob/main/docs/component-overview.svg)
-
-```yaml
-components:
-  terraform:
-    philips-labs-github-runners:
-      vars:
-        enabled: true
-```
 
 ## Modules
 

--- a/modules/philips-labs-github-runners/README.md
+++ b/modules/philips-labs-github-runners/README.md
@@ -134,9 +134,9 @@ This is output by the component, and available via the `webhook` output under `e
 
 | Name | Description |
 |------|-------------|
-| <a name="output_github_runners"></a> [github\_runners](#output\_github\_runners) | n/a |
-| <a name="output_queues"></a> [queues](#output\_queues) | n/a |
-| <a name="output_ssm_parameters"></a> [ssm\_parameters](#output\_ssm\_parameters) | n/a |
+| <a name="output_github_runners"></a> [github\_runners](#output\_github\_runners) | Information about the GitHub runners. |
+| <a name="output_queues"></a> [queues](#output\_queues) | Information about the GitHub runner queues. Such as `build_queue_arn` the ARN of the SQS queue to use for the build queue. |
+| <a name="output_ssm_parameters"></a> [ssm\_parameters](#output\_ssm\_parameters) | Information about the SSM parameters to use to register the runner. |
 | <a name="output_webhook"></a> [webhook](#output\_webhook) | Information about the webhook to use to register the runner. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/modules/philips-labs-github-runners/README.md
+++ b/modules/philips-labs-github-runners/README.md
@@ -57,7 +57,12 @@ RUN apt-get update && apt-get install -y --allow-downgrades \
     gh="${GH_CLI_VERSION}-*"
 ```
 
-You can disable this module with `enable_update_github_app_webhook` set to `false`. This means you must manually
+By default, we leave this disabled, as it requires a github token to be set. You can enable it by setting `var.enable_update_github_app_webhook` to `true`.
+When enabled, it will update the github app webhook to point to the API Gateway. This can occur if the API Gateway is deleted and recreated.
+
+When disabled, you will need to manually update the github app webhook to point to the API Gateway.
+This is output by the component, and available via the `webhook` output under `endpoint`.
+
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements

--- a/modules/philips-labs-github-runners/README.md
+++ b/modules/philips-labs-github-runners/README.md
@@ -72,12 +72,13 @@ This is output by the component, and available via the `webhook` output under `e
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 2.4.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 3.0 |
 
 ## Modules
 

--- a/modules/philips-labs-github-runners/context.tf
+++ b/modules/philips-labs-github-runners/context.tf
@@ -1,0 +1,279 @@
+#
+# ONLY EDIT THIS FILE IN github.com/cloudposse/terraform-null-label
+# All other instances of this file should be a copy of that one
+#
+#
+# Copy this file from https://github.com/cloudposse/terraform-null-label/blob/master/exports/context.tf
+# and then place it in your Terraform module to automatically get
+# Cloud Posse's standard configuration inputs suitable for passing
+# to Cloud Posse modules.
+#
+# curl -sL https://raw.githubusercontent.com/cloudposse/terraform-null-label/master/exports/context.tf -o context.tf
+#
+# Modules should access the whole context as `module.this.context`
+# to get the input variables with nulls for defaults,
+# for example `context = module.this.context`,
+# and access individual variables as `module.this.<var>`,
+# with final values filled in.
+#
+# For example, when using defaults, `module.this.context.delimiter`
+# will be null, and `module.this.delimiter` will be `-` (hyphen).
+#
+
+module "this" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0" # requires Terraform >= 0.13.0
+
+  enabled             = var.enabled
+  namespace           = var.namespace
+  tenant              = var.tenant
+  environment         = var.environment
+  stage               = var.stage
+  name                = var.name
+  delimiter           = var.delimiter
+  attributes          = var.attributes
+  tags                = var.tags
+  additional_tag_map  = var.additional_tag_map
+  label_order         = var.label_order
+  regex_replace_chars = var.regex_replace_chars
+  id_length_limit     = var.id_length_limit
+  label_key_case      = var.label_key_case
+  label_value_case    = var.label_value_case
+  descriptor_formats  = var.descriptor_formats
+  labels_as_tags      = var.labels_as_tags
+
+  context = var.context
+}
+
+# Copy contents of cloudposse/terraform-null-label/variables.tf here
+
+variable "context" {
+  type = any
+  default = {
+    enabled             = true
+    namespace           = null
+    tenant              = null
+    environment         = null
+    stage               = null
+    name                = null
+    delimiter           = null
+    attributes          = []
+    tags                = {}
+    additional_tag_map  = {}
+    regex_replace_chars = null
+    label_order         = []
+    id_length_limit     = null
+    label_key_case      = null
+    label_value_case    = null
+    descriptor_formats  = {}
+    # Note: we have to use [] instead of null for unset lists due to
+    # https://github.com/hashicorp/terraform/issues/28137
+    # which was not fixed until Terraform 1.0.0,
+    # but we want the default to be all the labels in `label_order`
+    # and we want users to be able to prevent all tag generation
+    # by setting `labels_as_tags` to `[]`, so we need
+    # a different sentinel to indicate "default"
+    labels_as_tags = ["unset"]
+  }
+  description = <<-EOT
+    Single object for setting entire context at once.
+    See description of individual variables for details.
+    Leave string and numeric variables as `null` to use default value.
+    Individual variable settings (non-null) override settings in context object,
+    except for attributes, tags, and additional_tag_map, which are merged.
+  EOT
+
+  validation {
+    condition     = lookup(var.context, "label_key_case", null) == null ? true : contains(["lower", "title", "upper"], var.context["label_key_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+
+  validation {
+    condition     = lookup(var.context, "label_value_case", null) == null ? true : contains(["lower", "title", "upper", "none"], var.context["label_value_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+variable "enabled" {
+  type        = bool
+  default     = null
+  description = "Set to false to prevent the module from creating any resources"
+}
+
+variable "namespace" {
+  type        = string
+  default     = null
+  description = "ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique"
+}
+
+variable "tenant" {
+  type        = string
+  default     = null
+  description = "ID element _(Rarely used, not included by default)_. A customer identifier, indicating who this instance of a resource is for"
+}
+
+variable "environment" {
+  type        = string
+  default     = null
+  description = "ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT'"
+}
+
+variable "stage" {
+  type        = string
+  default     = null
+  description = "ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release'"
+}
+
+variable "name" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.
+    This is the only ID element not also included as a `tag`.
+    The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input.
+    EOT
+}
+
+variable "delimiter" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Delimiter to be used between ID elements.
+    Defaults to `-` (hyphen). Set to `""` to use no delimiter at all.
+  EOT
+}
+
+variable "attributes" {
+  type        = list(string)
+  default     = []
+  description = <<-EOT
+    ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,
+    in the order they appear in the list. New attributes are appended to the
+    end of the list. The elements of the list are joined by the `delimiter`
+    and treated as a single ID element.
+    EOT
+}
+
+variable "labels_as_tags" {
+  type        = set(string)
+  default     = ["default"]
+  description = <<-EOT
+    Set of labels (ID elements) to include as tags in the `tags` output.
+    Default is to include all labels.
+    Tags with empty values will not be included in the `tags` output.
+    Set to `[]` to suppress all generated tags.
+    **Notes:**
+      The value of the `name` tag, if included, will be the `id`, not the `name`.
+      Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be
+      changed in later chained modules. Attempts to change it will be silently ignored.
+    EOT
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+    Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).
+    Neither the tag keys nor the tag values will be modified by this module.
+    EOT
+}
+
+variable "additional_tag_map" {
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+    Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.
+    This is for some rare cases where resources want additional configuration of tags
+    and therefore take a list of maps with tag key, value, and additional configuration.
+    EOT
+}
+
+variable "label_order" {
+  type        = list(string)
+  default     = null
+  description = <<-EOT
+    The order in which the labels (ID elements) appear in the `id`.
+    Defaults to ["namespace", "environment", "stage", "name", "attributes"].
+    You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present.
+    EOT
+}
+
+variable "regex_replace_chars" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Terraform regular expression (regex) string.
+    Characters matching the regex will be removed from the ID elements.
+    If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits.
+  EOT
+}
+
+variable "id_length_limit" {
+  type        = number
+  default     = null
+  description = <<-EOT
+    Limit `id` to this many characters (minimum 6).
+    Set to `0` for unlimited length.
+    Set to `null` for keep the existing setting, which defaults to `0`.
+    Does not affect `id_full`.
+  EOT
+  validation {
+    condition     = var.id_length_limit == null ? true : var.id_length_limit >= 6 || var.id_length_limit == 0
+    error_message = "The id_length_limit must be >= 6 if supplied (not null), or 0 for unlimited length."
+  }
+}
+
+variable "label_key_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Controls the letter case of the `tags` keys (label names) for tags generated by this module.
+    Does not affect keys of tags passed in via the `tags` input.
+    Possible values: `lower`, `title`, `upper`.
+    Default value: `title`.
+  EOT
+
+  validation {
+    condition     = var.label_key_case == null ? true : contains(["lower", "title", "upper"], var.label_key_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+}
+
+variable "label_value_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Controls the letter case of ID elements (labels) as included in `id`,
+    set as tag values, and output by this module individually.
+    Does not affect values of tags passed in via the `tags` input.
+    Possible values: `lower`, `title`, `upper` and `none` (no transformation).
+    Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.
+    Default value: `lower`.
+  EOT
+
+  validation {
+    condition     = var.label_value_case == null ? true : contains(["lower", "title", "upper", "none"], var.label_value_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+variable "descriptor_formats" {
+  type        = any
+  default     = {}
+  description = <<-EOT
+    Describe additional descriptors to be output in the `descriptors` output map.
+    Map of maps. Keys are names of descriptors. Values are maps of the form
+    `{
+       format = string
+       labels = list(string)
+    }`
+    (Type is `any` so the map values can later be enhanced to provide additional options.)
+    `format` is a Terraform format string to be passed to the `format()` function.
+    `labels` is a list of labels, in order, to pass to `format()` function.
+    Label values will be normalized before being passed to `format()` so they will be
+    identical to how they appear in `id`.
+    Default is `{}` (`descriptors` output will be empty).
+    EOT
+}
+
+#### End of copy of cloudposse/terraform-null-label/variables.tf

--- a/modules/philips-labs-github-runners/main.tf
+++ b/modules/philips-labs-github-runners/main.tf
@@ -1,0 +1,101 @@
+locals {
+  enabled     = var.enabled
+  version     = var.enabled ? var.release_version : null
+  lambda_repo = "https://github.com/philips-labs/terraform-aws-github-runner"
+
+  lambdas = var.enabled ? [
+    {
+      name = "webhook"
+      tag  = local.version
+    },
+    {
+      name = "runners"
+      tag  = local.version
+    },
+    {
+      name = "runner-binaries-syncer"
+      tag  = local.version
+    }
+  ] : []
+}
+
+module "store_read" {
+  count = local.enabled ? 1 : 0
+
+  source  = "cloudposse/ssm-parameter-store/aws"
+  version = "0.11.0"
+
+  parameter_read = [
+    var.github_app_key_ssm_path,
+    var.github_app_id_ssm_path
+  ]
+}
+
+resource "random_id" "webhook_secret" {
+  byte_length = 20
+}
+
+module "fetch_lambdas" {
+  count = local.enabled ? 1 : 0
+
+  source  = "philips-labs/github-runner/aws//modules/download-lambda"
+  version = "5.4.0"
+
+  lambdas = local.lambdas
+}
+
+module "github_runner" {
+  count = local.enabled ? 1 : 0
+
+  source  = "philips-labs/github-runner/aws"
+  version = "5.4.0"
+
+  aws_region = var.region
+  vpc_id     = module.vpc.outputs.vpc_id
+  subnet_ids = module.vpc.outputs.private_subnet_ids
+
+  github_app = {
+    key_base64     = module.store_read[0].map[var.github_app_key_ssm_path]
+    id             = module.store_read[0].map[var.github_app_id_ssm_path]
+    webhook_secret = random_id.webhook_secret.hex
+  }
+
+  # here we hardcode the names of the lambda zips because they always have the same name,
+  # the output of the fetch lambdas module is a list of zip names, which we cannot be certain will have the same order.
+  webhook_lambda_zip                = "webhook.zip"
+  runner_binaries_syncer_lambda_zip = "runner-binaries-syncer.zip"
+  runners_lambda_zip                = "runners.zip"
+
+  enable_organization_runners             = true
+  enable_ssm_on_runners                   = true
+  create_service_linked_role_spot         = true
+  enable_fifo_build_queue                 = true
+  scale_up_reserved_concurrent_executions = var.scale_up_reserved_concurrent_executions
+
+  enable_user_data_debug_logging_runner = true
+
+  # this variable is substituted in the user-data.sh startup script. It cannot point to another script if using a base ami.
+  # instead this will just run after the runner is installed. Hence we use `file` to read the contents of the file which is injected into the user-data.sh
+  userdata_post_install = file("${path.module}/templates/userdata_post_install.sh")
+
+  runner_extra_labels = var.runner_extra_labels
+
+  tags = module.this.tags
+}
+
+module "webhook_github_app" {
+  count = local.enabled && var.enable_update_github_app_webhook ? 1 : 0
+  ## See README.md for more info on why we use this source instead of:
+  # source = "philips-labs/github-runner/aws//modules/webhook-github-app"
+  # version = "5.4.0"
+  source = "./modules/webhook-github-app"
+
+  depends_on = [module.github_runner]
+
+  github_app = {
+    key_base64     = module.store_read[0].map[var.github_app_key_ssm_path]
+    id             = module.store_read[0].map[var.github_app_id_ssm_path]
+    webhook_secret = random_id.webhook_secret.hex
+  }
+  webhook_endpoint = one(module.github_runner[*].webhook.endpoint)
+}

--- a/modules/philips-labs-github-runners/modules/README.md
+++ b/modules/philips-labs-github-runners/modules/README.md
@@ -1,0 +1,22 @@
+# Modules
+
+## `webhook-github-app`
+
+This is a fork of https://github.com/philips-labs/terraform-aws-github-runner/tree/main/modules/webhook-github-app.
+
+We customized it until this PR is resolved as it does not update the github app webhook until this is merged.
+ * https://github.com/philips-labs/terraform-aws-github-runner/pull/3625
+
+This module also requires an environment variable
+  * `GH_TOKEN` - a github token be set
+
+This module also requires the `gh` cli to be installed. Your Dockerfile can be updated to include the following to install it:
+```dockerfile
+ARG GH_CLI_VERSION=2.39.1
+# ...
+ARG GH_CLI_VERSION
+RUN apt-get update && apt-get install -y --allow-downgrades \
+    gh="${GH_CLI_VERSION}-*"
+```
+
+You can disable this module with `enable_update_github_app_webhook` set to `false`. This means you must manually

--- a/modules/philips-labs-github-runners/modules/webhook-github-app/README.md
+++ b/modules/philips-labs-github-runners/modules/webhook-github-app/README.md
@@ -1,0 +1,41 @@
+# Module - Update GitHub App Webhook
+
+> This module is using the local executor to run a bash script.
+
+This module updates the GitHub App webhook with the endpoint and secret and can be changed with the root module. See the examples for usages.
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_null"></a> [null](#provider\_null) | ~> 3 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [null_resource.update_app](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_github_app"></a> [github\_app](#input\_github\_app) | GitHub app parameters, see your github app. Ensure the key is the base64-encoded `.pem` file (the output of `base64 app.private-key.pem`, not the content of `private-key.pem`). | <pre>object({<br>    key_base64     = string<br>    id             = string<br>    webhook_secret = string<br>  })</pre> | n/a | yes |
+| <a name="input_webhook_endpoint"></a> [webhook\_endpoint](#input\_webhook\_endpoint) | The endpoint to use for the webhook, defaults to the endpoint of the runners module. | `string` | n/a | yes |
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/modules/philips-labs-github-runners/modules/webhook-github-app/bin/update-app.sh
+++ b/modules/philips-labs-github-runners/modules/webhook-github-app/bin/update-app.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+set -e
+
+### CHECKS ###
+
+function testCommand() {
+  if ! command -v $1 &> /dev/null
+  then
+      echo "$1 could not be found"
+      exit
+  fi
+}
+
+testCommand gh
+
+# create usages function usages mesaages. APP_ID and APP_PRIVATE_KEY_PATH are required as parameter or environment variable
+usages() {
+    echo "Description: Update the GitHub App webhook configuration with terraform output for the webhook output of the module." >&2
+    echo " " >&2
+    echo "Usage: $0" >&2
+    echo "Usage: $0 [-h]" >&2
+    echo "  <no flags>                   Use environment variables" >&2
+    echo "  -a APP_ID                    GitHub App ID" >&2
+    echo "  -k APP_PRIVATE_KEY_BASE64    Base64 encoded private key of the GitHub App" >&2
+    echo "  -f APP APP_PRIVATE_KEY_FILE  Path to the private key of the GitHub App" >&2
+    echo "  -e WEBHOOK_ENDPOINT          Webhook endpoint" >&2
+    echo "  -s WEBHOOK_SECRET            Webhook secret" >&2
+    echo "  -h                           Show this help message" >&2
+    exit 1
+}
+
+# hadd h flag to show help
+while getopts a:f:k:s:e:h flag
+do
+    case "${flag}" in
+        a) APP_ID=${OPTARG};;
+        f) APP_PRIVATE_KEY_FILE=${OPTARG};;
+        k) APP_PRIVATE_KEY_BASE64=${OPTARG};;
+        e) WEBHOOK_ENDPOINT=${OPTARG};;
+        s) WEBHOOK_SECRET=${OPTARG};;
+        h) usages ;;
+    esac
+done
+
+if [ -z "$APP_ID" ]; then
+  echo "APP_ID must be set"
+  usages
+fi
+
+# check one of variables APP_PRIVATE_KEY_PATH or APP_PRIVATE_KEY are set
+if [ -z "$APP_PRIVATE_KEY_BASE64" ] && [ -z "$APP_PRIVATE_KEY_FILE" ]; then
+  echo "APP_PRIVATE_KEY_BASE64 or APP_PRIVATE_KEY_FILE must be set"
+  usages
+fi
+
+### Terraform outputs ###
+
+if [ -z "$WEBHOOK_ENDPOINT" ]; then
+  testCommand terraform
+  WEBHOOK_ENDPOINT=$(terraform output --raw webhook_endpoint)
+fi
+
+if [ -z "$WEBHOOK_SECRET" ]; then
+  testCommand terraform
+  WEBHOOK_SECRET=$(terraform output --raw webhook_secret)
+fi
+
+### CREATE JWT TOKEN ###
+
+# Generate the JWT header and payload
+HEADER=$(echo -n '{"alg":"RS256","typ":"JWT"}' | base64 | tr -d '\n')
+PAYLOAD=$(echo -n "{\"iat\":$(date +%s),\"exp\":$(( $(date +%s) + 600 )),\"iss\":$APP_ID}" | base64 | tr -d '\n')
+
+# Generate the signature
+if [ -z "$APP_PRIVATE_KEY_BASE64" ]; then
+  APP_PRIVATE_KEY_BASE64=$(cat $APP_PRIVATE_KEY_FILE | base64 | tr -d '\n')
+fi
+
+SIGNATURE=$(echo -n "$HEADER.$PAYLOAD" | openssl dgst -sha256 -sign <(echo "$APP_PRIVATE_KEY_BASE64" | base64 -d) | base64 | tr -d '\n')
+
+JWT_TOKEN="$HEADER.$PAYLOAD.$SIGNATURE"
+
+
+### UPDATE WEBHOOK ###
+
+gh api \
+  --method PATCH \
+  -H "Authorization: Bearer ${JWT_TOKEN}" \
+  -H "Accept: application/vnd.github+json" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  /app/hook/config \
+  -f content_type='json' \
+ -f insecure_ssl='0' \
+ -f secret=${WEBHOOK_SECRET} \
+ -f url=${WEBHOOK_ENDPOINT}

--- a/modules/philips-labs-github-runners/modules/webhook-github-app/main.tf
+++ b/modules/philips-labs-github-runners/modules/webhook-github-app/main.tf
@@ -1,0 +1,13 @@
+resource "null_resource" "update_app" {
+  triggers = {
+    webhook_endpoint = var.webhook_endpoint
+    webhook_secret   = var.github_app.webhook_secret
+    always_run       = timestamp()
+  }
+
+  provisioner "local-exec" {
+    interpreter = ["bash", "-c"]
+    command     = "${path.module}/bin/update-app.sh -e ${var.webhook_endpoint} -s ${var.github_app.webhook_secret} -a ${var.github_app.id} -k ${var.github_app.key_base64}"
+    on_failure  = fail
+  }
+}

--- a/modules/philips-labs-github-runners/modules/webhook-github-app/variables.tf
+++ b/modules/philips-labs-github-runners/modules/webhook-github-app/variables.tf
@@ -1,0 +1,13 @@
+variable "github_app" {
+  description = "GitHub app parameters, see your github app. Ensure the key is the base64-encoded `.pem` file (the output of `base64 app.private-key.pem`, not the content of `private-key.pem`)."
+  type = object({
+    key_base64     = string
+    id             = string
+    webhook_secret = string
+  })
+}
+
+variable "webhook_endpoint" {
+  description = "The endpoint to use for the webhook, defaults to the endpoint of the runners module."
+  type        = string
+}

--- a/modules/philips-labs-github-runners/modules/webhook-github-app/versions.tf
+++ b/modules/philips-labs-github-runners/modules/webhook-github-app/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3"
+    }
+  }
+}

--- a/modules/philips-labs-github-runners/outputs.tf
+++ b/modules/philips-labs-github-runners/outputs.tf
@@ -1,0 +1,16 @@
+output "webhook" {
+  description = "Information about the webhook to use to register the runner."
+  value       = one(module.github_runner[*].webhook)
+}
+
+output "ssm_parameters" {
+  value = one(module.github_runner[*].ssm_parameters)
+}
+
+output "github_runners" {
+  value = one(module.github_runner[*].runners)
+}
+
+output "queues" {
+  value = one(module.github_runner[*].queues)
+}

--- a/modules/philips-labs-github-runners/outputs.tf
+++ b/modules/philips-labs-github-runners/outputs.tf
@@ -4,13 +4,16 @@ output "webhook" {
 }
 
 output "ssm_parameters" {
-  value = one(module.github_runner[*].ssm_parameters)
+  description = "Information about the SSM parameters to use to register the runner."
+  value       = one(module.github_runner[*].ssm_parameters)
 }
 
 output "github_runners" {
-  value = one(module.github_runner[*].runners)
+  description = "Information about the GitHub runners."
+  value       = one(module.github_runner[*].runners)
 }
 
 output "queues" {
-  value = one(module.github_runner[*].queues)
+  description = "Information about the GitHub runner queues. Such as `build_queue_arn` the ARN of the SQS queue to use for the build queue."
+  value       = one(module.github_runner[*].queues)
 }

--- a/modules/philips-labs-github-runners/providers.tf
+++ b/modules/philips-labs-github-runners/providers.tf
@@ -1,0 +1,19 @@
+provider "aws" {
+  region = var.region
+
+  # Profile is deprecated in favor of terraform_role_arn. When profiles are not in use, terraform_profile_name is null.
+  profile = module.iam_roles.terraform_profile_name
+
+  dynamic "assume_role" {
+    # module.iam_roles.terraform_role_arn may be null, in which case do not assume a role.
+    for_each = compact([module.iam_roles.terraform_role_arn])
+    content {
+      role_arn = module.iam_roles.terraform_role_arn
+    }
+  }
+}
+
+module "iam_roles" {
+  source  = "../account-map/modules/iam-roles"
+  context = module.this.context
+}

--- a/modules/philips-labs-github-runners/remote-state.tf
+++ b/modules/philips-labs-github-runners/remote-state.tf
@@ -1,0 +1,8 @@
+module "vpc" {
+  source  = "cloudposse/stack-config/yaml//modules/remote-state"
+  version = "1.5.0"
+
+  component = "vpc"
+
+  context = module.this.context
+}

--- a/modules/philips-labs-github-runners/templates/userdata_post_install.sh
+++ b/modules/philips-labs-github-runners/templates/userdata_post_install.sh
@@ -1,0 +1,3 @@
+
+echo "Installing Custom Packages..."
+yum install -y make

--- a/modules/philips-labs-github-runners/variables.tf
+++ b/modules/philips-labs-github-runners/variables.tf
@@ -1,0 +1,60 @@
+variable "region" {
+  type        = string
+  description = "AWS region"
+}
+
+variable "enable_update_github_app_webhook" {
+  type        = bool
+  description = "Enable updating the github app webhook"
+  default     = false
+}
+
+variable "lambda_repo_url" {
+  type        = string
+  description = "URL of the lambda repository"
+  default     = "https://github.com/philips-labs/terraform-aws-github-runner"
+}
+
+variable "release_version" {
+  type        = string
+  description = "Version of the application"
+  default     = "v5.4.0"
+}
+
+variable "github_app_key_ssm_path" {
+  type        = string
+  description = "Path to the github key in SSM"
+  default     = "/pl-github-runners/key"
+}
+
+variable "github_app_id_ssm_path" {
+  type        = string
+  description = "Path to the github app id in SSM"
+  default     = "/pl-github-runners/id"
+}
+
+variable "runner_extra_labels" {
+  description = "Extra (custom) labels for the runners (GitHub). Labels checks on the webhook can be enforced by setting `enable_workflow_job_labels_check`. GitHub read-only labels should not be provided."
+  type        = list(string)
+  default     = ["default"]
+}
+
+variable "scale_up_reserved_concurrent_executions" {
+  description = "Amount of reserved concurrent executions for the scale-up lambda function. A value of 0 disables lambda from being triggered and -1 removes any concurrency limitations."
+  type        = number
+  # default from philips labs is 1, which gives an error when creating the lambda Specified ReservedConcurrentExecutions for function decreases account's UnreservedConcurrentExecution below its minimum value of [10]
+  # https://github.com/philips-labs/terraform-aws-github-runner/issues/1671
+  default = -1
+}
+
+variable "instance_types" {
+  description = "List of instance types for the action runner. Defaults are based on runner_os (al2023 for linux and Windows Server Core for win)."
+  type        = list(string)
+  default     = ["m5.large", "c5.large"]
+}
+
+variable "repository_white_list" {
+  description = "List of github repository full names (owner/repo_name) that will be allowed to use the github app. Leave empty for no filtering."
+  type        = list(string)
+  default     = []
+}

--- a/modules/philips-labs-github-runners/versions.tf
+++ b/modules/philips-labs-github-runners/versions.tf
@@ -10,5 +10,9 @@ terraform {
       source  = "hashicorp/local"
       version = ">= 2.4.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
   }
 }

--- a/modules/philips-labs-github-runners/versions.tf
+++ b/modules/philips-labs-github-runners/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.0.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.9.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = ">= 2.4.0"
+    }
+  }
+}


### PR DESCRIPTION
## what

 - The [philips-labs/terraform-aws-github-runner](https://github.com/philips-labs/terraform-aws-github-runner) is a popular way to deploy scalable self-hosted GitHub Runners on AWS. This PR introduces a component to deploy those runners.
 - This uses their default example as the basis of this component.

## why

 - When not using EKS and actions runner controller, we need a scalable way to use self-hosted GitHub runners. Currently, we use an ASG-based component. This is slower and less responsive to surges, furthermore, it scales down slower, resulting in higher operating costs.

## references

 * https://github.com/philips-labs/terraform-aws-github-runner
 
## Future Improvements
 - The Philips lab module currently has support for yaml based multi-arch runners. This would fit nicely into the Cloud Posse Reference architecture with stacks and atmos merging.