### PR TITLE
fix `spacelift/admin-stack`: changed resource type from set to list

### DIFF
--- a/modules/spacelift/admin-stack/README.md
+++ b/modules/spacelift/admin-stack/README.md
@@ -157,11 +157,11 @@ components:
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_all_admin_stacks_config"></a> [all\_admin\_stacks\_config](#module\_all\_admin\_stacks\_config) | cloudposse/cloud-infrastructure-automation/spacelift//modules/spacelift-stacks-from-atmos-config | 1.4.0 |
-| <a name="module_child_stack"></a> [child\_stack](#module\_child\_stack) | cloudposse/cloud-infrastructure-automation/spacelift//modules/spacelift-stack | 1.4.0 |
-| <a name="module_child_stacks_config"></a> [child\_stacks\_config](#module\_child\_stacks\_config) | cloudposse/cloud-infrastructure-automation/spacelift//modules/spacelift-stacks-from-atmos-config | 1.4.0 |
-| <a name="module_root_admin_stack"></a> [root\_admin\_stack](#module\_root\_admin\_stack) | cloudposse/cloud-infrastructure-automation/spacelift//modules/spacelift-stack | 1.4.0 |
-| <a name="module_root_admin_stack_config"></a> [root\_admin\_stack\_config](#module\_root\_admin\_stack\_config) | cloudposse/cloud-infrastructure-automation/spacelift//modules/spacelift-stacks-from-atmos-config | 1.4.0 |
+| <a name="module_all_admin_stacks_config"></a> [all\_admin\_stacks\_config](#module\_all\_admin\_stacks\_config) | cloudposse/cloud-infrastructure-automation/spacelift//modules/spacelift-stacks-from-atmos-config | 1.5.0 |
+| <a name="module_child_stack"></a> [child\_stack](#module\_child\_stack) | cloudposse/cloud-infrastructure-automation/spacelift//modules/spacelift-stack | 1.5.0 |
+| <a name="module_child_stacks_config"></a> [child\_stacks\_config](#module\_child\_stacks\_config) | cloudposse/cloud-infrastructure-automation/spacelift//modules/spacelift-stacks-from-atmos-config | 1.5.0 |
+| <a name="module_root_admin_stack"></a> [root\_admin\_stack](#module\_root\_admin\_stack) | cloudposse/cloud-infrastructure-automation/spacelift//modules/spacelift-stack | 1.5.0 |
+| <a name="module_root_admin_stack_config"></a> [root\_admin\_stack\_config](#module\_root\_admin\_stack\_config) | cloudposse/cloud-infrastructure-automation/spacelift//modules/spacelift-stacks-from-atmos-config | 1.5.0 |
 | <a name="module_spaces"></a> [spaces](#module\_spaces) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 
@@ -203,7 +203,7 @@ components:
 | <a name="input_component_root"></a> [component\_root](#input\_component\_root) | The path, relative to the root of the repository, where the component can be found | `string` | n/a | yes |
 | <a name="input_component_vars"></a> [component\_vars](#input\_component\_vars) | All Terraform values to be applied to the stack via a mounted file | `any` | `{}` | no |
 | <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "descriptor_formats": {},<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "labels_as_tags": [<br>    "unset"<br>  ],<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {},<br>  "tenant": null<br>}</pre> | no |
-| <a name="input_context_attachments"></a> [context\_attachments](#input\_context\_attachments) | A list of context IDs to attach to this stack | `set(string)` | `[]` | no |
+| <a name="input_context_attachments"></a> [context\_attachments](#input\_context\_attachments) | A list of context IDs to attach to this stack | `list(string)` | `[]` | no |
 | <a name="input_context_filters"></a> [context\_filters](#input\_context\_filters) | Context filters to select atmos stacks matching specific criteria to create as children. | <pre>object({<br>    namespaces          = optional(list(string), [])<br>    environments        = optional(list(string), [])<br>    tenants             = optional(list(string), [])<br>    stages              = optional(list(string), [])<br>    tags                = optional(map(string), {})<br>    administrative      = optional(bool)<br>    root_administrative = optional(bool)<br>  })</pre> | n/a | yes |
 | <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between ID elements.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
 | <a name="input_description"></a> [description](#input\_description) | Specify description of stack | `string` | `null` | no |

--- a/modules/spacelift/admin-stack/child-stacks.tf
+++ b/modules/spacelift/admin-stack/child-stacks.tf
@@ -44,7 +44,7 @@ resource "null_resource" "child_stack_parent_precondition" {
 # for each one.
 module "child_stacks_config" {
   source  = "cloudposse/cloud-infrastructure-automation/spacelift//modules/spacelift-stacks-from-atmos-config"
-  version = "1.4.0"
+  version = "1.5.0"
 
   context_filters          = var.context_filters
   excluded_context_filters = var.excluded_context_filters
@@ -54,7 +54,7 @@ module "child_stacks_config" {
 
 module "child_stack" {
   source  = "cloudposse/cloud-infrastructure-automation/spacelift//modules/spacelift-stack"
-  version = "1.4.0"
+  version = "1.5.0"
 
   for_each = local.child_stacks
 

--- a/modules/spacelift/admin-stack/root-admin-stack.tf
+++ b/modules/spacelift/admin-stack/root-admin-stack.tf
@@ -3,7 +3,7 @@
 # such stack is allowed in the Spacelift organization.
 module "root_admin_stack_config" {
   source  = "cloudposse/cloud-infrastructure-automation/spacelift//modules/spacelift-stacks-from-atmos-config"
-  version = "1.4.0"
+  version = "1.5.0"
 
   enabled = local.create_root_admin_stack
 
@@ -15,7 +15,7 @@ module "root_admin_stack_config" {
 # This gets the atmos stack config for all of the administrative stacks
 module "all_admin_stacks_config" {
   source  = "cloudposse/cloud-infrastructure-automation/spacelift//modules/spacelift-stacks-from-atmos-config"
-  version = "1.4.0"
+  version = "1.5.0"
 
   enabled = local.create_root_admin_stack
 
@@ -26,7 +26,7 @@ module "all_admin_stacks_config" {
 
 module "root_admin_stack" {
   source  = "cloudposse/cloud-infrastructure-automation/spacelift//modules/spacelift-stack"
-  version = "1.4.0"
+  version = "1.5.0"
 
   enabled = local.create_root_admin_stack
 

--- a/modules/spacelift/admin-stack/variables.tf
+++ b/modules/spacelift/admin-stack/variables.tf
@@ -106,7 +106,7 @@ variable "component_vars" {
 }
 
 variable "context_attachments" {
-  type        = set(string)
+  type        = list(string)
   description = "A list of context IDs to attach to this stack"
   default     = []
 }


### PR DESCRIPTION
## what
- Change the resource type used for `var.context_attachments` to a list of strings rather than a set of strings

## why
- The terraform logic for Spacelift stack attachments (found in attachments.tf) uses a terraform for-loop in the two-symbol form to retrieve the index in each iteration of the loop. This leads to an error as the type of the variables used for these attachments is set(string), which does not support two-symbol loops.

## references
- https://github.com/cloudposse/terraform-spacelift-cloud-infrastructure-automation/pull/160
- resolves https://github.com/cloudposse/terraform-aws-components/issues/939 