### PR TITLE
[eks/github-actions-runner] Explain about tools missing from runners

### DIFF
--- a/modules/eks/github-actions-runner/CHANGELOG.md
+++ b/modules/eks/github-actions-runner/CHANGELOG.md
@@ -21,6 +21,17 @@ you remove the old ones. You can then migrate your workflows to use the new
 runners sets and have zero downtime.
 
 Major differences:
+- The official GitHub runners deployed are different from the GitHub hosted
+  runners and the Summerwind self-hosted runners in that [they have very few tools installed](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners-with-actions-runner-controller/about-actions-runner-controller#about-the-runner-container-image). You will need to
+  install any tools you need in your workflows, either as part of your workflow
+  (recommended) or by maintaining a [custom runner image](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners-with-actions-runner-controller/about-actions-runner-controller#creating-your-own-runner-image), or by running
+  such steps in a [separate container](https://docs.github.com/en/actions/using-jobs/running-jobs-in-a-container)
+  that has the tools pre-installed. Many tools have publicly available actions
+  to install them, such as `actions/setup-node` to install NodeJS or `dcarbone/install-jq-action`
+  to install `jq`. You can also install packages using `awalsh128/cache-apt-pkgs-action`,
+  which has the advantage of being able to skip the installation if the package
+  is already installed, so you can more efficiently run the same workflow on
+  GitHub hosted as well as self-hosted runners.
 - Self-hosted runners, such as those deployed with the `actions-runner-controller`
   component, are targeted by a set of labels indicated by a workflow's `runs-on`
   array, of which the first must be "self-hosted". Runner Sets, such as are

--- a/modules/eks/github-actions-runner/README.md
+++ b/modules/eks/github-actions-runner/README.md
@@ -11,7 +11,7 @@ by Summerwind and deployed by Cloud Posse's [actions-runner-controller](https://
 The runner image used by Runner Sets contains [no more packages than are necessary](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners-with-actions-runner-controller/about-actions-runner-controller#about-the-runner-container-image)
 to run the runner. This is in contrast to the Summerwind implementation, which
 contains some commonly needed packages like `build-essential`, `curl`, `wget`,
-`git`, and `jq`, and the GitHub hosted images which contain a roubst set of tools.
+`git`, and `jq`, and the GitHub hosted images which contain a robust set of tools.
 (This is a limitation of the official Runner Sets implementation, not this
 component per se.) You will need to
 install any tools you need in your workflows, either as part of your workflow

--- a/modules/eks/github-actions-runner/README.md
+++ b/modules/eks/github-actions-runner/README.md
@@ -8,6 +8,22 @@ by Summerwind and deployed by Cloud Posse's [actions-runner-controller](https://
 
 ### Current limitations
 
+The runner image used by Runner Sets contains [no more packages than are necessary](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners-with-actions-runner-controller/about-actions-runner-controller#about-the-runner-container-image)
+to run the runner. This is in contrast to the Summerwind implementation, which
+contains some commonly needed packages like `build-essential`, `curl`, `wget`,
+`git`, and `jq`, and the GitHub hosted images which contain a roubst set of tools.
+(This is a limitation of the official Runner Sets implementation, not this
+component per se.) You will need to
+install any tools you need in your workflows, either as part of your workflow
+(recommended) or by maintaining a [custom runner image](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners-with-actions-runner-controller/about-actions-runner-controller#creating-your-own-runner-image), or by running
+such steps in a [separate container](https://docs.github.com/en/actions/using-jobs/running-jobs-in-a-container)
+that has the tools pre-installed. Many tools have publicly available actions
+to install them, such as `actions/setup-node` to install NodeJS or `dcarbone/install-jq-action`
+to install `jq`. You can also install packages using `awalsh128/cache-apt-pkgs-action`,
+which has the advantage of being able to skip the installation if the package
+is already installed, so you can more efficiently run the same workflow on
+GitHub hosted as well as self-hosted runners.
+
 In the current version of this component, only "dind" (Docker in Docker) mode has been tested.
 Support for "kubernetes" mode is provided, but has not been validated.
 
@@ -314,6 +330,7 @@ or `gha-runner-scale-set-controller` itself.
 
 - Runner Scale Set Controller's Helm chart [values.yaml](https://github.com/actions/actions-runner-controller/blob/master/charts/gha-runner-scale-set-controller/values.yaml)
 - Runner Scale Set's Helm chart [values.yaml](https://github.com/actions/actions-runner-controller/blob/master/charts/gha-runner-scale-set/values.yaml)
+- Runner Scale Set's [Docker image](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners-with-actions-runner-controller/about-actions-runner-controller#about-the-runner-container-image) and [how to create your own](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners-with-actions-runner-controller/about-actions-runner-controller#creating-your-own-runner-image)
 
 When reviewing documentation, code, issues, etc. for self-hosted GitHub action runners
 or the Actions Runner Controller (ARC), keep in mind that there are 2 implementations

--- a/modules/eks/github-actions-runner/README.md
+++ b/modules/eks/github-actions-runner/README.md
@@ -15,7 +15,7 @@ contains some commonly needed packages like `build-essential`, `curl`, `wget`,
 (This is a limitation of the official Runner Sets implementation, not this
 component per se.) You will need to
 install any tools you need in your workflows, either as part of your workflow
-(recommended) or by maintaining a [custom runner image](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners-with-actions-runner-controller/about-actions-runner-controller#creating-your-own-runner-image), or by running
+(recommended), by maintaining a [custom runner image](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners-with-actions-runner-controller/about-actions-runner-controller#creating-your-own-runner-image), or by running
 such steps in a [separate container](https://docs.github.com/en/actions/using-jobs/running-jobs-in-a-container)
 that has the tools pre-installed. Many tools have publicly available actions
 to install them, such as `actions/setup-node` to install NodeJS or `dcarbone/install-jq-action`
@@ -23,6 +23,16 @@ to install `jq`. You can also install packages using `awalsh128/cache-apt-pkgs-a
 which has the advantage of being able to skip the installation if the package
 is already installed, so you can more efficiently run the same workflow on
 GitHub hosted as well as self-hosted runners.
+
+:::info
+There are (as of this writing) open feature requests to add some
+commonly needed packages to the official Runner Sets runner image. You can
+upvote these
+requests [here](https://github.com/actions/actions-runner-controller/discussions/3168)
+and [here](https://github.com/orgs/community/discussions/80868) to help get them
+implemented.
+
+:::
 
 In the current version of this component, only "dind" (Docker in Docker) mode has been tested.
 Support for "kubernetes" mode is provided, but has not been validated.
@@ -176,8 +186,6 @@ components:
 
 ```
 
-## TODO pick up from here
-
 ### Authentication and Secrets
 
 The GitHub Action Runners need to authenticate to GitHub in order to do such
@@ -241,8 +249,6 @@ You can verify the file was correctly written to SSM by matching the private key
 ```
 AWS_PROFILE=acme-core-gbl-auto-terraform AWS_REGION=us-west-2 chamber read -q github-action-runners github-auth-secret | openssl rsa -in - -pubout -outform DER | openssl sha256 -binary | openssl base64
 ```
-
-## TODO pick up from here
 
 At this stage, record the Application ID and the private key fingerprint in your secrets manager (e.g. 1Password).
 You may want to record the private key as well, or you may consider it sufficient to have it in SSM.


### PR DESCRIPTION
## what

- [eks/github-actions-runner] Update documentation to explain about tools missing from runners

## why

- Lack of common tools has caught people by surprise

## references

- Official documentation stating that runners contain [no more packages than are necessary](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners-with-actions-runner-controller/about-actions-runner-controller#about-the-runner-container-image)
- Feature request asking for additional tools in [actions/actions-runner-controller discussions](https://github.com/actions/actions-runner-controller/discussions/3168)
- Feature request asking for additional tools in [GitHub community discussions](https://github.com/orgs/community/discussions/80868)
- [Dockerfile](https://github.com/actions/actions-runner-controller/blob/3e4201ac5f6c6d172a19b580154eaf5abf24a2ca/runner/actions-runner.ubuntu-20.04.dockerfile#L22-L47) showing tools included in the Summwerwind (old) action runner image
- List of [tools pre-installed](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md) in the GitHub hosted runner image for Ubuntu 22.04
