### PR TITLE
hotfix: `ecs-service` S3 Mirroring conditional

### DIFF
--- a/modules/ecs-service/outputs.tf
+++ b/modules/ecs-service/outputs.tf
@@ -54,6 +54,6 @@ output "service_image" {
 }
 
 output "task_template" {
-  value       = jsondecode(nonsensitive(jsonencode(local.task_template)))
+  value       = local.s3_mirroring_enabled ? jsondecode(nonsensitive(jsonencode(local.task_template))) : null
   description = "The task template rendered"
 }


### PR DESCRIPTION
## what

- S3 mirroring should be a conditional statement for additional features

## why

- Missed conditionals which prevent's backwards compatibility

## references

#997 