### PR TITLE
feature(tgw): allow specifying of arbitrary destinations on the tgw spoke

### DIFF
--- a/modules/tgw/spoke/main.tf
+++ b/modules/tgw/spoke/main.tf
@@ -50,6 +50,7 @@ module "tgw_spoke_vpc_attachment" {
   expose_eks_sg        = var.expose_eks_sg
   peered_region        = var.peered_region
   static_routes        = var.static_routes
+  static_tgw_routes    = var.static_tgw_routes
 
   context = module.this.context
 }

--- a/modules/tgw/spoke/modules/standard_vpc_attachment/main.tf
+++ b/modules/tgw/spoke/modules/standard_vpc_attachment/main.tf
@@ -138,7 +138,7 @@ module "standard_vpc_attachment" {
       route_to                          = null
       static_routes                     = var.static_routes
       transit_gateway_vpc_attachment_id = null
-      route_to_cidr_blocks              = [for vpc in local.allowed_vpcs : vpc.cidr if !vpc.cross_region]
+      route_to_cidr_blocks              = concat([for vpc in local.allowed_vpcs : vpc.cidr if !vpc.cross_region], var.static_tgw_routes)
     }
   }
 

--- a/modules/tgw/spoke/modules/standard_vpc_attachment/variables.tf
+++ b/modules/tgw/spoke/modules/standard_vpc_attachment/variables.tf
@@ -61,6 +61,12 @@ variable "static_routes" {
   default     = []
 }
 
+variable "static_tgw_routes" {
+  type        = list(string)
+  description = "A list of static routes to add to the local routing table with the transit gateway as a destination."
+  default     = []
+}
+
 variable "expose_eks_sg" {
   type        = bool
   description = "Set true to allow EKS clusters to accept traffic from source accounts"

--- a/modules/tgw/spoke/variables.tf
+++ b/modules/tgw/spoke/variables.tf
@@ -72,9 +72,13 @@ variable "static_routes" {
     blackhole              = bool
     destination_cidr_block = string
   }))
-  description = <<-EOT
-  A list of static routes.
-  EOT
+  description = "A list of static routes to add to the transit gateway, pointing at this VPC as a destination."
+  default     = []
+}
+
+variable "static_tgw_routes" {
+  type        = list(string)
+  description = "A list of static routes to add to the local routing table with the transit gateway as a destination."
   default     = []
 }
 


### PR DESCRIPTION
## what

Allow the Transit Gateway spoke to specify static routes to send to the Transit Gateway

## why

This allows users to configure the TGW spoke's local routing tables with CIDR destinations such as an external account's VPC that can't be looked up with remote state