### PR TITLE
`sqs-queue`: Update to include SQS Policy

### DIFF
--- a/modules/sqs-queue/README.md
+++ b/modules/sqs-queue/README.md
@@ -30,19 +30,25 @@ components:
 
 ## Providers
 
-No providers.
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
+| <a name="module_queue_policy"></a> [queue\_policy](#module\_queue\_policy) | cloudposse/iam-policy/aws | 2.0.1 |
 | <a name="module_sqs_queue"></a> [sqs\_queue](#module\_sqs\_queue) | ./modules/terraform-aws-sqs-queue | n/a |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 
 ## Resources
 
-No resources.
+| Name | Type |
+|------|------|
+| [aws_sqs_queue_policy.sqs_queue_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue_policy) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 
 ## Inputs
 
@@ -60,6 +66,8 @@ No resources.
 | <a name="input_environment"></a> [environment](#input\_environment) | ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | <a name="input_fifo_queue"></a> [fifo\_queue](#input\_fifo\_queue) | Boolean designating a FIFO queue. If not set, it defaults to false making it standard. | `bool` | `false` | no |
 | <a name="input_fifo_throughput_limit"></a> [fifo\_throughput\_limit](#input\_fifo\_throughput\_limit) | Specifies whether the FIFO queue throughput quota applies to the entire queue or per message group. Valid values are perQueue and perMessageGroupId. This can be specified if fifo\_queue is true. | `list(string)` | `[]` | no |
+| <a name="input_iam_policy"></a> [iam\_policy](#input\_iam\_policy) | IAM policy as list of Terraform objects, compatible with Terraform `aws_iam_policy_document` data source<br>except that `source_policy_documents` and `override_policy_documents` are not included.<br>Use inputs `iam_source_policy_documents` and `iam_override_policy_documents` for that. | <pre>list(object({<br>    policy_id = optional(string, null)<br>    version   = optional(string, null)<br>    statements = list(object({<br>      sid           = optional(string, null)<br>      effect        = optional(string, null)<br>      actions       = optional(list(string), null)<br>      not_actions   = optional(list(string), null)<br>      resources     = optional(list(string), null)<br>      not_resources = optional(list(string), null)<br>      conditions = optional(list(object({<br>        test     = string<br>        variable = string<br>        values   = list(string)<br>      })), [])<br>      principals = optional(list(object({<br>        type        = string<br>        identifiers = list(string)<br>      })), [])<br>      not_principals = optional(list(object({<br>        type        = string<br>        identifiers = list(string)<br>      })), [])<br>    }))<br>  }))</pre> | `[]` | no |
+| <a name="input_iam_policy_limit_to_current_account"></a> [iam\_policy\_limit\_to\_current\_account](#input\_iam\_policy\_limit\_to\_current\_account) | Boolean designating whether the IAM policy should be limited to the current account. | `bool` | `true` | no |
 | <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for keep the existing setting, which defaults to `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
 | <a name="input_kms_data_key_reuse_period_seconds"></a> [kms\_data\_key\_reuse\_period\_seconds](#input\_kms\_data\_key\_reuse\_period\_seconds) | The length of time, in seconds, for which Amazon SQS can reuse a data key to encrypt or decrypt messages before calling AWS KMS again. An integer representing seconds, between 60 seconds (1 minute) and 86,400 seconds (24 hours). The default is 300 (5 minutes). | `number` | `300` | no |
 | <a name="input_kms_master_key_id"></a> [kms\_master\_key\_id](#input\_kms\_master\_key\_id) | The ID of an AWS-managed customer master key (CMK) for Amazon SQS or a custom CMK. For more information, see Key Terms. | `list(string)` | <pre>[<br>  "alias/aws/sqs"<br>]</pre> | no |

--- a/modules/sqs-queue/main.tf
+++ b/modules/sqs-queue/main.tf
@@ -28,7 +28,7 @@ module "sqs_queue" {
 }
 
 module "queue_policy" {
-  count = local.enabled && var.iam_policy != null ? 1 : 0
+  count = local.enabled && var.iam_policy != [] ? 1 : 0
 
   source  = "cloudposse/iam-policy/aws"
   version = "2.0.1"
@@ -59,7 +59,7 @@ module "queue_policy" {
 }
 
 resource "aws_sqs_queue_policy" "sqs_queue_policy" {
-  count = local.enabled && var.iam_policy != null ? 1 : 0
+  count = local.enabled && var.iam_policy != [] ? 1 : 0
 
   queue_url = module.sqs_queue.url
   policy    = one(module.queue_policy[*].json)

--- a/modules/sqs-queue/main.tf
+++ b/modules/sqs-queue/main.tf
@@ -1,5 +1,10 @@
 locals {
-  enabled = module.this.enabled
+  enabled            = module.this.enabled
+  aws_account_number = one(data.aws_caller_identity.current[*].account_id)
+}
+
+data "aws_caller_identity" "current" {
+  count = local.enabled ? 1 : 0
 }
 
 module "sqs_queue" {
@@ -20,4 +25,42 @@ module "sqs_queue" {
   deduplication_scope               = try([var.deduplication_scope[0]], [])
 
   context = module.this.context
+}
+
+module "queue_policy" {
+  count = local.enabled && var.iam_policy != null ? 1 : 0
+
+  source  = "cloudposse/iam-policy/aws"
+  version = "2.0.1"
+
+  iam_policy = [for policy in var.iam_policy : {
+    policy_id = policy.policy_id
+    version   = policy.version
+
+    statements = [for statement in policy.statements :
+      merge(
+        statement,
+        {
+          resources = [module.sqs_queue.arn]
+        },
+        var.iam_policy_limit_to_current_account ? {
+          conditions = concat(statement.conditions, [{
+            test     = "StringEquals"
+            variable = "aws:SourceAccount"
+            values   = [local.aws_account_number]
+          }])
+        } : {}
+      )
+    ]
+    }
+  ]
+
+  context = module.this.context
+}
+
+resource "aws_sqs_queue_policy" "sqs_queue_policy" {
+  count = local.enabled && var.iam_policy != null ? 1 : 0
+
+  queue_url = module.sqs_queue.url
+  policy    = one(module.queue_policy[*].json)
 }

--- a/modules/sqs-queue/variables.tf
+++ b/modules/sqs-queue/variables.tf
@@ -80,3 +80,44 @@ variable "deduplication_scope" {
   description = "Specifies whether message deduplication occurs at the message group or queue level. Valid values are messageGroup and queue. This can be specified if fifo_queue is true."
   default     = []
 }
+
+variable "iam_policy_limit_to_current_account" {
+  type        = bool
+  description = "Boolean designating whether the IAM policy should be limited to the current account."
+  default     = true
+}
+
+variable "iam_policy" {
+  type = list(object({
+    policy_id = optional(string, null)
+    version   = optional(string, null)
+    statements = list(object({
+      sid           = optional(string, null)
+      effect        = optional(string, null)
+      actions       = optional(list(string), null)
+      not_actions   = optional(list(string), null)
+      resources     = optional(list(string), null)
+      not_resources = optional(list(string), null)
+      conditions = optional(list(object({
+        test     = string
+        variable = string
+        values   = list(string)
+      })), [])
+      principals = optional(list(object({
+        type        = string
+        identifiers = list(string)
+      })), [])
+      not_principals = optional(list(object({
+        type        = string
+        identifiers = list(string)
+      })), [])
+    }))
+  }))
+  description = <<-EOT
+    IAM policy as list of Terraform objects, compatible with Terraform `aws_iam_policy_document` data source
+    except that `source_policy_documents` and `override_policy_documents` are not included.
+    Use inputs `iam_source_policy_documents` and `iam_override_policy_documents` for that.
+    EOT
+  default     = []
+  nullable    = false
+}


### PR DESCRIPTION
## what
* Update SQS Queue component to include an access policy block
* Add IAM Policy variable to make it writeable per queue
* Added helpers to add filters like current account and current queue arn

## why
* need an access policy that can allow s3 notifications
