### PR TITLE
fix: prettier format errors

### DIFF
--- a/modules/eks/actions-runner-controller/README.md
+++ b/modules/eks/actions-runner-controller/README.md
@@ -313,7 +313,9 @@ on the capacity reservation until enough reservations ahead of it are removed fo
 and active job. Although there are some edge cases regarding `webhook_startup_timeout` that seem not to be covered
 properly (see
 [actions-runner-controller issue #2466](https://github.com/actions/actions-runner-controller/issues/2466)), they only
-merit adding a few extra minutes to the timeout. :::
+merit adding a few extra minutes to the timeout.
+
+:::
 
 ### Recommended `webhook_startup_timeout` Duration
 

--- a/modules/eks/datadog-agent/README.md
+++ b/modules/eks/datadog-agent/README.md
@@ -107,9 +107,10 @@ for `<integration name>.yaml`.
 
 :::caution The key of a filename must match datadog docs, which is `<INTEGRATION_NAME>.yaml`
 [Datadog Cluster Checks](https://docs.datadoghq.com/agent/cluster_agent/clusterchecks/?tab=helm#configuration-from-static-configuration-files)
+:::
 
-::: Cluster Checks **can** be used for external URL testing (loadbalancer endpoints), whereas annotations **must** be
-used for kubernetes services.
+Cluster Checks **can** be used for external URL testing (loadbalancer endpoints), whereas annotations **must** be used
+for kubernetes services.
 
 ```
 http_check.yaml:

--- a/modules/github-runners/README.md
+++ b/modules/github-runners/README.md
@@ -179,7 +179,9 @@ permissions “mode” for Self-hosted runners to Read-Only. The instructions fo
 
 :::info We highly recommend using a GitHub Application with the github-action-token-rotator module to generate the
 Registration Token. This will ensure that the token is rotated and that the token is stored in SSM Parameter Store
-encrypted with KMS. :::
+encrypted with KMS.
+
+:::
 
 #### GitHub Application
 

--- a/modules/tfstate-backend/README.md
+++ b/modules/tfstate-backend/README.md
@@ -13,7 +13,9 @@ security configuration information, so careful planning is required when archite
 :::info Part of cold start so it has to initially be run with `SuperAdmin`, multiple times: to create the S3 bucket and
 then to move the state into it. Follow the guide
 **[here](https://docs.cloudposse.com/reference-architecture/how-to-guides/implementation/enterprise/implement-aws-cold-start/#provision-tfstate-backend-component)**
-to get started. :::
+to get started.
+
+:::
 
 ### Access Control
 


### PR DESCRIPTION
## what

- move the end of `:::` blocks

## why

- prettier tries to flow them into the paragraph, which causes docusaurus to
not close blocks

## references

- see example of error here: https://docs.cloudposse.com/components/library/aws/tfstate-backend/
