### PR TITLE
fix-lambda-function-name-null

### DIFF
--- a/modules/lambda/main.tf
+++ b/modules/lambda/main.tf
@@ -2,8 +2,8 @@ locals {
   enabled             = module.this.enabled
   iam_policy_enabled  = local.enabled && (try(length(var.iam_policy), 0) > 0 || var.policy_json != null)
   s3_bucket_full_name = var.s3_bucket_name != null ? format("%s-%s-%s-%s-%s", module.this.namespace, module.this.tenant, module.this.environment, module.this.stage, var.s3_bucket_name) : null
-
-  cicd_s3_key_format = var.cicd_s3_key_format != null ? var.cicd_s3_key_format : "stage/${module.this.stage}/lambda/${var.function_name}/%s"
+  function_name = coalesce(var.function_name, module.label.id)
+  cicd_s3_key_format = var.cicd_s3_key_format != null ? var.cicd_s3_key_format : "stage/${module.this.stage}/lambda/${local.function_name}/%s"
   s3_key             = var.s3_bucket_name == null ? null : (var.s3_key != null ? var.s3_key : format(local.cicd_s3_key_format, coalesce(one(data.aws_ssm_parameter.cicd_ssm_param[*].value), "example")))
 
 }
@@ -53,7 +53,7 @@ module "lambda" {
   source  = "cloudposse/lambda-function/aws"
   version = "0.4.1"
 
-  function_name      = coalesce(var.function_name, module.label.id)
+  function_name      = local.function_name
   description        = var.description
   handler            = var.handler
   lambda_environment = var.lambda_environment

--- a/modules/lambda/main.tf
+++ b/modules/lambda/main.tf
@@ -2,9 +2,9 @@ locals {
   enabled             = module.this.enabled
   iam_policy_enabled  = local.enabled && (try(length(var.iam_policy), 0) > 0 || var.policy_json != null)
   s3_bucket_full_name = var.s3_bucket_name != null ? format("%s-%s-%s-%s-%s", module.this.namespace, module.this.tenant, module.this.environment, module.this.stage, var.s3_bucket_name) : null
-  function_name = coalesce(var.function_name, module.label.id)
-  cicd_s3_key_format = var.cicd_s3_key_format != null ? var.cicd_s3_key_format : "stage/${module.this.stage}/lambda/${local.function_name}/%s"
-  s3_key             = var.s3_bucket_name == null ? null : (var.s3_key != null ? var.s3_key : format(local.cicd_s3_key_format, coalesce(one(data.aws_ssm_parameter.cicd_ssm_param[*].value), "example")))
+  function_name       = coalesce(var.function_name, module.label.id)
+  cicd_s3_key_format  = var.cicd_s3_key_format != null ? var.cicd_s3_key_format : "stage/${module.this.stage}/lambda/${local.function_name}/%s"
+  s3_key              = var.s3_bucket_name == null ? null : (var.s3_key != null ? var.s3_key : format(local.cicd_s3_key_format, coalesce(one(data.aws_ssm_parameter.cicd_ssm_param[*].value), "example")))
 
 }
 


### PR DESCRIPTION
Solution is to  address a bug in the Terraform lambda component where null values for var.function_name break the formatting of local.cicd_s3_key_format. The bug causes issues when no function name is provided, which should default to using module.label.id instead.

https://github.com/sm-core/infrastructure/pull/1115
