### PR TITLE
fix: add missing multi_az_enabled variable

### DIFF
--- a/modules/elasticache-redis/modules/redis_cluster/variables.tf
+++ b/modules/elasticache-redis/modules/redis_cluster/variables.tf
@@ -55,6 +55,7 @@ variable "cluster_attributes" {
     family                          = string
     port                            = number
     zone_id                         = string
+    multi_az_enabled                = bool
     at_rest_encryption_enabled      = bool
     transit_encryption_enabled      = bool
     apply_immediately               = bool


### PR DESCRIPTION
## what

- Add missing variable `multi_az_enabled`

## why

- This variable should have been included in https://github.com/cloudposse/terraform-aws-components/pull/1040

## references

- https://github.com/cloudposse/terraform-aws-components/pull/1040
- https://github.com/cloudposse/terraform-aws-elasticache-redis/blob/caabd7ea05a5809cc71383b34a0556ffe76a6d5a/variables.tf#L127-L131
