### PR TITLE
bugfix: `ECS` additional_certs is empty

### DIFF
--- a/modules/ecs/main.tf
+++ b/modules/ecs/main.tf
@@ -227,12 +227,12 @@ module "alb" {
 }
 
 locals {
-  # formats the loadbalancer configuration data to be:
+  # formats the load-balancer configuration data to be:
   # { "${alb_configuration key}_${additional_cert_entry}" => "additional_cert_entry" }
   certificate_domains = merge([
     for config_key, config in var.alb_configuration :
     { for domain in config.additional_certs :
-    "${config_key}_${domain}" => domain }
+    "${config_key}_${domain}" => domain } if lookup(config, "additional_certs", []) != []
   ]...)
 }
 


### PR DESCRIPTION
## what

 - ECS Cluster bugfix if optional deep nested kv is empty we shouldn't try to add the additional certs

## why

 - bugfix
