### PR TITLE
Update remote-state.tf in vpc module

### DIFF
--- a/modules/vpc/remote-state.tf
+++ b/modules/vpc/remote-state.tf
@@ -1,5 +1,5 @@
 module "vpc_flow_logs_bucket" {
-  count = var.vpc_flow_logs_enabled ? 1 : 0
+  count = local.vpc_flow_logs_enabled ? 1 : 0
 
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
   version = "1.5.0"


### PR DESCRIPTION
## what

- replace var.vpc_flow_logs_enabled with local.vpc_flow_logs_enabled in remote-state.tf

## why

- Because it was giving error when vpc was disabled (when enabled flag was set to false).

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow).
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
