### PR TITLE
Fix: `ecs-service` perma-drift for `key_id`

### DIFF
--- a/modules/ecs-service/systems-manager.tf
+++ b/modules/ecs-service/systems-manager.tf
@@ -51,9 +51,11 @@ resource "aws_ssm_parameter" "full_urls" {
   name        = each.key
   description = each.value.description
   type        = each.value.type
-  key_id      = var.kms_alias_name_ssm
-  value       = each.value.value
-  overwrite   = true
+  # key_id is only used with SecureStrings.
+  # With other types Terraform will pass but will constantly suggest adding the key_id (perma drift)
+  key_id    = each.value.type == "SecureString" ? var.kms_alias_name_ssm : null
+  value     = each.value.value
+  overwrite = true
 
   tags = module.this.tags
 }


### PR DESCRIPTION
## what
- Only set `key_id` for `aws_ssm_parameter` when the type is "SecureString"

## why
- With other types Terraform will pass but will constantly suggest adding the `key_id`

## references
- https://github.com/hashicorp/terraform-provider-aws/issues/21095
