### PR TITLE
chore: bump elasticache-redis module version

### DIFF
--- a/modules/elasticache-redis/main.tf
+++ b/modules/elasticache-redis/main.tf
@@ -70,7 +70,7 @@ module "redis_clusters" {
   num_shards             = lookup(each.value, "num_shards", 0)
   replicas_per_shard     = lookup(each.value, "replicas_per_shard", 0)
   engine_version         = each.value.engine_version
-  create_parameter_group = lookup(each.value, "create_parameter_group", null)
+  create_parameter_group = lookup(each.value, "create_parameter_group", true)
   parameters             = each.value.parameters
   parameter_group_name   = lookup(each.value, "parameter_group_name", null)
   cluster_attributes     = local.cluster_attributes

--- a/modules/elasticache-redis/main.tf
+++ b/modules/elasticache-redis/main.tf
@@ -65,13 +65,15 @@ module "redis_clusters" {
   cluster_name  = lookup(each.value, "cluster_name", replace(each.key, "_", "-"))
   dns_subdomain = join(".", [lookup(each.value, "cluster_name", replace(each.key, "_", "-")), module.this.environment])
 
-  instance_type      = each.value.instance_type
-  num_replicas       = lookup(each.value, "num_replicas", 1)
-  num_shards         = lookup(each.value, "num_shards", 0)
-  replicas_per_shard = lookup(each.value, "replicas_per_shard", 0)
-  engine_version     = each.value.engine_version
-  parameters         = each.value.parameters
-  cluster_attributes = local.cluster_attributes
+  instance_type          = each.value.instance_type
+  num_replicas           = lookup(each.value, "num_replicas", 1)
+  num_shards             = lookup(each.value, "num_shards", 0)
+  replicas_per_shard     = lookup(each.value, "replicas_per_shard", 0)
+  engine_version         = each.value.engine_version
+  create_parameter_group = lookup(each.value, "create_parameter_group", null)
+  parameters             = each.value.parameters
+  parameter_group_name   = lookup(each.value, "parameter_group_name", null)
+  cluster_attributes     = local.cluster_attributes
 
   context = module.this.context
 }

--- a/modules/elasticache-redis/main.tf
+++ b/modules/elasticache-redis/main.tf
@@ -38,6 +38,7 @@ locals {
     vpc_id             = module.vpc.outputs.vpc_id
     subnets            = module.vpc.outputs.private_subnet_ids
     availability_zones = var.availability_zones
+    multi_az_enabled   = var.multi_az_enabled
 
     allowed_security_groups         = local.allowed_security_groups
     additional_security_group_rules = local.additional_security_group_rules

--- a/modules/elasticache-redis/main.tf
+++ b/modules/elasticache-redis/main.tf
@@ -71,7 +71,7 @@ module "redis_clusters" {
   replicas_per_shard     = lookup(each.value, "replicas_per_shard", 0)
   engine_version         = each.value.engine_version
   create_parameter_group = lookup(each.value, "create_parameter_group", true)
-  parameters             = each.value.parameters
+  parameters             = lookup(each.value, "parameters", null)
   parameter_group_name   = lookup(each.value, "parameter_group_name", null)
   cluster_attributes     = local.cluster_attributes
 

--- a/modules/elasticache-redis/modules/redis_cluster/main.tf
+++ b/modules/elasticache-redis/modules/redis_cluster/main.tf
@@ -10,7 +10,7 @@ locals {
 
 module "redis" {
   source  = "cloudposse/elasticache-redis/aws"
-  version = "0.52.0"
+  version = "1.2.2"
 
   name = var.cluster_name
 
@@ -30,7 +30,9 @@ module "redis" {
   engine_version                       = var.engine_version
   family                               = var.cluster_attributes.family
   instance_type                        = var.instance_type
+  create_parameter_group               = var.create_parameter_group
   parameter                            = var.parameters
+  parameter_group_name                 = var.parameter_group_name
   port                                 = var.cluster_attributes.port
   subnets                              = var.cluster_attributes.subnets
   transit_encryption_enabled           = var.cluster_attributes.transit_encryption_enabled

--- a/modules/elasticache-redis/modules/redis_cluster/main.tf
+++ b/modules/elasticache-redis/modules/redis_cluster/main.tf
@@ -22,6 +22,7 @@ module "redis" {
   auth_token                           = local.auth_token
   automatic_failover_enabled           = var.cluster_attributes.automatic_failover_enabled
   availability_zones                   = var.cluster_attributes.availability_zones
+  multi_az_enabled                     = var.cluster_attributes.multi_az_enabled
   cluster_mode_enabled                 = var.num_shards > 0
   cluster_mode_num_node_groups         = var.num_shards
   cluster_mode_replicas_per_node_group = var.replicas_per_shard

--- a/modules/elasticache-redis/modules/redis_cluster/variables.tf
+++ b/modules/elasticache-redis/modules/redis_cluster/variables.tf
@@ -5,6 +5,12 @@ variable "cluster_name" {
   description = "Elasticache Cluster name"
 }
 
+variable "create_parameter_group" {
+  type        = bool
+  default     = true
+  description = "Whether new parameter group should be created. Set to false if you want to use existing parameter group"
+}
+
 variable "engine_version" {
   type        = string
   description = "Redis Version"
@@ -64,6 +70,12 @@ variable "parameters" {
     value = string
   }))
   description = "Parameters to configure cluster parameter group"
+}
+
+variable "parameter_group_name" {
+  type        = string
+  default     = null
+  description = "Override the default parameter group name"
 }
 
 variable "kms_alias_name_ssm" {

--- a/modules/elasticache-redis/variables.tf
+++ b/modules/elasticache-redis/variables.tf
@@ -9,6 +9,12 @@ variable "availability_zones" {
   default     = []
 }
 
+variable "multi_az_enabled" {
+  type        = bool
+  default     = false
+  description = "Multi AZ (Automatic Failover must also be enabled.  If Cluster Mode is enabled, Multi AZ is on by default, and this setting is ignored)"
+}
+
 variable "family" {
   type        = string
   description = "Redis family"


### PR DESCRIPTION
## what

- Upgrade `elasticache-redis` module version in the `elasticache-redis` component
- Adds three new variables from the module; `create_parameter_group`, `parameter_group_name`, and `multi_az_enabled`

## why

- Use the latest module version with the component

## references

- New variables were added in module version `1.0.0` https://github.com/cloudposse/terraform-aws-elasticache-redis/releases/tag/1.0.0
