### PR TITLE
fix: `api-gateway-rest-api` Default Value

### DIFF
--- a/modules/api-gateway-rest-api/remote-state.tf
+++ b/modules/api-gateway-rest-api/remote-state.tf
@@ -15,6 +15,10 @@ module "acm" {
   component     = "acm"
   ignore_errors = true
 
+  defaults = {
+    domain_name = ""
+  }
+
   context = module.this.context
 }
 


### PR DESCRIPTION
## what
- Set default value for remote `acm` component reference in the `api-gateway-rest-api` component

## why
- When the `acm` component doesnt exist, we want to use the value from `dns-delegated` instead like this

```hcl
  root_domain = coalesce(module.acm.outputs.domain_name, join(".", [
    module.this.environment, module.dns_delegated.outputs.default_domain_name
  ]), module.dns_delegated.outputs.default_domain_name)
```

- However, if `acm` doesnt exist, `module.acm.outputs` will be null:

```console
│ Error: Attempt to get attribute from null value
│
│   on main.tf line 5, in locals:
│    5:   root_domain = coalesce(module.acm.outputs.domain_name, join(".", [
│     ├────────────────
│     │ module.acm.outputs is null
│
│ This value is null, so it does not have any attributes.
╵
exit status 1
```

## references
- n/a