### PR TITLE
chore: upgrades child iam-account-settings for hashicorp/template fix

### DIFF
--- a/modules/account-settings/main.tf
+++ b/modules/account-settings/main.tf
@@ -8,7 +8,7 @@ resource "aws_ebs_encryption_by_default" "default" {
 # It also sets the account alias for the current account.
 module "iam_account_settings" {
   source  = "cloudposse/iam-account-settings/aws"
-  version = "0.4.0"
+  version = "0.5.0"
 
   hard_expiry             = true
   minimum_password_length = var.minimum_password_length


### PR DESCRIPTION
## what

* Bumps `accounts-settings` component's `iam-account-settings` child module version to `0.5.0` 

## why

* Obtain the fix from https://github.com/cloudposse/terraform-aws-iam-account-settings/releases/tag/0.4.1 : `hashicorp/template` provider is not built for `darwin_arm64`
* Stay up-to-date

## references

* N/A