### PR TITLE
Use GitHub Action Workflows from `cloudposse/.github` Repo

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -1,0 +1,19 @@
+---
+name: release-branch
+on:
+  push:
+    branches:
+      - main
+      - release/v*
+    paths-ignore:
+      - '.github/**'
+      - 'docs/**'
+      - 'examples/**'
+      - 'test/**'
+
+permissions: {}
+
+jobs:
+  terraform-module:
+    uses: cloudposse/github-actions-workflows-terraform-module/.github/workflows/release-branch.yml@main
+    secrets: inherit

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -1,0 +1,13 @@
+---
+name: release-published
+on:
+  release:
+    types:
+      - published
+
+permissions: {}
+
+jobs:
+  terraform-module:
+    uses: cloudposse/github-actions-workflows-terraform-module/.github/workflows/release-published.yml@main
+    secrets: inherit


### PR DESCRIPTION
## what

- Install latest GitHub Action Workflows

## why

- Use shared workflows from `cldouposse/.github` repository
- Simplify management of workflows from centralized hub of configuration
