### PR TITLE
fix: `bastion` userdata volume mount

### DIFF
--- a/modules/bastion/templates/user-data.sh
+++ b/modules/bastion/templates/user-data.sh
@@ -1,13 +1,5 @@
 #!/bin/bash
 
-# Mount additional volume
-echo "Mounting additional volume..."
-while [ ! -b $(readlink -f /dev/sdh) ]; do echo 'waiting for device /dev/sdh'; sleep 5 ; done
-blkid $(readlink -f /dev/sdh) || mkfs -t ext4 $(readlink -f /dev/sdh)
-e2label $(readlink -f /dev/sdh) sdh-volume
-grep -q ^LABEL=sdh-volume /etc/fstab || echo 'LABEL=sdh-volume /mnt ext4 defaults' >> /etc/fstab
-grep -q \"^$(readlink -f /dev/sdh) /mnt \" /proc/mounts || mount /mnt
-
 # Install docker
 echo "Installing docker..."
 amazon-linux-extras install docker


### PR DESCRIPTION
## what
- removed volume mount steps from `bastion` userdata

## why
- there is no additional volume or block storage attached to a bastion instance. So userdata would get stuck at this step and fail to complete.

```console
[  345.411338] cloud-init[2351]: waiting for device /dev/sdh
```

## references
- https://sweetops.slack.com/archives/CDYGZCLDQ/p1701787882992429