### PR TITLE
[eks/echo-server] Fix resource settings via chart inputs

### DIFF
--- a/modules/eks/echo-server/charts/echo-server/templates/deployment.yaml
+++ b/modules/eks/echo-server/charts/echo-server/templates/deployment.yaml
@@ -45,10 +45,14 @@ spec:
             successThreshold: 1
           {{- with index .Values "resources" }}
           resources:
+            {{- with index . "limits" }}
             limits:
-              cpu: {{ index . "limits.cpu" | default "50m" }}
-              memory: {{ index . "limits.memory" | default "128Mi" }}
+              cpu: {{ index . "cpu" | default "50m" }}
+              memory: {{ index . "memory" | default "128Mi" }}
+            {{- end }}
+            {{- with index . "requests" }}
             requests:
-              cpu: {{ index . "requests.cpu" | default "50m" }}
-              memory: {{ index . "requests.memory" | default "128Mi" }}
+              cpu: {{ index . "cpu" | default "50m" }}
+              memory: {{ index . "memory" | default "128Mi" }}
+            {{- end }}
           {{- end }}


### PR DESCRIPTION
## what

- Fix setting resources limits and request via chart inputs

## why

- Previously, the Deployment template incorrectly accessed the chart values for resource limits and requests, making them impossible to set.

Echo-server can serve other purposes than just verifying end-to-end cluster configuration. Among them, by setting high resource requests, it can be used to trigger cluster autoscaling. However, that requires resource requests settings to be able to be configured.

