### PR TITLE
[tfstate-backend] Recommend explicit configuration of SuperAdmin

### DIFF
--- a/modules/tfstate-backend/README.md
+++ b/modules/tfstate-backend/README.md
@@ -10,9 +10,11 @@ wish to restrict who can read the production Terraform state backend S3 bucket. 
 all Terraform users require read access to the most sensitive accounts, such as `root` and `audit`, in order to read
 security configuration information, so careful planning is required when architecting backend splits.
 
-:::info Part of cold start so it has to initially be run with `SuperAdmin`, multiple times: to create the S3 bucket and
-then to move the state into it. Follow the guide
-**[here](https://docs.cloudposse.com/reference-architecture/how-to-guides/implementation/enterprise/implement-aws-cold-start/#provision-tfstate-backend-component)**
+:::info
+
+Part of cold start, so it has to initially be run with `SuperAdmin`, multiple
+times: to create the S3 bucket and then to move the state into it. Follow
+the guide **[here](https://docs.cloudposse.com/reference-architecture/how-to-guides/implementation/enterprise/implement-aws-cold-start/#provision-tfstate-backend-component)**
 to get started.
 
 :::
@@ -56,7 +58,9 @@ access. You can configure who is allowed to assume these roles.
 
 - For convenience, the component automatically grants access to the backend to the user deploying it. This is helpful
   because it allows that user, presumably SuperAdmin, to deploy the normal components that expect the user does not have
-  direct access to Terraform state.
+  direct access to Terraform state, without requiring custom configuration. However, you may want to explicitly
+  grant SuperAdmin access to the backend in the `allowed_principal_arns` configuration, to ensure that SuperAdmin
+  can always access the backend, even if the component is later updated by the `root-admin` role.
 
 ### Quotas
 

--- a/modules/tfstate-backend/iam.tf
+++ b/modules/tfstate-backend/iam.tf
@@ -35,7 +35,7 @@ module "assume_role" {
   denied_roles  = each.value.denied_roles
 
   # Allow whatever user or role is running Terraform to manage the backend to assume any backend access role
-  allowed_principal_arns = concat(each.value.allowed_principal_arns, [local.caller_arn])
+  allowed_principal_arns = distinct(concat(each.value.allowed_principal_arns, [local.caller_arn]))
   denied_principal_arns  = each.value.denied_principal_arns
   # Permission sets are for AWS SSO, which is optional
   allowed_permission_sets = try(each.value.allowed_permission_sets, {})


### PR DESCRIPTION
## what

- `tfstate-backend`:
  - Update documentation to recommend explicitly configuring SuperAdmin access when convenient
  - Update component to filter out duplicate "allowed principal" when current user is explicitly allowed

## why

- The current reference architecture allows both SuperAdmin and `root-admin` to administer most "cold-start" components after cold start has been completed. However, without these changes, if `root-admin` updated `tfstate-backend`, SuperAdmin would lose access to Terraform state.

