### PR TITLE
[spa-s3-cloudfront] Fix preview enviornments

### DIFF
--- a/modules/spa-s3-cloudfront/CHANGELOG.md
+++ b/modules/spa-s3-cloudfront/CHANGELOG.md
@@ -1,8 +1,8 @@
-## Component PR [#991]()
+## Component PRs [#991](https://github.com/cloudposse/terraform-aws-components/pull/991) and [#995](https://github.com/cloudposse/terraform-aws-components/pull/995)
 
-### Drop `lambda_edge_redirect_404`
+### Drop `lambda_edge_redirect_404` 
 
-This PR removes the `lambda_edge_redirect_404` functionality because it leads to significat costs. 
+This PRs removes the `lambda_edge_redirect_404` functionality because it leads to significat costs. 
 Use native CloudFront error pages configs instead.
 
 ```yaml


### PR DESCRIPTION
## what

* [spa-s3-cloudfront] Fix preview environments

## why

* Preview envs required `x-forwarded-host` that is set by paywall lambdas. When the paywall is disabled, the preview still needs to work correctly.

