### PR TITLE
Return `local.identity_account_name` for `spacelift/worker-pool`

### DIFF
--- a/modules/spacelift/worker-pool/iam.tf
+++ b/modules/spacelift/worker-pool/iam.tf
@@ -25,7 +25,8 @@ data "aws_iam_policy_document" "assume_role_policy" {
 }
 
 locals {
-  role_arn_template = module.account_map.outputs.iam_role_arn_templates[local.identity_account_name]
+  identity_account_name = module.account_map.outputs.identity_account_account_name
+  role_arn_template     = module.account_map.outputs.iam_role_arn_templates[local.identity_account_name]
 }
 
 data "aws_iam_policy_document" "default" {


### PR DESCRIPTION
## what
- Added back local definition for `local.identity_account_name` for the `spacelift/worker-pool` component

## why
- This value is used in the `iam.tf` policy
- Only `local.identity_account_id` should have been removed, not `local.identity_account_name`

## references
- https://sweetops.slack.com/archives/C04NBF4JYJV/p1700604335106819