### PR TITLE
SQS module - replace relative path

### DIFF
--- a/modules/sqs-queue/main.tf
+++ b/modules/sqs-queue/main.tf
@@ -3,7 +3,7 @@ locals {
 }
 
 module "sqs_queue" {
-  source = "./modules/terraform-aws-sqs-queue"
+  source = "github.com/cloudposse/terraform-aws-components.git//modules/sqs-queue/modules/terraform-aws-sqs-queue?ref=1.398.0"
 
   visibility_timeout_seconds        = var.visibility_timeout_seconds
   message_retention_seconds         = var.message_retention_seconds


### PR DESCRIPTION
in sqs-queue module changed relative path with absolute path, as it was giving error when used with atmos , pulled it using vendor pull.

## what

- in sqs-queue module changed relative path with absolute path

## why

- it was giving error when used with atmos , pulled it using vendor pull.

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow).
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
