### PR TITLE
`philips-labs-github-runners` install terraform docs

### DIFF
--- a/modules/philips-labs-github-runners/templates/userdata_post_install.sh
+++ b/modules/philips-labs-github-runners/templates/userdata_post_install.sh
@@ -14,3 +14,6 @@ sudo yum install -y gh
 
 # Install nodejs
 sudo yum install -y nodejs-1:18.18.2-1.amzn2023.0.1
+
+# Install terraform-docs
+curl -L "$(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/latest | grep -o -E -m 1 "https://.+?-linux-amd64.tar.gz")" > terraform-docs.tgz && tar -xzf terraform-docs.tgz terraform-docs && rm terraform-docs.tgz && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/


### PR DESCRIPTION
## what

- install `terraform-docs` on philips labs runners by default

## why

required for many of our actions
