### PR TITLE
[vpc] update dynamic-subnet module version

### DIFF
--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -139,7 +139,7 @@ module "vpc_endpoints" {
 
 module "subnets" {
   source  = "cloudposse/dynamic-subnets/aws"
-  version = "2.3.0"
+  version = "2.4.2"
 
   availability_zones              = local.availability_zones
   availability_zone_ids           = local.availability_zone_ids


### PR DESCRIPTION
## what

Update `dynamic-subnets` module version to fix issue https://github.com/cloudposse/terraform-aws-components/issues/1047

## why

Version 2.3.0 of `dynamic-subnets` does not support the new opt-in Melbourne region.

## references

This change in `utils` module adds support for Melbourne (amongst other regions) - https://github.com/cloudposse/terraform-aws-utils/pull/26 
And this is the version of `dynamic-subnets` where it was updated to use the updated `utils` module.  https://github.com/cloudposse/terraform-aws-dynamic-subnets/releases/tag/2.4.0 

This PR closes #1047 