### PR TITLE
Consolidate auto-release workflow

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -15,4 +15,4 @@ jobs:
         with:
           prerelease: false
           publish: true
-          config-name: auto-release.yml          
+          config-name: auto-release.yml

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -11,16 +11,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      # Get PR from merged commit to master
-      - uses: actions-ecosystem/action-get-merged-pull-request@v1
-        id: get-merged-pull-request
+      - uses: cloudposse/github-action-auto-release@v1
         with:
-          github_token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
-      # Drafts your next Release notes as Pull Requests are merged into "main"
-      - uses: release-drafter/release-drafter@v5
-        with:
-          publish: ${{ !contains(steps.get-merged-pull-request.outputs.labels, 'no-release') }}
           prerelease: false
-          config-name: auto-release.yml
-        env:
-          GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+          publish: true
+          config-name: auto-release.yml          

--- a/.github/workflows/bats.yml
+++ b/.github/workflows/bats.yml
@@ -16,7 +16,7 @@ jobs:
       BATS_SUBMODULE_TESTS: input-descriptions lint output-descriptions
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
         repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -32,7 +32,7 @@ jobs:
         HEAD_REF: ${{ github.head_ref }}
       run: |
         # when running in test-harness, need to mark the directory safe for git operations
-        make safe-directory
+        make get-safe-directory
         MODIFIED_MODULES=($(git diff --name-only origin/${BASE_REF} origin/${HEAD_REF} | xargs -n 1 dirname | sort | uniq | grep ^modules/ || true))
         if [ -z "$MODIFIED_MODULES" ]; then
             echo "No modules changed in this PR. Skipping tests."

--- a/.github/workflows/bats.yml
+++ b/.github/workflows/bats.yml
@@ -32,7 +32,7 @@ jobs:
         HEAD_REF: ${{ github.head_ref }}
       run: |
         # when running in test-harness, need to mark the directory safe for git operations
-        make get-safe-directory
+        make git-safe-directory
         MODIFIED_MODULES=($(git diff --name-only origin/${BASE_REF} origin/${HEAD_REF} | xargs -n 1 dirname | sort | uniq | grep ^modules/ || true))
         if [ -z "$MODIFIED_MODULES" ]; then
             echo "No modules changed in this PR. Skipping tests."


### PR DESCRIPTION
## what
* Use `cloudposse/github-action-auto-release` in `auto-release.yaml` workflow

## why
* Solve old nodejs warning
* Reduce duplication of code
