### PR TITLE
`ecs-service` better task definition merging

### DIFF
--- a/modules/ecs-service/CHANGELOG.md
+++ b/modules/ecs-service/CHANGELOG.md
@@ -1,0 +1,11 @@
+## PR [#]()
+
+### Possible Breaking Change
+
+- Refactored how S3 Task Definitions and the Terraform Task definition are merged.
+  - Introduced local `local.containers_priority_terraform` to be referenced whenever terraform Should take priority
+  - Introduced local `local.containers_priority_s3` to be referenced whenever S3 Should take priority
+- `map_secrets` pulled out from container definition to local where it can be better maintained. Used Terraform as
+  priority as it is a calculated as a map of arns.
+- `s3_mirror_name` now automatically uploads a task-template.json to s3 mirror where it can be pulled from GitHub
+  Actions.

--- a/modules/ecs-service/CHANGELOG.md
+++ b/modules/ecs-service/CHANGELOG.md
@@ -1,4 +1,4 @@
-## PR [#]()
+## PR [#1008](https://github.com/cloudposse/terraform-aws-components/pull/1008)
 
 ### Possible Breaking Change
 

--- a/modules/ecs-service/README.md
+++ b/modules/ecs-service/README.md
@@ -458,6 +458,8 @@ components:
 | <a name="output_ssm_key_prefix"></a> [ssm\_key\_prefix](#output\_ssm\_key\_prefix) | SSM prefix |
 | <a name="output_ssm_parameters"></a> [ssm\_parameters](#output\_ssm\_parameters) | SSM parameters for the ECS Service |
 | <a name="output_subnet_ids"></a> [subnet\_ids](#output\_subnet\_ids) | Selected subnet IDs |
+| <a name="output_task_definition_arn"></a> [task\_definition\_arn](#output\_task\_definition\_arn) | The task definition ARN |
+| <a name="output_task_definition_revision"></a> [task\_definition\_revision](#output\_task\_definition\_revision) | The task definition revision |
 | <a name="output_task_template"></a> [task\_template](#output\_task\_template) | The task template rendered |
 | <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | Selected VPC ID |
 | <a name="output_vpc_sg_id"></a> [vpc\_sg\_id](#output\_vpc\_sg\_id) | Selected VPC SG ID |

--- a/modules/ecs-service/outputs.tf
+++ b/modules/ecs-service/outputs.tf
@@ -49,11 +49,21 @@ output "environment_map" {
 }
 
 output "service_image" {
-  value       = try(nonsensitive(local.containers.service.image), null)
+  value       = try(nonsensitive(local.containers_priority_terraform.service.image), null)
   description = "The image of the service container"
 }
 
 output "task_template" {
   value       = local.s3_mirroring_enabled ? jsondecode(nonsensitive(jsonencode(local.task_template))) : null
   description = "The task template rendered"
+}
+
+output "task_definition_arn" {
+  value       = one(module.ecs_alb_service_task[*].task_definition_arn)
+  description = "The task definition ARN"
+}
+
+output "task_definition_revision" {
+  value       = one(module.ecs_alb_service_task[*].task_definition_revision)
+  description = "The task definition revision"
 }

--- a/modules/ecs-service/systems-manager.tf
+++ b/modules/ecs-service/systems-manager.tf
@@ -51,11 +51,9 @@ resource "aws_ssm_parameter" "full_urls" {
   name        = each.key
   description = each.value.description
   type        = each.value.type
-  # key_id is only used with SecureStrings.
-  # With other types Terraform will pass but will constantly suggest adding the key_id (perma drift)
-  key_id    = each.value.type == "SecureString" ? var.kms_alias_name_ssm : null
-  value     = each.value.value
-  overwrite = true
+  key_id      = var.kms_alias_name_ssm
+  value       = each.value.value
+  overwrite   = true
 
   tags = module.this.tags
 }


### PR DESCRIPTION
## what

ECS Service Upstream for better support of partial task definition.

## why

* Fixes issue with bad merges on s3 task definition
  * Map_secrets not being updated


