### PR TITLE
Update vpc-flow-logs.tf

### DIFF
--- a/modules/vpc/vpc-flow-logs.tf
+++ b/modules/vpc/vpc-flow-logs.tf
@@ -1,7 +1,7 @@
 # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/flow_log
 
 resource "aws_flow_log" "default" {
-  count                = local.vpc_flow_logs_enabled ? 1 : 0
+  count                = local.enabled && local.vpc_flow_logs_enabled ? 1 : 0
   log_destination      = module.vpc_flow_logs_bucket[0].outputs.vpc_flow_logs_bucket_arn
   log_destination_type = var.vpc_flow_logs_log_destination_type
   traffic_type         = var.vpc_flow_logs_traffic_type


### PR DESCRIPTION
If the VPC flag is enabled, you can create AWS Flow Logs. Without VPC, it will result in an error.

## what

- In vpc-flow-logs.tf, I have updated condition, so that vpc flow logs gets created only if enabled and vpc_flow_logs_enabled is true.

## why

- If the VPC flag is enabled, you can create AWS Flow Logs. Without VPC, it will result in an error.

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow).
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
