### PR TITLE
fix: `spacelift/worker-pool` AMI User Data Docker Login

### DIFF
--- a/modules/spacelift/worker-pool/templates/user-data.sh
+++ b/modules/spacelift/worker-pool/templates/user-data.sh
@@ -3,7 +3,9 @@
 spacelift() { (
   set -e
 
-  $(aws --region ${ecr_region} ecr get-login --registry-ids ${ecr_account_id} --no-include-email)
+	aws ecr get-login-password --region ${ecr_region} \
+		| docker login --username AWS --password-stdin ${ecr_account_id}.dkr.ecr.${ecr_region}.amazonaws.com
+
   docker pull ${spacelift_runner_image}
 
   echo "Updating packages (security)" | tee -a /var/log/spacelift/info.log

--- a/modules/spacelift/worker-pool/templates/user-data.sh
+++ b/modules/spacelift/worker-pool/templates/user-data.sh
@@ -3,8 +3,8 @@
 spacelift() { (
   set -e
 
-	aws ecr get-login-password --region ${ecr_region} \
-		| docker login --username AWS --password-stdin ${ecr_account_id}.dkr.ecr.${ecr_region}.amazonaws.com
+  aws ecr get-login-password --region ${ecr_region} \
+    | docker login --username AWS --password-stdin ${ecr_account_id}.dkr.ecr.${ecr_region}.amazonaws.com
 
   docker pull ${spacelift_runner_image}
 


### PR DESCRIPTION
## what
- Updated CLI command to log into docker in Spacelift Worker Pool user data

## why
- Spacelift has updated the AWS CLI in their AMIs, creating a breaking change. This is a quote from Spacelift

> [...] you have a very good point about this being an unannounced breaking change. we’ll prepare an announcment today, and we’ll try to think about introducing semver into this process. sorry for the inconvenience.

## references
- https://sweetops.slack.com/archives/C04NBF4JYJV/p1700606072243389
- https://sweetops.slack.com/archives/C04NBF4JYJV/p1700652828337319
- https://github.com/spacelift-io/spacelift-worker-image/releases/tag/1.0.0
