### PR TITLE
New component deploying GitHub Action Runner Scale Sets

### DIFF
--- a/modules/aurora-postgres-resources/README.md
+++ b/modules/aurora-postgres-resources/README.md
@@ -22,8 +22,25 @@ components:
               - grant: [ "ALL" ]
                 db: example
                 object_type: database
-                schema: null
+                schema: ""
 ```
+
+## PostgreSQL Quick Reference on Grants
+
+GRANTS can be on database, schema, role, table, and other database objects (e.g. columns in a table for fine control). Database and schema do not have much to grant. The `object_type` field in the input determines which kind of object the grant is being applied to. The `db` field is always required. The `schema` field is required unless the `object_type` is `db`, in which case it should be set to the empty string (`""`).
+
+The key word PUBLIC indicates that the privileges are to be granted to all roles, including those that might be created later. PUBLIC can be thought of as an implicitly defined group that always includes all roles. Any particular role will have the sum of privileges granted directly to it, privileges granted to any role it is presently a member of, and privileges granted to PUBLIC.
+
+When an object is created, it is assigned an owner. The owner is normally the role that executed the creation statement. For most kinds of objects, the initial state is that only the owner (or a superuser) can do anything with the object. To allow other roles to use it, privileges must be granted. (When using AWS managed RDS, you cannot have access to any superuser roles; superuser is reserved for AWS to use to manage the cluster.)
+
+PostgreSQL grants privileges on some types of objects to PUBLIC by default when the objects are created. No privileges are granted to PUBLIC by default on tables, table columns, sequences, foreign data wrappers, foreign servers, large objects, schemas, or tablespaces. For other types of objects, the default privileges granted to PUBLIC are as follows: CONNECT and TEMPORARY (create temporary tables) privileges for databases; EXECUTE privilege for functions and procedures; and USAGE privilege for languages and data types (including domains). The object owner can, of course, REVOKE both default and expressly granted privileges. (For maximum security, issue the REVOKE in the same transaction that creates the object; then there is no window in which another user can use the object.) Also, these default privilege settings can be overridden using the ALTER DEFAULT PRIVILEGES command.
+
+The CREATE privilege:
+- For databases, allows new schemas and publications to be created within the database, and allows trusted extensions to be installed within the database.
+- For schemas, allows new objects to be created within the schema. To rename an existing object, you must own the object and have this privilege for the containing schema.
+
+For databases and schemas, there are not a lot of other privileges to grant, and all but CREATE are granted by default, so you might as well grant "ALL".  For tables etc., the creator has full control. You grant access to other users via explicit grants. This component does not allow fine-grained grants. You have to specify the database, and unless the grant is on the database, you have to specify the schema. For any other object type (table, sequence, function, procedure, routine, foreign_data_wrapper, foreign_server, column), the component applies the grants to all objects of that type in the specified schema.
+
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
@@ -109,5 +126,8 @@ components:
 ## References
 * [cloudposse/terraform-aws-components](https://github.com/cloudposse/terraform-aws-components/tree/master/modules/aurora-postgres-resources) - Cloud Posse's upstream component
 
+* PostgreSQL references (select the correct version of PostgreSQL at the top of the page):
+  * [GRANT command](https://www.postgresql.org/docs/14/sql-grant.html)
+  * [Privileges that can be GRANTed](https://www.postgresql.org/docs/14/ddl-priv.html)
 
 [<img src="https://cloudposse.com/logo-300x69.svg" height="32" align="right"/>](https://cpco.io/component)

--- a/modules/aurora-postgres-resources/README.md
+++ b/modules/aurora-postgres-resources/README.md
@@ -29,7 +29,7 @@ components:
 
 GRANTS can be on database, schema, role, table, and other database objects (e.g. columns in a table for fine control). Database and schema do not have much to grant. The `object_type` field in the input determines which kind of object the grant is being applied to. The `db` field is always required. The `schema` field is required unless the `object_type` is `db`, in which case it should be set to the empty string (`""`).
 
-The key word PUBLIC indicates that the privileges are to be granted to all roles, including those that might be created later. PUBLIC can be thought of as an implicitly defined group that always includes all roles. Any particular role will have the sum of privileges granted directly to it, privileges granted to any role it is presently a member of, and privileges granted to PUBLIC.
+The keyword PUBLIC indicates that the privileges are to be granted to all roles, including those that might be created later. PUBLIC can be thought of as an implicitly defined group that always includes all roles. Any particular role will have the sum of privileges granted directly to it, privileges granted to any role it is presently a member of, and privileges granted to PUBLIC.
 
 When an object is created, it is assigned an owner. The owner is normally the role that executed the creation statement. For most kinds of objects, the initial state is that only the owner (or a superuser) can do anything with the object. To allow other roles to use it, privileges must be granted. (When using AWS managed RDS, you cannot have access to any superuser roles; superuser is reserved for AWS to use to manage the cluster.)
 

--- a/modules/eks/github-actions-runner/CHANGELOG.md
+++ b/modules/eks/github-actions-runner/CHANGELOG.md
@@ -1,0 +1,166 @@
+## Initial Release
+
+This release has been tested and used in production, but testing has not covered
+all available features. Please use with caution and report any issues you
+encounter.
+
+### Migration from `actions-runner-controller`
+
+GitHub has released its own official self-hosted GitHub Actions Runner support,
+replacing the `actions-runner-controller` implementation developed by Summerwind.
+(See the [announcement from GitHub](https://github.com/actions/actions-runner-controller/discussions/2072).)
+Accordingly, this component is a replacement for the [`actions-runner-controller`](https://github.com/cloudposse/terraform-aws-components/tree/main/modules/eks/actions-runner-controller)
+component. Although there are different defaults for some of the configuration options, if
+you are already using `actions-runner-controller` you should be able to reuse
+the GitHub app or PAT and image pull secret you are already using, making
+migration relatively straightforward.
+
+We recommend deploying this component into a separate namespace (or namespaces)
+than `actions-runner-controller` and get the new runners sets running before
+you remove the old ones. You can then migrate your workflows to use the new
+runners sets and have zero downtime.
+
+Major differences:
+- Self-hosted runners, such as are deployed with the `actions-runner-controller`
+  component, are targeted by a set of labels indicated by a workflow's `runs-on`
+  array, of which the first must be "self-hosted". Runner Sets, such as are
+  deployed with this component, are targeted by a single label, which is the
+  name of the Runner Set. This means that you will need to update your workflows
+  to target the new Runner Set label. See [here](https://github.com/actions/actions-runner-controller/discussions/2921#discussioncomment-7501051)
+  for the reasoning behind GitHub's decision to use a single label instead of a set.
+- The `actions-runner-controller` component includes a custom Helm chart for
+  the runners, whereas this component uses the official Helm chart. This means
+  that this component requires configuration of 2 charts, although both should be
+  kept at the same version.
+- The `actions-runner-controller` component has a `resources/values.yaml` file
+  that provided defaults for the controller Helm chart. This component does not have
+  files like that by default, but supports a `resources/values-controller.yaml` file
+  for the "gha-runner-scale-set-controller" chart and a `resources/values-runner.yaml`
+  file for the "gha-runner-scale-set" chart.
+- The default values for the SSM paths for the GitHub auth secret and the imagePullSecret
+  have changed. Specify the old values explicitly to keep using the same secrets.
+- The `actions-runner-controller` component creates an IAM Role (IRSA) for the runners
+  to use. This component does not create an IRSA, because the chart does not support
+  using one while in "dind" mode. Use GitHub OIDC authentication inside your workflows instead.
+- The Runner Sets deployed by this component use a different autoscaling mechanism,
+  so most of the `actions-runner-controller` configuration options related to
+  autoscaling are not applicable.
+- For the same reason, this component does not deploy a webhook listener or Ingress and
+  does not require configuration of a GitHub webhook.
+- The `actions-runner-controller` component has an input named `existing_kubernetes_secret_name`.
+  The equivalent input for this component is `github_kubernetes_secret_name`,
+  in order to clearly distinguish it from the `image_pull_kubernetes_secret_name` input.
+
+### Translating configuration from `actions-runner-controller`
+
+Here is an example configuration for the `github-actions-runner` controller,
+with comments indicating where in the `actions-runner-controller` configuration
+the corresponding configuration option can be copied from.
+
+```yaml
+components:
+  terraform:
+    eks/github-actions-runner:
+      vars:
+        # This first set of values you can just copy from here.
+        # However, if you had customized the standard Helm configuration
+        # (such things as `cleanup_on_fail`, `atmoic`, or `timeout`), you
+        # now need to do that per chart under the `charts` input.
+        enabled: true
+        name: "gha-runner-controller"
+        charts:
+          controller:
+            chart: "gha-runner-scale-set-controller"
+            chart_repository: "oci://ghcr.io/actions/actions-runner-controller-charts"
+            # As of the time of the creation of this component, 0.7.0 is the latest version
+            # of the chart. If you use a newer version, check for breaking changes
+            # and any updates to this component that may be required.
+            # Find the latest version at https://github.com/actions/actions-runner-controller/blob/master/charts/gha-runner-scale-set-controller/Chart.yaml#L18
+            chart_version: "0.7.0"
+          runner_sets:
+            chart: "gha-runner-scale-set"
+            chart_repository:
+            # We expect that the runner set chart will always be at the same version as the controller chart,
+            # but the charts are still in pre-release so that may change.
+            chart_version: "0.7.0"
+        controller:
+          # These inputs from `actions-runner-controller` are now parts of the controller configuration input
+          kubernetes_namespace: "gha-runner-controller"
+          create_namespace: true
+          replicas: 1 # From `actions-runner-controller` file `resources/values.yaml`, value `replicaCount`
+          # resources from var.resources
+
+
+
+        # These values can be copied directly from the `actions-runner-controller` configuration
+        ssm_github_secret_path: "/github_runners/controller_github_app_secret"
+        github_app_id: "250828"
+        github_app_installation_id: "30395627"
+
+
+        # These values require some converstion from the `actions-runner-controller` configuration
+        # Set `create_github_kubernetes_secret` to `true` if `existing_kubernetes_secret_name` was not set, `false` otherwise.
+        create_github_kubernetes_secret: true
+        # If `existing_kubernetes_secret_name` was set, copy the setting to `github_kubernetes_secret_name` here.
+        # github_kubernetes_secret_name: <existing_kubernetes_secret_name>
+
+        # To configure imagePullSecrets:
+        # Set `image_pull_secret_enabled` to the value of `docker_config_json_enabled` in `actions-runner-controller` configuration.
+        image_pull_secret_enabled: true
+        # Set `ssm_image_pull_secret_path` to the value of `ssm_docker_config_json_path` in `actions-runner-controller` configuration.
+        ssm_image_pull_secret_path: "/github_runners/docker/config-json"
+
+        # To configure the runner sets, there is still a map of `runners`, but most
+        # of the configuration options from `actions-runner-controller` are not applicable.
+        # Most of the applicable configuration options are the same as for `actions-runner-controller`.
+        runners:
+          # The name of the runner set is the key of the map. The name is now the only label
+          # that is used to target the runner set.
+          self-hosted-default:
+            # Namespace is new. The `actions-runner-controller` always deployed the runners to the same namespace as the controller.
+            # Runner sets support deploying the runners in a namespace other than the controller,
+            # and it is recommended to do so. If you do not set kubernetes_namespace, the runners will be deployed
+            # in the same namespace as the controller.
+            kubernetes_namespace: "gha-runner-private"
+            # Set create_namespace to false if the namespace has been created by another component.
+            create_namespace: true
+
+            # `actions-runner-controller` had a `dind_enabled` input that was switch between "kubernetes" and "dind" mode.
+            # This component has a `mode` input that can be set to "kubernetes" or "dind".
+            mode: "dind"
+
+            # Where the `actions-runner-controller` configuration had `type` and `scope`,
+            # the runner set has `github_url`. For organization scope runners, use https://github.com/myorg
+            # (or, if you are using Enterprise GitHub, your GitHub Enterprise URL).
+            # For repo runners, use the repo URL, e.g. https://github.com/myorg/myrepo
+            github_url: https://github.com/cloudposse
+
+            # These configuration options are the same as for `actions-runner-controller`
+            #   group: "default"
+            #   node_selector:
+            #     kubernetes.io/os: "linux"
+            #     kubernetes.io/arch: "arm64"
+            #   tolerations:
+            #   - key: "kubernetes.io/arch"
+            #     operator: "Equal"
+            #     value: "arm64"
+            #     effect: "NoSchedule"
+            # If min_replicas > 0 and you also have do-not-evict: "true" set
+            # then the idle/waiting runner will keep Karpenter from deprovisioning the node
+            # until a job runs and the runner is deleted. So we do not set it by default.
+            # pod_annotations:
+            #   karpenter.sh/do-not-evict: "true"
+            min_replicas: 1
+            max_replicas: 12
+            resources:
+              limits:
+                cpu: 1100m
+                memory: 1024Mi
+                ephemeral-storage: 5Gi
+              requests:
+                cpu: 500m
+                memory: 256Mi
+                ephemeral-storage: 1Gi
+            # The rest of the `actions-runner-controller` configuration is not applicable.
+            # This includes `labels` as well as anything to do with autoscaling.
+```

--- a/modules/eks/github-actions-runner/CHANGELOG.md
+++ b/modules/eks/github-actions-runner/CHANGELOG.md
@@ -21,16 +21,18 @@ you remove the old ones. You can then migrate your workflows to use the new
 runners sets and have zero downtime.
 
 Major differences:
-- Self-hosted runners, such as are deployed with the `actions-runner-controller`
+- Self-hosted runners, such as those deployed with the `actions-runner-controller`
   component, are targeted by a set of labels indicated by a workflow's `runs-on`
   array, of which the first must be "self-hosted". Runner Sets, such as are
   deployed with this component, are targeted by a single label, which is the
   name of the Runner Set. This means that you will need to update your workflows
   to target the new Runner Set label. See [here](https://github.com/actions/actions-runner-controller/discussions/2921#discussioncomment-7501051)
   for the reasoning behind GitHub's decision to use a single label instead of a set.
-- The `actions-runner-controller` component includes a custom Helm chart for
-  the runners, whereas this component uses the official Helm chart. This means
-  that this component requires configuration of 2 charts, although both should be
+- The `actions-runner-controller` component uses the published Helm chart for the
+  controller, but there is none for the runners, so it includes a custom Helm chart
+  for them. However, for Runner Sets, GitHub has published 2 charts, one for the controller
+  and one for the runners (runner sets). This means that this component requires
+  configuration (e.g. version numbers) of 2 charts, although both should be
   kept at the same version.
 - The `actions-runner-controller` component has a `resources/values.yaml` file
   that provided defaults for the controller Helm chart. This component does not have
@@ -70,18 +72,15 @@ components:
         name: "gha-runner-controller"
         charts:
           controller:
-            chart: "gha-runner-scale-set-controller"
-            chart_repository: "oci://ghcr.io/actions/actions-runner-controller-charts"
             # As of the time of the creation of this component, 0.7.0 is the latest version
             # of the chart. If you use a newer version, check for breaking changes
             # and any updates to this component that may be required.
             # Find the latest version at https://github.com/actions/actions-runner-controller/blob/master/charts/gha-runner-scale-set-controller/Chart.yaml#L18
             chart_version: "0.7.0"
           runner_sets:
-            chart: "gha-runner-scale-set"
-            chart_repository:
             # We expect that the runner set chart will always be at the same version as the controller chart,
             # but the charts are still in pre-release so that may change.
+            # Find the latest version at https://github.com/actions/actions-runner-controller/blob/master/charts/gha-runner-scale-set/Chart.yaml#L18
             chart_version: "0.7.0"
         controller:
           # These inputs from `actions-runner-controller` are now parts of the controller configuration input

--- a/modules/eks/github-actions-runner/README.md
+++ b/modules/eks/github-actions-runner/README.md
@@ -169,8 +169,8 @@ things as register runners and pickup jobs. You can authenticate using either
 a [GitHub App](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners-with-actions-runner-controller/authenticating-to-the-github-api#authenticating-arc-with-a-github-app)
 or a [Personal Access Token (classic)](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners-with-actions-runner-controller/authenticating-to-the-github-api#authenticating-arc-with-a-personal-access-token-classic).
 The preferred way to authenticate is by _creating_ and _installing_ a GitHub
-App. This is the recommended approach as it allows for more much more restricted
-access than using a Personal Access Token (classic), and the Action Runners to
+App. This is the recommended approach as it allows for much more restricted
+access than using a Personal Access Token (classic), and the Action Runners do
 not currently support using a fine-grained Personal Access Token.
 
 
@@ -191,12 +191,13 @@ you have 2 choices:
    parameters in a new region.
 
 Alternatively, you can create Kubernetes secrets outside of this component
-(perhaps using [SOPS]()) and reference them by name. We describe here how to save the secrets
-to SSM, but you can save the secrets wherever and however you want to, as long
-as you deploy them as Kubernetes secret the runners can reference. If you store
-them in SSM, this component will take care of the rest, but the standard
-Terraform caveat applies: any secrets referenced by Terraform will be stored
-unencrypted in the Terraform state file.
+(perhaps using [SOPS](https://github.com/getsops/sops)) and reference them by
+name. We describe here how to save the secrets to SSM, but you can save the
+secrets wherever and however you want to, as long as you deploy them as
+Kubernetes secret the runners can reference. If you store them in SSM, this
+component will take care of the rest, but the standard Terraform caveat applies:
+any secrets referenced by Terraform will be stored unencrypted in the Terraform
+state file.
 
 #### Creating and Using a GitHub App
 

--- a/modules/eks/github-actions-runner/README.md
+++ b/modules/eks/github-actions-runner/README.md
@@ -1,0 +1,448 @@
+# Component: `github-actions-runner`
+
+This component deploys self-hosted GitHub Actions Runners and a [Controller](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners-with-actions-runner-controller/quickstart-for-actions-runner-controller#introduction)
+on an EKS cluster, using "[runner scale sets](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners-with-actions-runner-controller/deploying-runner-scale-sets-with-actions-runner-controller#runner-scale-set)", on an EKS cluster.
+
+This solution is supported by GitHub and supersedes the [actions-runner-controller](https://github.com/actions/actions-runner-controller/blob/master/docs/about-arc.md) developed
+by Summerwind and deployed by Cloud Posse's [actions-runner-controller](https://docs.cloudposse.com/components/library/aws/eks/actions-runner-controller/) component.
+
+### Current limitations
+
+In the current version of this component, only "dind" (Docker in Docker) mode has been tested.
+Support for "kubernetes" mode is provided, but has not been validated.
+
+Many elements in the Controller chart are not directly configurable by named inputs.
+To configure them, you can use the `controller.chart_values` input or create a
+`resources/values-controller.yaml` file in the component to supply values.
+
+Almost all the features of the Runner Scale Set chart are configurable by named inputs.
+The exceptions are:
+- There is no specific input for specifying an outbound HTTP proxy.
+- There is no specific input for supplying a [custom certificate authority (CA) certificate](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners-with-actions-runner-controller/deploying-runner-scale-sets-with-actions-runner-controller#custom-tls-certificates)
+  to use when connecting to GitHub Enterprise Server.
+
+You can specify these values by creating a `resources/values-runner.yaml` file
+in the component and setting values as shown by the default Helm [values.yaml](https://github.com/actions/actions-runner-controller/blob/master/charts/gha-runner-scale-set/values.yaml),
+and they will be applied to all runners.
+
+Currently, this component has some additional limitations. In particular:
+- The controller and all runners and listeners share the Image Pull Secrets.
+You cannot use different ones for different runners.
+- All the runners use the same GitHub secret (app or PAT). Using a GitHub app
+  is preferred anyway, and the single GitHub app serves the entire organization.
+- Only one controller is supported per cluster, though it can have multiple replicas.
+
+These limitations could be addressed if there is demand. Contact [Cloud Posse Professional Services](https://cloudposse.com/professional-services/)
+if you would be interested in sponsoring the development of any of these features.
+
+### Ephemeral work storage
+
+The runners are configured to use ephemeral storage for workspaces, but the
+details and defaults can be a bit confusing.
+
+When running in "dind" ("Docker in Docker") mode, the default is to use `emptyDir`, which
+means space on the `kubelet` base directory, which is usually the root disk. You
+can manage the amount of storage allowed to be used with `ephemeral_storage` requests and limits,
+or you can just let it use whatever free space there is on the root disk.
+
+When running in `kubernetes` mode, the only supported local disk storage is an
+ephemeral `PersistentVolumeClaim`, which causes a separate disk to be allocated
+for the runner pod. This disk is ephemeral, and will be deleted when the runner
+pod is deleted. When combined with the recommended ephemeral runner
+configuration, this means that a new disk will be created for each job, and
+deleted when the job is complete. That is a lot of overhead and will slow things
+down somewhat.
+
+
+The size of the attached PersistentVolume is controlled
+by `ephemeral_pvc_storage` (a Kubernetes size string like "1G") and the kind of
+storage is controlled by `ephemeral_pvc_storage_class`
+(which can be omitted to use the cluster default storage class).
+
+This mode is also optionally available when using `dind`. To enable it, set
+`ephemeral_pvc_storage` to the desired size. Leave `ephemeral_pvc_storage` at
+the default value of `null` to use `emptyDir` storage (recommended).
+
+Beware that using a PVC may significantly increase the startup of the runner.
+If you are using a PVC, you may want to keep idle runners available so that
+jobs can be started without waiting for a new runner to start.
+
+## Usage
+
+**Stack Level**: Regional
+
+Once the catalog file is created, the file can be imported as follows.
+
+```yaml
+import:
+  - catalog/eks/github-actions-runner
+  ...
+```
+
+The default catalog values `e.g. stacks/catalog/eks/github-actions-runner.yaml`
+
+```yaml
+components:
+  terraform:
+    eks/github-actions-runner:
+      vars:
+        enabled: true
+        ssm_region: "us-east-2"
+        name: "gha-runner-controller"
+        charts:
+          controller:
+            chart_version: "0.7.0"
+          runner_sets:
+            chart_version: "0.7.0"
+        controller:
+          kubernetes_namespace: "gha-runner-controller"
+          create_namespace: true
+
+        create_github_kubernetes_secret: true
+        ssm_github_secret_path: "/github-action-runners/github-auth-secret"
+        github_app_id: "123456"
+        github_app_installation_id: "12345678"
+        runners:
+          config-default: &runner-default
+            enabled: false
+            github_url: https://github.com/cloudposse
+            # group: "default"
+            # kubernetes_namespace: "gha-runner-private"
+            create_namespace: true
+            # If min_replicas > 0 and you also have do-not-evict: "true" set
+            # then the idle/waiting runner will keep Karpenter from deprovisioning the node
+            # until a job runs and the runner is deleted.
+            # override by setting `pod_annotations: {}`
+            pod_annotations:
+              karpenter.sh/do-not-evict: "true"
+            min_replicas: 0
+            max_replicas: 8
+            resources:
+              limits:
+                cpu: 1100m
+                memory: 1024Mi
+                ephemeral-storage: 5Gi
+              requests:
+                cpu: 500m
+                memory: 256Mi
+                ephemeral-storage: 1Gi
+          self-hosted-default:
+            <<: *runner-default
+            enabled: true
+            kubernetes_namespace: "gha-runner-private"
+            # If min_replicas > 0 and you also have do-not-evict: "true" set
+            # then the idle/waiting runner will keep Karpenter from deprovisioning the node
+            # until a job runs and the runner is deleted. So we override the default.
+            pod_annotations: {}
+            min_replicas: 1
+            max_replicas: 12
+            resources:
+              limits:
+                cpu: 1100m
+                memory: 1024Mi
+                ephemeral-storage: 5Gi
+              requests:
+                cpu: 500m
+                memory: 256Mi
+                ephemeral-storage: 1Gi
+          self-hosted-large:
+            <<: *runner-default
+            enabled: true
+            resources:
+              limits:
+                cpu: 6000m
+                memory: 7680Mi
+                ephemeral-storage: 90G
+              requests:
+                cpu: 4000m
+                memory: 7680Mi
+                ephemeral-storage: 40G
+
+```
+
+## TODO pick up from here
+
+### Authentication and Secrets
+
+The GitHub Action Runners need to authenticate to GitHub in order to do such
+things as register runners and pickup jobs. You can authenticate using either
+a [GitHub App](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners-with-actions-runner-controller/authenticating-to-the-github-api#authenticating-arc-with-a-github-app)
+or a [Personal Access Token (classic)](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners-with-actions-runner-controller/authenticating-to-the-github-api#authenticating-arc-with-a-personal-access-token-classic).
+The preferred way to authenticate is by _creating_ and _installing_ a GitHub
+App. This is the recommended approach as it allows for more much more restricted
+access than using a Personal Access Token (classic), and the Action Runners to
+not currently support using a fine-grained Personal Access Token.
+
+
+#### Site note about SSM and Regions
+
+This component supports using AWS SSM to store and retrieve secrets. SSM
+parameters are regional, so if you want to deploy to multiple regions
+you have 2 choices:
+
+1. Create the secrets in each region. This is the most robust approach, but
+   requires you to create the secrets in each region and keep them in sync.
+2. Create the secrets in one region and use the `ssm_region` input to specify
+   the region where they are stored. This is the easiest approach, but does add
+   some obstacles to managing deployments during a region outage. If the region
+   where the secrets are stored goes down, there will be no impact on runners in
+   other regions, but you will not be able to deploy new runners or modify
+   existing runners until the SSM region is restored or until you set up SSM
+   parameters in a new region.
+
+Alternatively, you can create Kubernetes secrets outside of this component
+(perhaps using [SOPS]()) and reference them by name. We describe here how to save the secrets
+to SSM, but you can save the secrets wherever and however you want to, as long
+as you deploy them as Kubernetes secret the runners can reference. If you store
+them in SSM, this component will take care of the rest, but the standard
+Terraform caveat applies: any secrets referenced by Terraform will be stored
+unencrypted in the Terraform state file.
+
+#### Creating and Using a GitHub App
+
+Follow the instructions [here](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners-with-actions-runner-controller/authenticating-to-the-github-api#authenticating-arc-with-a-github-app) to create and install a GitHub App
+for the runners to use for authentication.
+
+At the App creation stage, you will be asked to generate a private key. This is
+the private key that will be used to authenticate the Action Runner. Download
+the file and store the contents in SSM using the following command, adjusting
+the profile, region, and file name. The profile should be the `terraform` role in the
+account to which you are deploying the runner controller. The region should be
+the region where you are deploying the primary runner controller. If you are
+deploying runners to multiple regions, they can all reference the same SSM
+parameter by using the `ssm_region` input to specify the region where they are
+stored. The file name (argument to `cat`) should be the name of the private key
+file you downloaded.
+
+```
+# Adjust profile name and region to suit your environment, use file name you chose for key
+AWS_PROFILE=acme-core-gbl-auto-terraform AWS_REGION=us-west-2 chamber write github-action-runners github-auth-secret -- "$(cat APP_NAME.DATE.private-key.pem)"
+```
+
+You can verify the file was correctly written to SSM by matching the private key fingerprint reported by GitHub with:
+
+```
+AWS_PROFILE=acme-core-gbl-auto-terraform AWS_REGION=us-west-2 chamber read -q github-action-runners github-auth-secret | openssl rsa -in - -pubout -outform DER | openssl sha256 -binary | openssl base64
+```
+
+## TODO pick up from here
+
+At this stage, record the Application ID and the private key fingerprint in your secrets manager (e.g. 1Password).
+You may want to record the private key as well, or you may consider it sufficient to have it in SSM.
+You will need the Application ID to configure the runner controller, and want the fingerprint to verify the private key.
+(You can see the fingerprint in the GitHub App settings, under "Private keys".)
+
+Proceed to install the GitHub App in the organization or repository you want to use the runner controller for,
+and record the Installation ID (the final numeric part of the URL, as explained in the instructions
+linked above) in your secrets manager. You will need the Installation ID to configure the runner controller.
+
+In your stack configuration, set the following variables, making sure to quote the values so they are
+treated as strings, not numbers.
+
+```
+github_app_id: "12345"
+github_app_installation_id: "12345"
+```
+
+#### OR (obsolete): Creating and Using a Personal Access Token (classic)
+
+Though not recommended, you can use a Personal Access Token (classic) to
+authenticate the runners. To do so, create a PAT (classic) as described in the [GitHub Documentation](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners-with-actions-runner-controller/authenticating-to-the-github-api#authenticating-arc-with-a-personal-access-token-classic).
+Save this to the value specified by `ssm_github_token_path` using the following command, adjusting the
+  AWS profile and region as explained above:
+
+```
+AWS_PROFILE=acme-core-gbl-auto-terraform AWS_REGION=us-west-2 chamber write github-action-runners github-auth-secret -- "<PAT>"
+```
+
+### Using Runner Groups
+
+GitHub supports grouping runners into distinct [Runner Groups](https://docs.github.com/en/actions/hosting-your-own-runners/managing-access-to-self-hosted-runners-using-groups), which allow you to have different access controls
+for different runners. Read the linked documentation about creating and configuring Runner Groups, which you must do
+through the GitHub Web UI. If you choose to create Runner Groups, you can assign one or more Runner Sets (from the
+`runners` map) to groups (only one group per runner set, but multiple sets can be in the same group) by including
+`group: <Runner Group Name>` in the runner configuration. We recommend including it immediately after `github_url`.
+
+
+### Interaction with Karpenter or other EKS autoscaling solutions
+
+Kubernetes cluster autoscaling solutions generally expect that a Pod runs a service that can be terminated on one
+Node and restarted on another with only a short duration needed to finish processing any in-flight requests. When
+the cluster is resized, the cluster autoscaler will do just that. However, GitHub Action Runner Jobs do not fit this
+model. If a Pod is terminated in the middle of a job, the job is lost. The likelihood of this happening is increased
+by the fact that the Action Runner Controller Autoscaler is expanding and contracting the size of the Runner Pool on
+a regular basis, causing the cluster autoscaler to more frequently want to scale up or scale down the EKS cluster,
+and, consequently, to move Pods around.
+
+To handle these kinds of situations, Karpenter respects an annotation on the Pod:
+
+```yaml
+spec:
+  template:
+    metadata:
+      annotations:
+        karpenter.sh/do-not-evict: "true"
+```
+
+When you set this annotation on the Pod, Karpenter will not voluntarily evict it. This means that the Pod will stay on the Node
+it is on, and the Node it is on will not be considered for deprovisioning (scale down). This is good because it means that the Pod
+will not be terminated in the middle of a job. However, it also means that the Node the Pod is on will remain running
+until the Pod is terminated, even if the node is underutilized and Karpenter would like to get rid of it.
+
+Since the Runner Pods terminate at the end of the job, this is not a problem for the Pods actually running jobs.
+However, if you have set `minReplicas > 0`, then you have some Pods that are just idling, waiting for jobs to be
+assigned to them. These Pods are exactly the kind of Pods you want terminated and moved when the cluster is underutilized.
+Therefore, when you set `minReplicas > 0`, you should **NOT** set `karpenter.sh/do-not-evict: "true"` on the Pod.
+
+
+### Updating CRDs
+
+When updating the chart or application version
+of `gha-runner-scale-set-controller`, it is possible you will need to install
+new CRDs. Such a requirement should be indicated in
+the `gha-runner-scale-set-controller` release notes and may require some
+adjustment to this component.
+
+This component uses `helm` to manage the deployment, and `helm` will not auto-update CRDs.
+If new CRDs are needed, follow the instructions in the release notes for the Helm chart
+or `gha-runner-scale-set-controller` itself.
+
+
+
+### Useful Reference
+
+When reviewing documentation, code, issues, etc. for self-hosted GitHub action runners
+or the Actions Runner Controller (ARC), keep in mind that there are 2 implementations
+going by that name. The original implementation, which is now deprecated, uses
+the `actions.summerwind.dev` API group, and is at times called the Summerwind
+or Legacy implementation. It is primarily described by documentation in the
+[actions/actions-runner-controller](https://github.com/actions/actions-runner-controller)
+GitHub repository itself.
+
+The new implementation, which is the one this component
+uses, uses the `actions.github.com` API group, and is at times called the GitHub
+implementation or "Runner Scale Sets" implementation. The new implementation is
+described in the official [GitHub documentation](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners-with-actions-runner-controller/about-actions-runner-controller).
+
+Feature requests about the new implementation are officially
+directed to the [Actions category of GitHub community discussion](https://github.com/orgs/community/discussions/categories/actions).
+However, Q&A and community support is directed to the `actions/actions-runner-controller`
+repo's [Discussion section](https://github.com/actions/actions-runner-controller/discussions),
+though beware that discussions about the old implementation are mixed in with
+discussions about the new implementation.
+
+Bug reports for the new implementation are still filed under the `actions/actions-runner-controller`
+repo's [Issues](https://github.com/actions/actions-runner-controller/issues) tab,
+though again, these are mixed in with bug reports for the old implementation.
+Look for the `gha-runner-scale-set` label to find issues specific to the new
+implementation.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9.0 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.0 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.0, != 2.21.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.9.0 |
+| <a name="provider_aws.ssm"></a> [aws.ssm](#provider\_aws.ssm) | >= 4.9.0 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.0, != 2.21.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_eks"></a> [eks](#module\_eks) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
+| <a name="module_gha_runner_controller"></a> [gha\_runner\_controller](#module\_gha\_runner\_controller) | cloudposse/helm-release/aws | 0.10.0 |
+| <a name="module_gha_runners"></a> [gha\_runners](#module\_gha\_runners) | cloudposse/helm-release/aws | 0.10.0 |
+| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../../account-map/modules/iam-roles | n/a |
+| <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [kubernetes_namespace.controller](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
+| [kubernetes_namespace.runner](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
+| [kubernetes_secret_v1.controller_image_pull_secret](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret_v1) | resource |
+| [kubernetes_secret_v1.controller_ns_github_secret](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret_v1) | resource |
+| [kubernetes_secret_v1.github_secret](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret_v1) | resource |
+| [kubernetes_secret_v1.image_pull_secret](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret_v1) | resource |
+| [aws_eks_cluster_auth.eks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster_auth) | data source |
+| [aws_ssm_parameter.github_token](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
+| [aws_ssm_parameter.image_pull_secret](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br>This is for some rare cases where resources want additional configuration of tags<br>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
+| <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br>in the order they appear in the list. New attributes are appended to the<br>end of the list. The elements of the list are joined by the `delimiter`<br>and treated as a single ID element. | `list(string)` | `[]` | no |
+| <a name="input_charts"></a> [charts](#input\_charts) | Map of Helm charts to install. Keys are "controller" and "runner\_sets". | <pre>map(object({<br>    chart_version     = string<br>    chart             = optional(string, null) # defaults according to the key to "gha-runner-scale-set-controller" or "gha-runner-scale-set"<br>    chart_description = optional(string, null) # visible in Helm history<br>    chart_repository  = optional(string, "oci://ghcr.io/actions/actions-runner-controller-charts")<br>    wait              = optional(bool, true)<br>    atomic            = optional(bool, true)<br>    cleanup_on_fail   = optional(bool, true)<br>    timeout           = optional(number, null)<br>  }))</pre> | n/a | yes |
+| <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "descriptor_formats": {},<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "labels_as_tags": [<br>    "unset"<br>  ],<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {},<br>  "tenant": null<br>}</pre> | no |
+| <a name="input_controller"></a> [controller](#input\_controller) | Configuration for the controller. | <pre>object({<br>    image = optional(object({<br>      repository  = optional(string, null)<br>      tag         = optional(string, null) # Defaults to the chart appVersion<br>      pull_policy = optional(string, null)<br>    }), null)<br>    replicas             = optional(number, 1)<br>    kubernetes_namespace = string<br>    create_namespace     = optional(bool, true)<br>    chart_values         = optional(any, null)<br>    affinity             = optional(map(string), {})<br>    labels               = optional(map(string), {})<br>    node_selector        = optional(map(string), {})<br>    priority_class_name  = optional(string, "")<br>    resources = optional(object({<br>      limits = optional(object({<br>        cpu    = optional(string, null)<br>        memory = optional(string, null)<br>      }), null)<br>      requests = optional(object({<br>        cpu    = optional(string, null)<br>        memory = optional(string, null)<br>      }), null)<br>    }), null)<br>    tolerations = optional(list(object({<br>      key      = string<br>      operator = string<br>      value    = optional(string, null)<br>      effect   = string<br>    })), [])<br>    log_level       = optional(string, "info")<br>    log_format      = optional(string, "json")<br>    update_strategy = optional(string, "immediate")<br>  })</pre> | n/a | yes |
+| <a name="input_create_github_kubernetes_secret"></a> [create\_github\_kubernetes\_secret](#input\_create\_github\_kubernetes\_secret) | If `true`, this component will create the Kubernetes Secret that will be used to get<br>the GitHub App private key or GitHub PAT token, based on the value retrieved<br>from SSM at the `var.ssm_github_secret_path`. WARNING: This will cause<br>the secret to be stored in plaintext in the Terraform state.<br>If `false`, this component will not create a secret and you must create it<br>(with the name given by `var.github_kubernetes_secret_name`) in every<br>namespace where you are deploying runners (the controller does not need it). | `bool` | `true` | no |
+| <a name="input_create_image_pull_kubernetes_secret"></a> [create\_image\_pull\_kubernetes\_secret](#input\_create\_image\_pull\_kubernetes\_secret) | If `true` and `image_pull_secret_enabled` is `true`, this component will create the Kubernetes image pull secret resource,<br>using the value in SSM at the path specified by `ssm_image_pull_secret_path`.<br>WARNING: This will cause the secret to be stored in plaintext in the Terraform state.<br>If `false`, this component will not create a secret and you must create it<br>(with the name given by `var.github_kubernetes_secret_name`) in every<br>namespace where you are deploying controllers or runners. | `bool` | `true` | no |
+| <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between ID elements.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
+| <a name="input_descriptor_formats"></a> [descriptor\_formats](#input\_descriptor\_formats) | Describe additional descriptors to be output in the `descriptors` output map.<br>Map of maps. Keys are names of descriptors. Values are maps of the form<br>`{<br>   format = string<br>   labels = list(string)<br>}`<br>(Type is `any` so the map values can later be enhanced to provide additional options.)<br>`format` is a Terraform format string to be passed to the `format()` function.<br>`labels` is a list of labels, in order, to pass to `format()` function.<br>Label values will be normalized before being passed to `format()` so they will be<br>identical to how they appear in `id`.<br>Default is `{}` (`descriptors` output will be empty). | `any` | `{}` | no |
+| <a name="input_eks_component_name"></a> [eks\_component\_name](#input\_eks\_component\_name) | The name of the eks component | `string` | `"eks/cluster"` | no |
+| <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
+| <a name="input_github_app_id"></a> [github\_app\_id](#input\_github\_app\_id) | The ID of the GitHub App to use for the runner controller. Leave empty if using a GitHub PAT. | `string` | `null` | no |
+| <a name="input_github_app_installation_id"></a> [github\_app\_installation\_id](#input\_github\_app\_installation\_id) | The "Installation ID" of the GitHub App to use for the runner controller. Leave empty if using a GitHub PAT. | `string` | `null` | no |
+| <a name="input_github_kubernetes_secret_name"></a> [github\_kubernetes\_secret\_name](#input\_github\_kubernetes\_secret\_name) | Name of the Kubernetes Secret that will be used to get the GitHub App private key or GitHub PAT token. | `string` | `"gha-github-secret"` | no |
+| <a name="input_helm_manifest_experiment_enabled"></a> [helm\_manifest\_experiment\_enabled](#input\_helm\_manifest\_experiment\_enabled) | Enable storing of the rendered manifest for helm\_release so the full diff of what is changing can been seen in the plan | `bool` | `false` | no |
+| <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for keep the existing setting, which defaults to `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
+| <a name="input_image_pull_kubernetes_secret_name"></a> [image\_pull\_kubernetes\_secret\_name](#input\_image\_pull\_kubernetes\_secret\_name) | Name of the Kubernetes Secret that will be used as the imagePullSecret. | `string` | `"gha-image-pull-secret"` | no |
+| <a name="input_image_pull_secret_enabled"></a> [image\_pull\_secret\_enabled](#input\_image\_pull\_secret\_enabled) | Whether to configure the controller and runners with an image pull secret. | `bool` | `false` | no |
+| <a name="input_kube_data_auth_enabled"></a> [kube\_data\_auth\_enabled](#input\_kube\_data\_auth\_enabled) | If `true`, use an `aws_eks_cluster_auth` data source to authenticate to the EKS cluster.<br>Disabled by `kubeconfig_file_enabled` or `kube_exec_auth_enabled`. | `bool` | `false` | no |
+| <a name="input_kube_exec_auth_aws_profile"></a> [kube\_exec\_auth\_aws\_profile](#input\_kube\_exec\_auth\_aws\_profile) | The AWS config profile for `aws eks get-token` to use | `string` | `""` | no |
+| <a name="input_kube_exec_auth_aws_profile_enabled"></a> [kube\_exec\_auth\_aws\_profile\_enabled](#input\_kube\_exec\_auth\_aws\_profile\_enabled) | If `true`, pass `kube_exec_auth_aws_profile` as the `profile` to `aws eks get-token` | `bool` | `false` | no |
+| <a name="input_kube_exec_auth_enabled"></a> [kube\_exec\_auth\_enabled](#input\_kube\_exec\_auth\_enabled) | If `true`, use the Kubernetes provider `exec` feature to execute `aws eks get-token` to authenticate to the EKS cluster.<br>Disabled by `kubeconfig_file_enabled`, overrides `kube_data_auth_enabled`. | `bool` | `true` | no |
+| <a name="input_kube_exec_auth_role_arn"></a> [kube\_exec\_auth\_role\_arn](#input\_kube\_exec\_auth\_role\_arn) | The role ARN for `aws eks get-token` to use | `string` | `""` | no |
+| <a name="input_kube_exec_auth_role_arn_enabled"></a> [kube\_exec\_auth\_role\_arn\_enabled](#input\_kube\_exec\_auth\_role\_arn\_enabled) | If `true`, pass `kube_exec_auth_role_arn` as the role ARN to `aws eks get-token` | `bool` | `true` | no |
+| <a name="input_kubeconfig_context"></a> [kubeconfig\_context](#input\_kubeconfig\_context) | Context to choose from the Kubernetes kube config file | `string` | `""` | no |
+| <a name="input_kubeconfig_exec_auth_api_version"></a> [kubeconfig\_exec\_auth\_api\_version](#input\_kubeconfig\_exec\_auth\_api\_version) | The Kubernetes API version of the credentials returned by the `exec` auth plugin | `string` | `"client.authentication.k8s.io/v1beta1"` | no |
+| <a name="input_kubeconfig_file"></a> [kubeconfig\_file](#input\_kubeconfig\_file) | The Kubernetes provider `config_path` setting to use when `kubeconfig_file_enabled` is `true` | `string` | `""` | no |
+| <a name="input_kubeconfig_file_enabled"></a> [kubeconfig\_file\_enabled](#input\_kubeconfig\_file\_enabled) | If `true`, configure the Kubernetes provider with `kubeconfig_file` and use that kubeconfig file for authenticating to the EKS cluster | `bool` | `false` | no |
+| <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | Controls the letter case of the `tags` keys (label names) for tags generated by this module.<br>Does not affect keys of tags passed in via the `tags` input.<br>Possible values: `lower`, `title`, `upper`.<br>Default value: `title`. | `string` | `null` | no |
+| <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The order in which the labels (ID elements) appear in the `id`.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present. | `list(string)` | `null` | no |
+| <a name="input_label_value_case"></a> [label\_value\_case](#input\_label\_value\_case) | Controls the letter case of ID elements (labels) as included in `id`,<br>set as tag values, and output by this module individually.<br>Does not affect values of tags passed in via the `tags` input.<br>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br>Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.<br>Default value: `lower`. | `string` | `null` | no |
+| <a name="input_labels_as_tags"></a> [labels\_as\_tags](#input\_labels\_as\_tags) | Set of labels (ID elements) to include as tags in the `tags` output.<br>Default is to include all labels.<br>Tags with empty values will not be included in the `tags` output.<br>Set to `[]` to suppress all generated tags.<br>**Notes:**<br>  The value of the `name` tag, if included, will be the `id`, not the `name`.<br>  Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be<br>  changed in later chained modules. Attempts to change it will be silently ignored. | `set(string)` | <pre>[<br>  "default"<br>]</pre> | no |
+| <a name="input_name"></a> [name](#input\_name) | ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.<br>This is the only ID element not also included as a `tag`.<br>The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input. | `string` | `null` | no |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique | `string` | `null` | no |
+| <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br>Characters matching the regex will be removed from the ID elements.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
+| <a name="input_region"></a> [region](#input\_region) | AWS Region. | `string` | n/a | yes |
+| <a name="input_runners"></a> [runners](#input\_runners) | Map of Runner Scale Set configurations, with the key being the name of the runner set.<br>Please note that the name must be in kebab-case (no underscores).<br><br>For example:<pre>hcl<br>organization-runner = {<br>  # Specify the scope (organization or repository) and the target<br>  # of the runner via the `github_url` input.<br>  # ex: https://github.com/myorg/myrepo or https://github.com/myorg<br>  github_url = https://github.com/myorg<br>  group = "core-automation" # Optional. Assigns the runners to a runner group, for access control.<br>  min_replicas = 1<br>  max_replicas = 5<br>}</pre> | <pre>map(object({<br>    # we allow a runner to be disabled because Atmos cannot delete an inherited map object<br>    enabled              = optional(bool, true)<br>    github_url           = string<br>    group                = optional(string, null)<br>    kubernetes_namespace = optional(string, null) # defaults to the controller's namespace<br>    create_namespace     = optional(bool, true)<br>    image                = optional(string, "ghcr.io/actions/actions-runner:latest") # repo and tag<br>    mode                 = optional(string, "dind")                                  # Optional. Can be "dind" or "kubernetes".<br>    pod_labels           = optional(map(string), {})<br>    pod_annotations      = optional(map(string), {})<br>    affinity             = optional(map(string), {})<br>    node_selector        = optional(map(string), {})<br>    tolerations = optional(list(object({<br>      key      = string<br>      operator = string<br>      value    = optional(string, null)<br>      effect   = string<br>      # tolerationSeconds is not supported, because Terraform requires all objects in a list to have the same keys,<br>      # but tolerationSeconds must be omitted to get the default behavior of "tolerate forever".<br>      # If really needed, could use a default value of 1,000,000,000 (one billion seconds = about 32 years).<br>    })), [])<br>    min_replicas = number<br>    max_replicas = number<br><br>    # ephemeral_pvc_storage and _class are ignored for "dind" mode but required for "kubernetes" mode<br>    ephemeral_pvc_storage       = optional(string, null) # ex: 10Gi<br>    ephemeral_pvc_storage_class = optional(string, null)<br><br>    kubernetes_mode_service_account_annotations = optional(map(string), {})<br><br>    resources = optional(object({<br>      limits = optional(object({<br>        cpu               = optional(string, null)<br>        memory            = optional(string, null)<br>        ephemeral-storage = optional(string, null)<br>      }), null)<br>      requests = optional(object({<br>        cpu               = optional(string, null)<br>        memory            = optional(string, null)<br>        ephemeral-storage = optional(string, null)<br>      }), null)<br>    }), null)<br>  }))</pre> | `{}` | no |
+| <a name="input_ssm_github_secret_path"></a> [ssm\_github\_secret\_path](#input\_ssm\_github\_secret\_path) | The path in SSM to the GitHub app private key file contents or GitHub PAT token. | `string` | `"/github-action-runners/github-auth-secret"` | no |
+| <a name="input_ssm_image_pull_secret_path"></a> [ssm\_image\_pull\_secret\_path](#input\_ssm\_image\_pull\_secret\_path) | SSM path to the base64 encoded `dockercfg` image pull secret. | `string` | `"/github-action-runners/image-pull-secrets"` | no |
+| <a name="input_ssm_region"></a> [ssm\_region](#input\_ssm\_region) | AWS Region where SSM secrets are stored. Defaults to `var.region`. | `string` | `null` | no |
+| <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
+| <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_metadata"></a> [metadata](#output\_metadata) | Block status of the deployed release |
+| <a name="output_runners"></a> [runners](#output\_runners) | Human-readable summary of the deployed runners |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+## References
+
+- [cloudposse/terraform-aws-components](https://github.com/cloudposse/terraform-aws-components/tree/master/modules/eks/actions-runner-controller) - Cloud Posse's upstream component
+- [alb-controller](https://artifacthub.io/packages/helm/aws/aws-load-balancer-controller) - Helm Chart
+- [alb-controller](https://github.com/kubernetes-sigs/aws-load-balancer-controller) - AWS Load Balancer Controller
+- [actions-runner-controller Webhook Driven Scaling](https://github.com/actions-runner-controller/actions-runner-controller/blob/master/docs/detailed-docs.md#webhook-driven-scaling)
+- [actions-runner-controller Chart Values](https://github.com/actions-runner-controller/actions-runner-controller/blob/master/charts/actions-runner-controller/values.yaml)
+- [How to set service account for workers spawned in Kubernetes mode](https://github.com/actions/actions-runner-controller/issues/2992#issuecomment-1764855221)
+
+[<img src="https://cloudposse.com/logo-300x69.svg" height="32" align="right"/>](https://cpco.io/component)

--- a/modules/eks/github-actions-runner/README.md
+++ b/modules/eks/github-actions-runner/README.md
@@ -1,7 +1,7 @@
 # Component: `github-actions-runner`
 
 This component deploys self-hosted GitHub Actions Runners and a [Controller](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners-with-actions-runner-controller/quickstart-for-actions-runner-controller#introduction)
-on an EKS cluster, using "[runner scale sets](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners-with-actions-runner-controller/deploying-runner-scale-sets-with-actions-runner-controller#runner-scale-set)", on an EKS cluster.
+on an EKS cluster, using "[runner scale sets](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners-with-actions-runner-controller/deploying-runner-scale-sets-with-actions-runner-controller#runner-scale-set)".
 
 This solution is supported by GitHub and supersedes the [actions-runner-controller](https://github.com/actions/actions-runner-controller/blob/master/docs/about-arc.md) developed
 by Summerwind and deployed by Cloud Posse's [actions-runner-controller](https://docs.cloudposse.com/components/library/aws/eks/actions-runner-controller/) component.
@@ -310,6 +310,9 @@ or `gha-runner-scale-set-controller` itself.
 
 
 ### Useful Reference
+
+- Runner Scale Set Controller's Helm chart [values.yaml](https://github.com/actions/actions-runner-controller/blob/master/charts/gha-runner-scale-set-controller/values.yaml)
+- Runner Scale Set's Helm chart [values.yaml](https://github.com/actions/actions-runner-controller/blob/master/charts/gha-runner-scale-set/values.yaml)
 
 When reviewing documentation, code, issues, etc. for self-hosted GitHub action runners
 or the Actions Runner Controller (ARC), keep in mind that there are 2 implementations

--- a/modules/eks/github-actions-runner/context.tf
+++ b/modules/eks/github-actions-runner/context.tf
@@ -1,0 +1,279 @@
+#
+# ONLY EDIT THIS FILE IN github.com/cloudposse/terraform-null-label
+# All other instances of this file should be a copy of that one
+#
+#
+# Copy this file from https://github.com/cloudposse/terraform-null-label/blob/master/exports/context.tf
+# and then place it in your Terraform module to automatically get
+# Cloud Posse's standard configuration inputs suitable for passing
+# to Cloud Posse modules.
+#
+# curl -sL https://raw.githubusercontent.com/cloudposse/terraform-null-label/master/exports/context.tf -o context.tf
+#
+# Modules should access the whole context as `module.this.context`
+# to get the input variables with nulls for defaults,
+# for example `context = module.this.context`,
+# and access individual variables as `module.this.<var>`,
+# with final values filled in.
+#
+# For example, when using defaults, `module.this.context.delimiter`
+# will be null, and `module.this.delimiter` will be `-` (hyphen).
+#
+
+module "this" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0" # requires Terraform >= 0.13.0
+
+  enabled             = var.enabled
+  namespace           = var.namespace
+  tenant              = var.tenant
+  environment         = var.environment
+  stage               = var.stage
+  name                = var.name
+  delimiter           = var.delimiter
+  attributes          = var.attributes
+  tags                = var.tags
+  additional_tag_map  = var.additional_tag_map
+  label_order         = var.label_order
+  regex_replace_chars = var.regex_replace_chars
+  id_length_limit     = var.id_length_limit
+  label_key_case      = var.label_key_case
+  label_value_case    = var.label_value_case
+  descriptor_formats  = var.descriptor_formats
+  labels_as_tags      = var.labels_as_tags
+
+  context = var.context
+}
+
+# Copy contents of cloudposse/terraform-null-label/variables.tf here
+
+variable "context" {
+  type = any
+  default = {
+    enabled             = true
+    namespace           = null
+    tenant              = null
+    environment         = null
+    stage               = null
+    name                = null
+    delimiter           = null
+    attributes          = []
+    tags                = {}
+    additional_tag_map  = {}
+    regex_replace_chars = null
+    label_order         = []
+    id_length_limit     = null
+    label_key_case      = null
+    label_value_case    = null
+    descriptor_formats  = {}
+    # Note: we have to use [] instead of null for unset lists due to
+    # https://github.com/hashicorp/terraform/issues/28137
+    # which was not fixed until Terraform 1.0.0,
+    # but we want the default to be all the labels in `label_order`
+    # and we want users to be able to prevent all tag generation
+    # by setting `labels_as_tags` to `[]`, so we need
+    # a different sentinel to indicate "default"
+    labels_as_tags = ["unset"]
+  }
+  description = <<-EOT
+    Single object for setting entire context at once.
+    See description of individual variables for details.
+    Leave string and numeric variables as `null` to use default value.
+    Individual variable settings (non-null) override settings in context object,
+    except for attributes, tags, and additional_tag_map, which are merged.
+  EOT
+
+  validation {
+    condition     = lookup(var.context, "label_key_case", null) == null ? true : contains(["lower", "title", "upper"], var.context["label_key_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+
+  validation {
+    condition     = lookup(var.context, "label_value_case", null) == null ? true : contains(["lower", "title", "upper", "none"], var.context["label_value_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+variable "enabled" {
+  type        = bool
+  default     = null
+  description = "Set to false to prevent the module from creating any resources"
+}
+
+variable "namespace" {
+  type        = string
+  default     = null
+  description = "ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique"
+}
+
+variable "tenant" {
+  type        = string
+  default     = null
+  description = "ID element _(Rarely used, not included by default)_. A customer identifier, indicating who this instance of a resource is for"
+}
+
+variable "environment" {
+  type        = string
+  default     = null
+  description = "ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT'"
+}
+
+variable "stage" {
+  type        = string
+  default     = null
+  description = "ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release'"
+}
+
+variable "name" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.
+    This is the only ID element not also included as a `tag`.
+    The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input.
+    EOT
+}
+
+variable "delimiter" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Delimiter to be used between ID elements.
+    Defaults to `-` (hyphen). Set to `""` to use no delimiter at all.
+  EOT
+}
+
+variable "attributes" {
+  type        = list(string)
+  default     = []
+  description = <<-EOT
+    ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,
+    in the order they appear in the list. New attributes are appended to the
+    end of the list. The elements of the list are joined by the `delimiter`
+    and treated as a single ID element.
+    EOT
+}
+
+variable "labels_as_tags" {
+  type        = set(string)
+  default     = ["default"]
+  description = <<-EOT
+    Set of labels (ID elements) to include as tags in the `tags` output.
+    Default is to include all labels.
+    Tags with empty values will not be included in the `tags` output.
+    Set to `[]` to suppress all generated tags.
+    **Notes:**
+      The value of the `name` tag, if included, will be the `id`, not the `name`.
+      Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be
+      changed in later chained modules. Attempts to change it will be silently ignored.
+    EOT
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+    Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).
+    Neither the tag keys nor the tag values will be modified by this module.
+    EOT
+}
+
+variable "additional_tag_map" {
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+    Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.
+    This is for some rare cases where resources want additional configuration of tags
+    and therefore take a list of maps with tag key, value, and additional configuration.
+    EOT
+}
+
+variable "label_order" {
+  type        = list(string)
+  default     = null
+  description = <<-EOT
+    The order in which the labels (ID elements) appear in the `id`.
+    Defaults to ["namespace", "environment", "stage", "name", "attributes"].
+    You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present.
+    EOT
+}
+
+variable "regex_replace_chars" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Terraform regular expression (regex) string.
+    Characters matching the regex will be removed from the ID elements.
+    If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits.
+  EOT
+}
+
+variable "id_length_limit" {
+  type        = number
+  default     = null
+  description = <<-EOT
+    Limit `id` to this many characters (minimum 6).
+    Set to `0` for unlimited length.
+    Set to `null` for keep the existing setting, which defaults to `0`.
+    Does not affect `id_full`.
+  EOT
+  validation {
+    condition     = var.id_length_limit == null ? true : var.id_length_limit >= 6 || var.id_length_limit == 0
+    error_message = "The id_length_limit must be >= 6 if supplied (not null), or 0 for unlimited length."
+  }
+}
+
+variable "label_key_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Controls the letter case of the `tags` keys (label names) for tags generated by this module.
+    Does not affect keys of tags passed in via the `tags` input.
+    Possible values: `lower`, `title`, `upper`.
+    Default value: `title`.
+  EOT
+
+  validation {
+    condition     = var.label_key_case == null ? true : contains(["lower", "title", "upper"], var.label_key_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+}
+
+variable "label_value_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Controls the letter case of ID elements (labels) as included in `id`,
+    set as tag values, and output by this module individually.
+    Does not affect values of tags passed in via the `tags` input.
+    Possible values: `lower`, `title`, `upper` and `none` (no transformation).
+    Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.
+    Default value: `lower`.
+  EOT
+
+  validation {
+    condition     = var.label_value_case == null ? true : contains(["lower", "title", "upper", "none"], var.label_value_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+variable "descriptor_formats" {
+  type        = any
+  default     = {}
+  description = <<-EOT
+    Describe additional descriptors to be output in the `descriptors` output map.
+    Map of maps. Keys are names of descriptors. Values are maps of the form
+    `{
+       format = string
+       labels = list(string)
+    }`
+    (Type is `any` so the map values can later be enhanced to provide additional options.)
+    `format` is a Terraform format string to be passed to the `format()` function.
+    `labels` is a list of labels, in order, to pass to `format()` function.
+    Label values will be normalized before being passed to `format()` so they will be
+    identical to how they appear in `id`.
+    Default is `{}` (`descriptors` output will be empty).
+    EOT
+}
+
+#### End of copy of cloudposse/terraform-null-label/variables.tf

--- a/modules/eks/github-actions-runner/main.tf
+++ b/modules/eks/github-actions-runner/main.tf
@@ -1,0 +1,172 @@
+locals {
+  enabled         = module.this.enabled
+  enabled_runners = { for k, v in var.runners : k => v if v.enabled && local.enabled }
+
+  # Default chart names
+  controller_chart_name = "gha-runner-scale-set-controller"
+  runner_chart_name     = "gha-runner-scale-set"
+
+  image_pull_secret_enabled = local.enabled && var.image_pull_secret_enabled
+  create_image_pull_secret  = local.image_pull_secret_enabled && var.create_image_pull_kubernetes_secret
+  image_pull_secret         = one(data.aws_ssm_parameter.image_pull_secret[*].value)
+  image_pull_secret_name    = var.image_pull_kubernetes_secret_name
+
+  controller_namespace     = var.controller.kubernetes_namespace
+  controller_namespace_set = toset([local.controller_namespace])
+  runner_namespaces        = toset([for v in values(local.enabled_runners) : coalesce(v.kubernetes_namespace, local.controller_namespace)])
+  runner_only_namespaces   = setsubtract(local.runner_namespaces, local.controller_namespace_set)
+
+  # We have the possibility of several deployments to the same namespace,
+  # with some deployments configured to create the namespace and others not.
+  # We choose to create any namespace that is asked to be created, even if
+  # other deployments to the same namespace do not ask for it to be created.
+  all_runner_namespaces_to_create = local.enabled ? toset([
+    for v in values(local.enabled_runners) : coalesce(v.kubernetes_namespace, local.controller_namespace) if v.create_namespace
+  ]) : []
+
+  # Potentially, the configuration calls for the controller's namespace to be created for the runner,
+  # even if the controller does not specify that its namespace be created. As before,
+  # we create the namespace if any deployment to the namespace asks for it to be created.
+  # Here, however, we have to be careful to create the controller's namespace
+  # using the controller's namespace resource, even if the request came from the runner.
+  create_controller_namespace = local.enabled && (var.controller.create_namespace || contains(local.all_runner_namespaces_to_create, local.controller_namespace))
+  runner_namespaces_to_create = setsubtract(local.all_runner_namespaces_to_create, local.controller_namespace_set)
+
+  #  github_secret_namespaces     = local.enabled ? local.runner_namespaces : []
+  #  image_pull_secret_namespaces = setunion(local.controller_namespace, local.runner_namespaces)
+
+}
+
+data "aws_ssm_parameter" "image_pull_secret" {
+  count = local.create_image_pull_secret ? 1 : 0
+
+  name            = var.ssm_image_pull_secret_path
+  with_decryption = true
+  provider        = aws.ssm
+}
+
+# We want to completely deploy the controller before deploying the runners,
+# so we need separate resources for the controller and the runners, or
+# else there will be a circular dependency as the runners depend on the controller
+# and the controller resources are mixed in with the runners.
+resource "kubernetes_namespace" "controller" {
+  for_each = local.create_controller_namespace ? local.controller_namespace_set : []
+
+  metadata {
+    name = each.value
+  }
+
+  # During destroy, we may need the IAM role preserved in order to run finalizers
+  # which remove resources. This depends_on ensures that the IAM role is not
+  # destroyed until after the namespace is destroyed.
+  depends_on = [module.gha_runner_controller.service_account_role_unique_id]
+}
+
+
+resource "kubernetes_secret_v1" "controller_image_pull_secret" {
+  for_each = local.create_image_pull_secret ? local.controller_namespace_set : []
+
+  metadata {
+    name      = local.image_pull_secret_name
+    namespace = each.value
+  }
+
+  binary_data = { ".dockercfg" = local.image_pull_secret }
+
+  type = "kubernetes.io/dockercfg"
+
+  depends_on = [kubernetes_namespace.controller]
+}
+
+resource "kubernetes_secret_v1" "controller_ns_github_secret" {
+  for_each = local.create_github_secret && contains(local.runner_namespaces, local.controller_namespace) ? local.controller_namespace_set : []
+
+  metadata {
+    name      = local.github_secret_name
+    namespace = each.value
+  }
+
+  data = local.github_secrets[local.github_app_enabled ? "app" : "pat"]
+
+  depends_on = [kubernetes_namespace.controller]
+}
+
+
+module "gha_runner_controller" {
+  source  = "cloudposse/helm-release/aws"
+  version = "0.10.0"
+
+  chart           = coalesce(var.charts["controller"].chart, local.controller_chart_name)
+  repository      = var.charts["controller"].chart_repository
+  description     = var.charts["controller"].chart_description
+  chart_version   = var.charts["controller"].chart_version
+  wait            = var.charts["controller"].wait
+  atomic          = var.charts["controller"].atomic
+  cleanup_on_fail = var.charts["controller"].cleanup_on_fail
+  timeout         = var.charts["controller"].timeout
+
+  # We need the module to wait for the namespace to be created before creating
+  # resources in the namespace, but we need it to create the IAM role first,
+  # so we cannot directly depend on the namespace resources, because that
+  # would create a circular dependency. So instead we make the kubernetes
+  # namespace depend on the resource, while the service_account_namespace
+  # (which is used to create the IAM role) does not.
+  kubernetes_namespace             = try(kubernetes_namespace.controller[local.controller_namespace].metadata[0].name, local.controller_namespace)
+  create_namespace_with_kubernetes = false
+
+  eks_cluster_oidc_issuer_url = module.eks.outputs.eks_cluster_identity_oidc_issuer
+
+  service_account_name      = module.this.name
+  service_account_namespace = local.controller_namespace
+
+  iam_role_enabled = false
+
+  values = compact([
+    # hardcoded values
+    try(file("${path.module}/resources/values-controller.yaml"), null),
+    # standard k8s object settings
+    yamlencode({
+      fullnameOverride = module.this.name,
+      serviceAccount = {
+        name = module.this.name
+      },
+      affinity          = var.controller.affinity,
+      labels            = var.controller.labels,
+      nodeSelector      = var.controller.node_selector,
+      priorityClassName = var.controller.priority_class_name,
+      replicaCount      = var.controller.replicas,
+      tolerations       = var.controller.tolerations,
+      flags = {
+        logLevel       = var.controller.log_level
+        logFormat      = var.controller.log_format
+        updateStrategy = var.controller.update_strategy
+      }
+    }),
+    # filter out null values
+    var.controller.resources == null ? null : yamlencode({
+      resources = merge(
+        try(var.controller.resources.requests, null) == null ? {} : { requests = { for k, v in var.controller.resources.requests : k => v if v != null } },
+        try(var.controller.resources.limits, null) == null ? {} : { limits = { for k, v in var.controller.resources.limits : k => v if v != null } },
+      )
+    }),
+    var.controller.image == null ? null : yamlencode(merge(
+      try(var.controller.image.repository, null) == null ? {} : { repository = var.controller.image.repository },
+      try(var.controller.image.tag, null) == null ? {} : { tag = var.controller.image.tag },
+      try(var.controller.image.pull_policy, null) == null ? {} : { pullPolicy = var.controller.image.pull_policy },
+    )),
+    local.image_pull_secret_enabled ? yamlencode({
+      # We need to wait until the secret is created before creating the controller,
+      # but we cannot explicitly make the whole module depend on the secret, because
+      # the secret depends on the namespace, and the namespace depends on the IAM role created by the module,
+      # even if no IAM role is created (because Terraform uses static dependencies).
+      imagePullSecrets = [{ name = try(kubernetes_secret_v1.controller_image_pull_secret[local.controller_namespace].metadata[0].name, var.image_pull_kubernetes_secret_name) }]
+    }) : null,
+    # additional values
+    yamlencode(var.controller.chart_values)
+  ])
+
+  context = module.this.context
+
+  # Cannot depend on the namespace directly, because that would create a circular dependency (see above)
+  # depends_on = [kubernetes_namespace.default]
+}

--- a/modules/eks/github-actions-runner/outputs.tf
+++ b/modules/eks/github-actions-runner/outputs.tf
@@ -1,0 +1,25 @@
+output "metadata" {
+  value       = module.gha_runner_controller.metadata
+  description = "Block status of the deployed release"
+}
+
+output "runners" {
+  value = { for k, v in local.enabled_runners : k => merge({
+    "1) Kubernetes namespace" = coalesce(v.kubernetes_namespace, local.controller_namespace)
+    "2) Runner Group"         = v.group
+    "3) Min Runners"          = v.min_replicas
+    "4) Max Runners"          = v.max_replicas
+    },
+    length(v.node_selector) > 0 ? {
+      "?) Node Selector" = v.node_selector
+    } : {},
+    length(v.tolerations) > 0 ? {
+      "?) Tolerations" = v.tolerations
+    } : {},
+    length(v.affinity) > 0 ? {
+      "?) Affinity" = v.affinity
+    } : {},
+    )
+  }
+  description = "Human-readable summary of the deployed runners"
+}

--- a/modules/eks/github-actions-runner/provider-helm.tf
+++ b/modules/eks/github-actions-runner/provider-helm.tf
@@ -1,0 +1,166 @@
+##################
+#
+# This file is a drop-in to provide a helm provider.
+#
+# It depends on 2 standard Cloud Posse data source modules to be already
+# defined in the same component:
+#
+#   1. module.iam_roles to provide the AWS profile or Role ARN to use to access the cluster
+#   2. module.eks to provide the EKS cluster information
+#
+# All the following variables are just about configuring the Kubernetes provider
+# to be able to modify EKS cluster. The reason there are so many options is
+# because at various times, each one of them has had problems, so we give you a choice.
+#
+# The reason there are so many "enabled" inputs rather than automatically
+# detecting whether or not they are enabled based on the value of the input
+# is that any logic based on input values requires the values to be known during
+# the "plan" phase of Terraform, and often they are not, which causes problems.
+#
+variable "kubeconfig_file_enabled" {
+  type        = bool
+  default     = false
+  description = "If `true`, configure the Kubernetes provider with `kubeconfig_file` and use that kubeconfig file for authenticating to the EKS cluster"
+}
+
+variable "kubeconfig_file" {
+  type        = string
+  default     = ""
+  description = "The Kubernetes provider `config_path` setting to use when `kubeconfig_file_enabled` is `true`"
+}
+
+variable "kubeconfig_context" {
+  type        = string
+  default     = ""
+  description = "Context to choose from the Kubernetes kube config file"
+}
+
+variable "kube_data_auth_enabled" {
+  type        = bool
+  default     = false
+  description = <<-EOT
+    If `true`, use an `aws_eks_cluster_auth` data source to authenticate to the EKS cluster.
+    Disabled by `kubeconfig_file_enabled` or `kube_exec_auth_enabled`.
+    EOT
+}
+
+variable "kube_exec_auth_enabled" {
+  type        = bool
+  default     = true
+  description = <<-EOT
+    If `true`, use the Kubernetes provider `exec` feature to execute `aws eks get-token` to authenticate to the EKS cluster.
+    Disabled by `kubeconfig_file_enabled`, overrides `kube_data_auth_enabled`.
+    EOT
+}
+
+variable "kube_exec_auth_role_arn" {
+  type        = string
+  default     = ""
+  description = "The role ARN for `aws eks get-token` to use"
+}
+
+variable "kube_exec_auth_role_arn_enabled" {
+  type        = bool
+  default     = true
+  description = "If `true`, pass `kube_exec_auth_role_arn` as the role ARN to `aws eks get-token`"
+}
+
+variable "kube_exec_auth_aws_profile" {
+  type        = string
+  default     = ""
+  description = "The AWS config profile for `aws eks get-token` to use"
+}
+
+variable "kube_exec_auth_aws_profile_enabled" {
+  type        = bool
+  default     = false
+  description = "If `true`, pass `kube_exec_auth_aws_profile` as the `profile` to `aws eks get-token`"
+}
+
+variable "kubeconfig_exec_auth_api_version" {
+  type        = string
+  default     = "client.authentication.k8s.io/v1beta1"
+  description = "The Kubernetes API version of the credentials returned by the `exec` auth plugin"
+}
+
+variable "helm_manifest_experiment_enabled" {
+  type        = bool
+  default     = false
+  description = "Enable storing of the rendered manifest for helm_release so the full diff of what is changing can been seen in the plan"
+}
+
+locals {
+  kubeconfig_file_enabled = var.kubeconfig_file_enabled
+  kube_exec_auth_enabled  = local.kubeconfig_file_enabled ? false : var.kube_exec_auth_enabled
+  kube_data_auth_enabled  = local.kube_exec_auth_enabled ? false : var.kube_data_auth_enabled
+
+  # Eventually we might try to get this from an environment variable
+  kubeconfig_exec_auth_api_version = var.kubeconfig_exec_auth_api_version
+
+  exec_profile = local.kube_exec_auth_enabled && var.kube_exec_auth_aws_profile_enabled ? [
+    "--profile", var.kube_exec_auth_aws_profile
+  ] : []
+
+  kube_exec_auth_role_arn = coalesce(var.kube_exec_auth_role_arn, module.iam_roles.terraform_role_arn)
+  exec_role = local.kube_exec_auth_enabled && var.kube_exec_auth_role_arn_enabled ? [
+    "--role-arn", local.kube_exec_auth_role_arn
+  ] : []
+
+  # Provide dummy configuration for the case where the EKS cluster is not available.
+  certificate_authority_data = try(module.eks.outputs.eks_cluster_certificate_authority_data, "")
+  # Use coalesce+try to handle both the case where the output is missing and the case where it is empty.
+  eks_cluster_id       = coalesce(try(module.eks.outputs.eks_cluster_id, ""), "missing")
+  eks_cluster_endpoint = try(module.eks.outputs.eks_cluster_endpoint, "")
+}
+
+data "aws_eks_cluster_auth" "eks" {
+  count = local.kube_data_auth_enabled ? 1 : 0
+  name  = local.eks_cluster_id
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = local.eks_cluster_endpoint
+    cluster_ca_certificate = base64decode(local.certificate_authority_data)
+    token                  = local.kube_data_auth_enabled ? one(data.aws_eks_cluster_auth.eks[*].token) : null
+    # The Kubernetes provider will use information from KUBECONFIG if it exists, but if the default cluster
+    # in KUBECONFIG is some other cluster, this will cause problems, so we override it always.
+    config_path    = local.kubeconfig_file_enabled ? var.kubeconfig_file : ""
+    config_context = var.kubeconfig_context
+
+    dynamic "exec" {
+      for_each = local.kube_exec_auth_enabled && length(local.certificate_authority_data) > 0 ? ["exec"] : []
+      content {
+        api_version = local.kubeconfig_exec_auth_api_version
+        command     = "aws"
+        args = concat(local.exec_profile, [
+          "eks", "get-token", "--cluster-name", local.eks_cluster_id
+        ], local.exec_role)
+      }
+    }
+  }
+  experiments {
+    manifest = var.helm_manifest_experiment_enabled && module.this.enabled
+  }
+}
+
+provider "kubernetes" {
+  host                   = local.eks_cluster_endpoint
+  cluster_ca_certificate = base64decode(local.certificate_authority_data)
+  token                  = local.kube_data_auth_enabled ? one(data.aws_eks_cluster_auth.eks[*].token) : null
+  # The Kubernetes provider will use information from KUBECONFIG if it exists, but if the default cluster
+  # in KUBECONFIG is some other cluster, this will cause problems, so we override it always.
+  config_path    = local.kubeconfig_file_enabled ? var.kubeconfig_file : ""
+  config_context = var.kubeconfig_context
+
+  dynamic "exec" {
+    for_each = local.kube_exec_auth_enabled && length(local.certificate_authority_data) > 0 ? ["exec"] : []
+    content {
+      api_version = local.kubeconfig_exec_auth_api_version
+      command     = "aws"
+      args = concat(local.exec_profile, [
+        "eks", "get-token", "--cluster-name", local.eks_cluster_id
+      ], local.exec_role)
+    }
+  }
+}

--- a/modules/eks/github-actions-runner/provider-ssm.tf
+++ b/modules/eks/github-actions-runner/provider-ssm.tf
@@ -1,0 +1,15 @@
+provider "aws" {
+  region = coalesce(var.ssm_region, var.region)
+  alias  = "ssm"
+
+  # Profile is deprecated in favor of terraform_role_arn. When profiles are not in use, terraform_profile_name is null.
+  profile = module.iam_roles.terraform_profile_name
+
+  dynamic "assume_role" {
+    # module.iam_roles.terraform_role_arn may be null, in which case do not assume a role.
+    for_each = compact([module.iam_roles.terraform_role_arn])
+    content {
+      role_arn = assume_role.value
+    }
+  }
+}

--- a/modules/eks/github-actions-runner/providers.tf
+++ b/modules/eks/github-actions-runner/providers.tf
@@ -1,0 +1,19 @@
+provider "aws" {
+  region = var.region
+
+  # Profile is deprecated in favor of terraform_role_arn. When profiles are not in use, terraform_profile_name is null.
+  profile = module.iam_roles.terraform_profile_name
+
+  dynamic "assume_role" {
+    # module.iam_roles.terraform_role_arn may be null, in which case do not assume a role.
+    for_each = compact([module.iam_roles.terraform_role_arn])
+    content {
+      role_arn = assume_role.value
+    }
+  }
+}
+
+module "iam_roles" {
+  source  = "../../account-map/modules/iam-roles"
+  context = module.this.context
+}

--- a/modules/eks/github-actions-runner/remote-state.tf
+++ b/modules/eks/github-actions-runner/remote-state.tf
@@ -1,0 +1,8 @@
+module "eks" {
+  source  = "cloudposse/stack-config/yaml//modules/remote-state"
+  version = "1.5.0"
+
+  component = var.eks_component_name
+
+  context = module.this.context
+}

--- a/modules/eks/github-actions-runner/runners.tf
+++ b/modules/eks/github-actions-runner/runners.tf
@@ -1,0 +1,185 @@
+locals {
+  github_app_enabled   = var.github_app_id != null && var.github_app_installation_id != null
+  create_github_secret = local.enabled && var.create_github_kubernetes_secret
+  github_secret_name   = var.github_kubernetes_secret_name
+
+  github_secrets = {
+    app = {
+      github_app_id              = var.github_app_id
+      github_app_installation_id = var.github_app_installation_id
+      github_app_private_key     = one(data.aws_ssm_parameter.github_token[*].value)
+    }
+    pat = {
+      github_token = one(data.aws_ssm_parameter.github_token[*].value)
+    }
+  }
+}
+
+data "aws_ssm_parameter" "github_token" {
+  count = local.create_github_secret ? 1 : 0
+
+  name            = var.ssm_github_secret_path
+  with_decryption = true
+  provider        = aws.ssm
+}
+
+resource "kubernetes_namespace" "runner" {
+  for_each = local.runner_namespaces_to_create
+
+  metadata {
+    name = each.value
+  }
+
+  # During destroy, we may need the IAM role preserved in order to run finalizers
+  # which remove resources. This depends_on ensures that the IAM role is not
+  # destroyed until after the namespace is destroyed.
+  depends_on = [module.gha_runners.service_account_role_unique_id]
+}
+
+resource "kubernetes_secret_v1" "github_secret" {
+  for_each = local.create_github_secret ? local.runner_only_namespaces : []
+
+  metadata {
+    name      = local.github_secret_name
+    namespace = each.value
+  }
+
+  data = local.github_secrets[local.github_app_enabled ? "app" : "pat"]
+
+  depends_on = [kubernetes_namespace.runner]
+}
+
+resource "kubernetes_secret_v1" "image_pull_secret" {
+  for_each = local.create_image_pull_secret ? local.runner_only_namespaces : []
+
+  metadata {
+    name      = local.image_pull_secret_name
+    namespace = each.value
+  }
+
+  binary_data = { ".dockercfg" = local.image_pull_secret }
+
+  type = "kubernetes.io/dockercfg"
+
+  depends_on = [kubernetes_namespace.runner]
+}
+
+module "gha_runners" {
+  for_each = local.enabled ? local.enabled_runners : {}
+
+  source  = "cloudposse/helm-release/aws"
+  version = "0.10.0"
+
+  name            = each.key
+  chart           = coalesce(var.charts["runner_sets"].chart, local.runner_chart_name)
+  repository      = var.charts["runner_sets"].chart_repository
+  description     = var.charts["runner_sets"].chart_description
+  chart_version   = var.charts["runner_sets"].chart_version
+  wait            = var.charts["runner_sets"].wait
+  atomic          = var.charts["runner_sets"].atomic
+  cleanup_on_fail = var.charts["runner_sets"].cleanup_on_fail
+  timeout         = var.charts["runner_sets"].timeout
+
+  kubernetes_namespace = coalesce(each.value.kubernetes_namespace, local.controller_namespace)
+  create_namespace     = false # will be created above to manage duplicate namespaces
+
+  eks_cluster_oidc_issuer_url = module.eks.outputs.eks_cluster_identity_oidc_issuer
+
+  iam_role_enabled = false
+
+  values = compact([
+    # hardcoded values
+    try(file("${path.module}/resources/values-runner.yaml"), null),
+    yamlencode({
+      githubConfigUrl = each.value.github_url
+      maxRunners      = each.value.max_replicas
+      minRunners      = each.value.min_replicas
+      runnerGroup     = each.value.group
+
+      # Create an explicit dependency on the secret to be sure it is created first.
+      githubConfigSecret = coalesce(each.value.kubernetes_namespace, local.controller_namespace) == local.controller_namespace ? (
+        try(kubernetes_secret_v1.controller_ns_github_secret[local.controller_namespace].metadata[0].name, local.github_secret_name)
+        ) : (
+        try(kubernetes_secret_v1.github_secret[each.value.kubernetes_namespace].metadata[0].name, local.github_secret_name)
+      )
+
+      containerMode = {
+        type = each.value.mode
+        kubernetesModeWorkVolumeClaim = {
+          accessModes      = ["ReadWriteOnce"]
+          storageClassName = each.value.ephemeral_pvc_storage_class
+          resources = {
+            requests = {
+              storage = each.value.ephemeral_pvc_storage
+            }
+          }
+        }
+        kubernetesModeServiceAccount = {
+          annotations = each.value.kubernetes_mode_service_account_annotations
+        }
+      }
+      template = {
+        metadata = {
+          annotations = each.value.pod_annotations
+          labels      = each.value.pod_labels
+        }
+        spec = merge(
+          local.image_pull_secret_enabled ? {
+            # We want to wait until the secret is created before creating the runner,
+            # but the secret might be the `controller_image_pull_secret`. That is O.K.
+            # because we separately depend on the controller, which depends on the secret.
+            imagePullSecrets = [{ name = try(kubernetes_secret_v1.image_pull_secret[each.value.kubernetes_namespace].metadata[0].name, var.image_pull_kubernetes_secret_name) }]
+          } : {},
+          try(length(each.value.ephemeral_pvc_storage), 0) > 0 ? {
+            volumes = [{
+              name = "work"
+              ephemeral = {
+                volumeClaimTemplate = {
+                  spec = merge(
+                    try(length(each.value.ephemeral_pvc_storage_class), 0) > 0 ? {
+                      storageClassName = each.value.ephemeral_pvc_storage_class
+                    } : {},
+                    {
+                      accessModes = ["ReadWriteOnce"]
+                      resources = {
+                        requests = {
+                          storage = each.value.ephemeral_pvc_storage
+                        }
+                      }
+                  })
+                }
+              }
+            }]
+          } : {},
+          {
+            affinity     = each.value.affinity
+            nodeSelector = each.value.node_selector
+            tolerations  = each.value.tolerations
+            containers = [merge({
+              name  = "runner"
+              image = each.value.image
+              # command from https://github.com/actions/actions-runner-controller/blob/0bfa57ac504dfc818128f7185fc82830cbdb83f1/charts/gha-runner-scale-set/values.yaml#L193
+              command = ["/home/runner/run.sh"]
+              },
+              each.value.resources == null ? {} : {
+                resources = merge(
+                  try(each.value.resources.requests, null) == null ? {} : { requests = { for k, v in each.value.resources.requests : k => v if v != null } },
+                  try(each.value.resources.limits, null) == null ? {} : { limits = { for k, v in each.value.resources.limits : k => v if v != null } },
+                )
+              },
+            )]
+          }
+        )
+      }
+    }),
+    local.image_pull_secret_enabled ? yamlencode({
+      listenerTemplate = {
+        spec = {
+          imagePullSecrets = [{ name = try(kubernetes_secret_v1.image_pull_secret[each.value.kubernetes_namespace].metadata[0].name, var.image_pull_kubernetes_secret_name) }]
+          containers       = []
+    } } }) : null
+  ])
+
+  # Cannot depend on the namespace directly, because that would create a circular dependency (see above).
+  depends_on = [module.gha_runner_controller, kubernetes_secret_v1.controller_ns_github_secret]
+}

--- a/modules/eks/github-actions-runner/variables.tf
+++ b/modules/eks/github-actions-runner/variables.tf
@@ -1,0 +1,223 @@
+variable "region" {
+  description = "AWS Region."
+  type        = string
+}
+
+variable "ssm_region" {
+  description = "AWS Region where SSM secrets are stored. Defaults to `var.region`."
+  type        = string
+  default     = null
+}
+
+variable "eks_component_name" {
+  type        = string
+  description = "The name of the eks component"
+  default     = "eks/cluster"
+}
+
+######## Helm Chart configurations
+
+variable "charts" {
+  description = "Map of Helm charts to install. Keys are \"controller\" and \"runner_sets\"."
+  type = map(object({
+    chart_version     = string
+    chart             = optional(string, null) # defaults according to the key to "gha-runner-scale-set-controller" or "gha-runner-scale-set"
+    chart_description = optional(string, null) # visible in Helm history
+    chart_repository  = optional(string, "oci://ghcr.io/actions/actions-runner-controller-charts")
+    wait              = optional(bool, true)
+    atomic            = optional(bool, true)
+    cleanup_on_fail   = optional(bool, true)
+    timeout           = optional(number, null)
+  }))
+  validation {
+    condition     = length(keys(var.charts)) == 2 && contains(keys(var.charts), "controller") && contains(keys(var.charts), "runner_sets")
+    error_message = "Must have exactly two charts: \"controller\" and \"runner_sets\"."
+  }
+}
+
+######## ImagePullSecret settings
+
+variable "image_pull_secret_enabled" {
+  type        = bool
+  description = "Whether to configure the controller and runners with an image pull secret."
+  default     = false
+}
+
+variable "image_pull_kubernetes_secret_name" {
+  type        = string
+  description = "Name of the Kubernetes Secret that will be used as the imagePullSecret."
+  default     = "gha-image-pull-secret"
+  nullable    = false
+}
+
+variable "create_image_pull_kubernetes_secret" {
+  type        = bool
+  description = <<-EOT
+    If `true` and `image_pull_secret_enabled` is `true`, this component will create the Kubernetes image pull secret resource,
+    using the value in SSM at the path specified by `ssm_image_pull_secret_path`.
+    WARNING: This will cause the secret to be stored in plaintext in the Terraform state.
+    If `false`, this component will not create a secret and you must create it
+    (with the name given by `var.github_kubernetes_secret_name`) in every
+    namespace where you are deploying controllers or runners.
+    EOT
+  default     = true
+  nullable    = false
+}
+
+variable "ssm_image_pull_secret_path" {
+  type        = string
+  description = "SSM path to the base64 encoded `dockercfg` image pull secret."
+  default     = "/github-action-runners/image-pull-secrets"
+  nullable    = false
+}
+
+######## Controller-specific settings
+
+variable "controller" {
+  type = object({
+    image = optional(object({
+      repository  = optional(string, null)
+      tag         = optional(string, null) # Defaults to the chart appVersion
+      pull_policy = optional(string, null)
+    }), null)
+    replicas             = optional(number, 1)
+    kubernetes_namespace = string
+    create_namespace     = optional(bool, true)
+    chart_values         = optional(any, null)
+    affinity             = optional(map(string), {})
+    labels               = optional(map(string), {})
+    node_selector        = optional(map(string), {})
+    priority_class_name  = optional(string, "")
+    resources = optional(object({
+      limits = optional(object({
+        cpu    = optional(string, null)
+        memory = optional(string, null)
+      }), null)
+      requests = optional(object({
+        cpu    = optional(string, null)
+        memory = optional(string, null)
+      }), null)
+    }), null)
+    tolerations = optional(list(object({
+      key      = string
+      operator = string
+      value    = optional(string, null)
+      effect   = string
+    })), [])
+    log_level       = optional(string, "info")
+    log_format      = optional(string, "json")
+    update_strategy = optional(string, "immediate")
+  })
+  description = "Configuration for the controller."
+}
+
+
+######## Runner-specific settings
+
+variable "github_app_id" {
+  type        = string
+  description = "The ID of the GitHub App to use for the runner controller. Leave empty if using a GitHub PAT."
+  default     = null
+}
+
+variable "github_app_installation_id" {
+  type        = string
+  description = "The \"Installation ID\" of the GitHub App to use for the runner controller. Leave empty if using a GitHub PAT."
+  default     = null
+}
+
+variable "ssm_github_secret_path" {
+  type        = string
+  description = "The path in SSM to the GitHub app private key file contents or GitHub PAT token."
+  default     = "/github-action-runners/github-auth-secret"
+  nullable    = false
+}
+
+variable "create_github_kubernetes_secret" {
+  type        = bool
+  description = <<-EOT
+    If `true`, this component will create the Kubernetes Secret that will be used to get
+    the GitHub App private key or GitHub PAT token, based on the value retrieved
+    from SSM at the `var.ssm_github_secret_path`. WARNING: This will cause
+    the secret to be stored in plaintext in the Terraform state.
+    If `false`, this component will not create a secret and you must create it
+    (with the name given by `var.github_kubernetes_secret_name`) in every
+    namespace where you are deploying runners (the controller does not need it).
+    EOT
+  default     = true
+}
+
+variable "github_kubernetes_secret_name" {
+  type        = string
+  description = "Name of the Kubernetes Secret that will be used to get the GitHub App private key or GitHub PAT token."
+  default     = "gha-github-secret"
+  nullable    = false
+}
+
+
+variable "runners" {
+  description = <<-EOT
+  Map of Runner Scale Set configurations, with the key being the name of the runner set.
+  Please note that the name must be in kebab-case (no underscores).
+
+  For example:
+
+  ```hcl
+  organization-runner = {
+    # Specify the scope (organization or repository) and the target
+    # of the runner via the `github_url` input.
+    # ex: https://github.com/myorg/myrepo or https://github.com/myorg
+    github_url = https://github.com/myorg
+    group = "core-automation" # Optional. Assigns the runners to a runner group, for access control.
+    min_replicas = 1
+    max_replicas = 5
+  }
+  ```
+  EOT
+
+  type = map(object({
+    # we allow a runner to be disabled because Atmos cannot delete an inherited map object
+    enabled              = optional(bool, true)
+    github_url           = string
+    group                = optional(string, null)
+    kubernetes_namespace = optional(string, null) # defaults to the controller's namespace
+    create_namespace     = optional(bool, true)
+    image                = optional(string, "ghcr.io/actions/actions-runner:latest") # repo and tag
+    mode                 = optional(string, "dind")                                  # Optional. Can be "dind" or "kubernetes".
+    pod_labels           = optional(map(string), {})
+    pod_annotations      = optional(map(string), {})
+    affinity             = optional(map(string), {})
+    node_selector        = optional(map(string), {})
+    tolerations = optional(list(object({
+      key      = string
+      operator = string
+      value    = optional(string, null)
+      effect   = string
+      # tolerationSeconds is not supported, because Terraform requires all objects in a list to have the same keys,
+      # but tolerationSeconds must be omitted to get the default behavior of "tolerate forever".
+      # If really needed, could use a default value of 1,000,000,000 (one billion seconds = about 32 years).
+    })), [])
+    min_replicas = number
+    max_replicas = number
+
+    # ephemeral_pvc_storage and _class are ignored for "dind" mode but required for "kubernetes" mode
+    ephemeral_pvc_storage       = optional(string, null) # ex: 10Gi
+    ephemeral_pvc_storage_class = optional(string, null)
+
+    kubernetes_mode_service_account_annotations = optional(map(string), {})
+
+    resources = optional(object({
+      limits = optional(object({
+        cpu               = optional(string, null)
+        memory            = optional(string, null)
+        ephemeral-storage = optional(string, null)
+      }), null)
+      requests = optional(object({
+        cpu               = optional(string, null)
+        memory            = optional(string, null)
+        ephemeral-storage = optional(string, null)
+      }), null)
+    }), null)
+  }))
+  default = {}
+}

--- a/modules/eks/github-actions-runner/versions.tf
+++ b/modules/eks/github-actions-runner/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.9.0"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.0, != 2.21.0"
+    }
+  }
+}


### PR DESCRIPTION
## what

- Add `eks/github-actions-runner` to deploy GitHub Action Runner Scale Sets
- [`aurora-postgres-resources`] Add/clarify documentation on PostgreSQL `GRANT`

## why

- Official GitHub implementation of GitHub Action Runners self-hosted on Kubernetes
- Clear up some confusion experienced by a customer

## references

### Actions Runner Controller
- `actions-runner-controller` adopted by GitHub: [Announcement](https://github.com/actions/actions-runner-controller/discussions/2072)
- https://github.com/actions/actions-runner-controller/discussions/2775
- [Quickstart for Actions Runner Controller](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners-with-actions-runner-controller/quickstart-for-actions-runner-controller)
- Runner Scale Set Controller's Helm chart [values.yaml](https://github.com/actions/actions-runner-controller/blob/f7eb88ce9c6b3cf013ae825bef197773e2bc9d0b/charts/gha-runner-scale-set-controller/values.yaml)
- Runner Scale Set's Helm chart [values.yaml](https://github.com/actions/actions-runner-controller/blob/0fd8eac305dbcacab02d114d5facecc82cf60c1e/charts/gha-runner-scale-set/values.yaml)

### PostgreSQL

- PostgreSQL 14 [GRANT](https://www.postgresql.org/docs/14/sql-grant.html)
- PostgreSQL 14 [privileges that can be GRANTed](https://www.postgresql.org/docs/14/ddl-priv.html)
