### PR TITLE
fix: image links for website

### DIFF
--- a/modules/aws-ssosync/README.md
+++ b/modules/aws-ssosync/README.md
@@ -76,15 +76,15 @@ Follow these steps:
 2. Create a new project. Give the project a descriptive name such as `AWS SSO Sync`
 3. Enable Admin SDK in APIs: `APIs & Services > Enabled APIs & Services > + ENABLE APIS AND SERVICES`
 
-![Enable Admin SDK](./docs/img/admin_sdk.png)
+![Enable Admin SDK](https://raw.githubusercontent.com/cloudposse/terraform-aws-components/main/modules/aws-ssosync/docs/img/admin_sdk.png) # use raw URL so that this works in both GitHub and docusaurus
 
 4. Create Service Account: `IAM & Admin > Service Accounts > Create Service Account` [(ref)](https://cloud.google.com/iam/docs/service-accounts-create).
 
-![Create Service Account](./docs/img/create_service_account.png)
+![Create Service Account](https://raw.githubusercontent.com/cloudposse/terraform-aws-components/main/modules/aws-ssosync/docs/img/create_service_account.png) # use raw URL so that this works in both GitHub and docusaurus
 
 5. Download credentials for the new Service Account: `IAM & Admin > Service Accounts > select Service Account > Keys > ADD KEY > Create new key > JSON`
 
-![Download Credentials](./docs/img/dl_service_account_creds.png)
+![Download Credentials](https://raw.githubusercontent.com/cloudposse/terraform-aws-components/main/modules/aws-ssosync/docs/img/dl_service_account_creds.png) # use raw URL so that this works in both GitHub and docusaurus
 
 6. Save the JSON credentials as a new `SecureString` AWS SSM parameter in the same account used for AWS SSO. Use the full JSON string as the value for the parameter.
 


### PR DESCRIPTION
## what
- changed image links to raw urls for `aws-ssosync` component README

## why
- When the docs.cloudposse website tries to render docusarus from this README, the image is not found. Instead we can use the raw URL to the image that will work for both GitHub and for docusarus

## references
- follow up to #941 
- resolves this failure (private repo): https://github.com/cloudposse/refarch-scaffold/actions/runs/7351459617/job/20014834647

```console
Error: Image content/components/library/aws/aws-ssosync/docs/img/admin_sdk.png used in content/components/library/aws/aws-ssosync/README.md not found.
    at async Promise.all (index 0)
Error:  Client bundle compiled with errors therefore further build is impossible.
make: *** [Makefile:16: build] Error 1
Error: Process completed with exit code 2.
```