### PR TITLE
chore: ecs-service policies should allow tagging now

### DIFF
--- a/modules/ecs-service/github-actions-iam-policy.tf
+++ b/modules/ecs-service/github-actions-iam-policy.tf
@@ -111,6 +111,7 @@ data "aws_iam_policy_document" "github_actions_iam_ecspresso_policy" {
     effect = "Allow"
     actions = [
       "ecs:RegisterTaskDefinition",
+      "ecs:TagResource",
       "ecs:DescribeTaskDefinition",
       "ecs:DescribeTasks",
       "application-autoscaling:DescribeScalableTargets"


### PR DESCRIPTION
## what

- add `ecs:TagResource` permission to policies

## why

- changes to ECS policies mean that Task definitions can't have tagging
details without a policy update

## references

- [Tag Resource permissions in
ECS](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-account-settings.html#tag-resources-setting)

