### PR TITLE
Lambda Component Support CICD

### DIFF
--- a/modules/lambda/README.md
+++ b/modules/lambda/README.md
@@ -107,6 +107,7 @@ components:
 |------|------|
 | [aws_iam_role_policy_attachment.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [archive_file.lambdazip](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
+| [aws_ssm_parameter.cicd_ssm_param](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 
 ## Inputs
 
@@ -115,6 +116,8 @@ components:
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br>This is for some rare cases where resources want additional configuration of tags<br>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
 | <a name="input_architectures"></a> [architectures](#input\_architectures) | Instruction set architecture for your Lambda function. Valid values are ["x86\_64"] and ["arm64"].<br>    Default is ["x86\_64"]. Removing this attribute, function's architecture stay the same. | `list(string)` | `null` | no |
 | <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br>in the order they appear in the list. New attributes are appended to the<br>end of the list. The elements of the list are joined by the `delimiter`<br>and treated as a single ID element. | `list(string)` | `[]` | no |
+| <a name="input_cicd_s3_key_format"></a> [cicd\_s3\_key\_format](#input\_cicd\_s3\_key\_format) | The format of the S3 key to store the latest version/sha of the Lambda function. This is used with cicd\_ssm\_param\_name. Defaults to 'stage/{stage}/lambda/{function\_name}/%s.zip' | `string` | `null` | no |
+| <a name="input_cicd_ssm_param_name"></a> [cicd\_ssm\_param\_name](#input\_cicd\_ssm\_param\_name) | The name of the SSM parameter to store the latest version/sha of the Lambda function. This is used with cicd\_s3\_key\_format | `string` | `null` | no |
 | <a name="input_cloudwatch_event_rules"></a> [cloudwatch\_event\_rules](#input\_cloudwatch\_event\_rules) | Creates EventBridge (CloudWatch Events) rules for invoking the Lambda Function along with the required permissions. | `map(any)` | `{}` | no |
 | <a name="input_cloudwatch_lambda_insights_enabled"></a> [cloudwatch\_lambda\_insights\_enabled](#input\_cloudwatch\_lambda\_insights\_enabled) | Enable CloudWatch Lambda Insights for the Lambda Function. | `bool` | `false` | no |
 | <a name="input_cloudwatch_log_subscription_filters"></a> [cloudwatch\_log\_subscription\_filters](#input\_cloudwatch\_log\_subscription\_filters) | CloudWatch Logs subscription filter resources. Currently supports only Lambda functions as destinations. | `map(any)` | `{}` | no |

--- a/modules/lambda/variables.tf
+++ b/modules/lambda/variables.tf
@@ -312,3 +312,16 @@ variable "zip" {
   description = "Zip Configuration for local file deployments"
   default     = {}
 }
+
+
+variable "cicd_ssm_param_name" {
+  type        = string
+  description = "The name of the SSM parameter to store the latest version/sha of the Lambda function. This is used with cicd_s3_key_format"
+  default     = null
+}
+
+variable "cicd_s3_key_format" {
+  type        = string
+  description = "The format of the S3 key to store the latest version/sha of the Lambda function. This is used with cicd_ssm_param_name. Defaults to 'stage/{stage}/lambda/{function_name}/%s.zip'"
+  default     = null
+}


### PR DESCRIPTION
## what

- Adds changes from our main_overrides.tf to simplify the ability to deploy a lambda through CICD using SSM Parameter store and an s3 bucket

## why

Simplify deployment process

