### PR TITLE
`account-map` bugfix

### DIFF
--- a/modules/account-map/dynamic-roles.tf
+++ b/modules/account-map/dynamic-roles.tf
@@ -60,7 +60,7 @@ locals {
 
   # ASSUMPTIONS: The stack pattern is the same for all accounts and uses the same delimiter as null-label
   teams_stacks = local.dynamic_role_enabled ? {
-    for k, v in yamldecode(data.utils_describe_stacks.teams[0].output) : k => v if !local.stack_has_namespace || try(split(module.this.delimiter, k)[local.stack_namespace_index] == module.this.namespace, false)
+    for k, v in yamldecode(data.utils_describe_stacks.teams[0].output) : k => v if v != {} && (!local.stack_has_namespace || try(split(module.this.delimiter, k)[local.stack_namespace_index] == module.this.namespace, false))
   } : local.empty
 
   teams_vars   = { for k, v in local.teams_stacks : k => v.components.terraform.aws-teams.vars }
@@ -69,7 +69,7 @@ locals {
   team_arns    = { for team_name in local.team_names : team_name => format(local.iam_role_arn_templates[local.account_role_map.identity], team_name) }
 
   team_roles_stacks = local.dynamic_role_enabled ? {
-    for k, v in yamldecode(data.utils_describe_stacks.team_roles[0].output) : k => v if !local.stack_has_namespace || try(split(module.this.delimiter, k)[local.stack_namespace_index] == module.this.namespace, false)
+    for k, v in yamldecode(data.utils_describe_stacks.team_roles[0].output) : k => v if v != {} && (!local.stack_has_namespace || try(split(module.this.delimiter, k)[local.stack_namespace_index] == module.this.namespace, false))
   } : local.empty
 
   team_roles_vars = { for k, v in local.team_roles_stacks : k => v.components.terraform.aws-team-roles.vars }

--- a/modules/account-map/dynamic-roles.tf
+++ b/modules/account-map/dynamic-roles.tf
@@ -60,19 +60,19 @@ locals {
 
   # ASSUMPTIONS: The stack pattern is the same for all accounts and uses the same delimiter as null-label
   teams_stacks = local.dynamic_role_enabled ? {
-    for k, v in yamldecode(data.utils_describe_stacks.teams[0].output) : k => v if v != {} && (!local.stack_has_namespace || try(split(module.this.delimiter, k)[local.stack_namespace_index] == module.this.namespace, false))
+    for k, v in yamldecode(data.utils_describe_stacks.teams[0].output) : k => v if !local.stack_has_namespace || try(split(module.this.delimiter, k)[local.stack_namespace_index] == module.this.namespace, false)
   } : local.empty
 
-  teams_vars   = { for k, v in local.teams_stacks : k => v.components.terraform.aws-teams.vars }
+  teams_vars   = { for k, v in local.teams_stacks : k => try(v.components.terraform.aws-teams.vars, k) if try(v.components.terraform.aws-teams.vars, null) != null }
   teams_config = local.dynamic_role_enabled ? values(local.teams_vars)[0].teams_config : local.empty
   team_names   = [for k, v in local.teams_config : k if try(v.enabled, true)]
   team_arns    = { for team_name in local.team_names : team_name => format(local.iam_role_arn_templates[local.account_role_map.identity], team_name) }
 
   team_roles_stacks = local.dynamic_role_enabled ? {
-    for k, v in yamldecode(data.utils_describe_stacks.team_roles[0].output) : k => v if v != {} && (!local.stack_has_namespace || try(split(module.this.delimiter, k)[local.stack_namespace_index] == module.this.namespace, false))
+    for k, v in yamldecode(data.utils_describe_stacks.team_roles[0].output) : k => v if !local.stack_has_namespace || try(split(module.this.delimiter, k)[local.stack_namespace_index] == module.this.namespace, false)
   } : local.empty
 
-  team_roles_vars = { for k, v in local.team_roles_stacks : k => v.components.terraform.aws-team-roles.vars }
+  team_roles_vars = { for k, v in local.team_roles_stacks : k => try(v.components.terraform.aws-team-roles.vars, k) if try(v.components.terraform.aws-team-roles.vars, null) != null }
 
   all_team_vars = merge(local.teams_vars, local.team_roles_vars)
 

--- a/modules/account-map/dynamic-roles.tf
+++ b/modules/account-map/dynamic-roles.tf
@@ -63,7 +63,7 @@ locals {
     for k, v in yamldecode(data.utils_describe_stacks.teams[0].output) : k => v if !local.stack_has_namespace || try(split(module.this.delimiter, k)[local.stack_namespace_index] == module.this.namespace, false)
   } : local.empty
 
-  teams_vars   = { for k, v in local.teams_stacks : k => try(v.components.terraform.aws-teams.vars, k) if try(v.components.terraform.aws-teams.vars, null) != null }
+  teams_vars   = { for k, v in local.teams_stacks : k => v.components.terraform.aws-teams.vars if try(v.components.terraform.aws-teams.vars, null) != null }
   teams_config = local.dynamic_role_enabled ? values(local.teams_vars)[0].teams_config : local.empty
   team_names   = [for k, v in local.teams_config : k if try(v.enabled, true)]
   team_arns    = { for team_name in local.team_names : team_name => format(local.iam_role_arn_templates[local.account_role_map.identity], team_name) }
@@ -72,9 +72,8 @@ locals {
     for k, v in yamldecode(data.utils_describe_stacks.team_roles[0].output) : k => v if !local.stack_has_namespace || try(split(module.this.delimiter, k)[local.stack_namespace_index] == module.this.namespace, false)
   } : local.empty
 
-  team_roles_vars = { for k, v in local.team_roles_stacks : k => try(v.components.terraform.aws-team-roles.vars, k) if try(v.components.terraform.aws-team-roles.vars, null) != null }
-
-  all_team_vars = merge(local.teams_vars, local.team_roles_vars)
+  team_roles_vars = { for k, v in local.team_roles_stacks : k => v.components.terraform.aws-team-roles.vars if try(v.components.terraform.aws-team-roles.vars, null) != null }
+  all_team_vars   = merge(local.teams_vars, local.team_roles_vars)
 
   stack_planners     = { for k, v in local.team_roles_vars : k => v.roles[local.plan_role].trusted_teams if try(length(v.roles[local.plan_role].trusted_teams), 0) > 0 && try(v.roles[local.plan_role].enabled, true) }
   stack_terraformers = { for k, v in local.team_roles_vars : k => v.roles[local.apply_role].trusted_teams if try(length(v.roles[local.apply_role].trusted_teams), 0) > 0 && try(v.roles[local.apply_role].enabled, true) }


### PR DESCRIPTION
## what

* Bugfix for Account-map: Do not check empty Stack definitions


 
## why

  Currently, `account-map` reads all stacks and looks for `aws-team-roles` and `aws-teams` components. This currently works when all stacks are defined. We often deploy many stacks that do not have team roles, specifically when deploying our compliance suite.

example command:
```bash
atmos describe stacks --components=aws-teams --component-types=terraform --sections=vars
```
sample Output:
```yaml
core-euw3-security: {}
core-gbl-identity:
  components:
    terraform:
      aws-teams:
        vars:
          descriptor_formats: ...
core-sae1-artifacts: {}
core-sae1-audit: {}
core-sae1-auto: {}
```

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow).
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
