### PR TITLE
fix(`rds`): Corrected SSM Paths for Non Existent `var.name`

### DIFF
--- a/modules/rds/README.md
+++ b/modules/rds/README.md
@@ -231,6 +231,7 @@ Example - I want a new instance `rds-example-new` to be provisioned from a snaps
 | Name | Description |
 |------|-------------|
 | <a name="output_exports"></a> [exports](#output\_exports) | Map of exports for use in deployment configuration templates |
+| <a name="output_kms_key_alias"></a> [kms\_key\_alias](#output\_kms\_key\_alias) | The KMS key alias |
 | <a name="output_psql_helper"></a> [psql\_helper](#output\_psql\_helper) | A helper output to use with psql for connecting to this RDS instance. |
 | <a name="output_rds_address"></a> [rds\_address](#output\_rds\_address) | Address of the instance |
 | <a name="output_rds_arn"></a> [rds\_arn](#output\_rds\_arn) | ARN of the instance |

--- a/modules/rds/outputs.tf
+++ b/modules/rds/outputs.tf
@@ -83,3 +83,8 @@ output "psql_helper" {
   value       = local.psql_access_enabled ? local.psql_message : ""
   description = "A helper output to use with psql for connecting to this RDS instance."
 }
+
+output "kms_key_alias" {
+  value       = module.kms_key_rds.alias_name
+  description = "The KMS key alias"
+}

--- a/modules/rds/systems-manager.tf
+++ b/modules/rds/systems-manager.tf
@@ -49,13 +49,14 @@ variable "ssm_key_port" {
 
 locals {
   ssm_enabled                = local.enabled && var.ssm_enabled
-  rds_database_password_path = format(var.ssm_key_format, var.ssm_key_prefix, var.name, var.ssm_key_password)
+  ssm_name_path              = join("-", compact(concat([var.name], var.attributes)))
+  rds_database_password_path = format(var.ssm_key_format, var.ssm_key_prefix, local.ssm_name_path, var.ssm_key_password)
 }
 
 resource "aws_ssm_parameter" "rds_database_user" {
   count = local.ssm_enabled ? 1 : 0
 
-  name        = format(var.ssm_key_format, var.ssm_key_prefix, var.name, var.ssm_key_user)
+  name        = format(var.ssm_key_format, var.ssm_key_prefix, local.ssm_name_path, var.ssm_key_user)
   value       = local.database_user
   description = "RDS DB user"
   type        = "String"
@@ -76,7 +77,7 @@ resource "aws_ssm_parameter" "rds_database_password" {
 resource "aws_ssm_parameter" "rds_database_hostname" {
   count = local.ssm_enabled ? 1 : 0
 
-  name        = format(var.ssm_key_format, var.ssm_key_prefix, var.name, var.ssm_key_hostname)
+  name        = format(var.ssm_key_format, var.ssm_key_prefix, local.ssm_name_path, var.ssm_key_hostname)
   value       = module.rds_instance.hostname == "" ? module.rds_instance.instance_address : module.rds_instance.hostname
   description = "RDS DB hostname"
   type        = "String"
@@ -86,7 +87,7 @@ resource "aws_ssm_parameter" "rds_database_hostname" {
 resource "aws_ssm_parameter" "rds_database_port" {
   count = local.ssm_enabled ? 1 : 0
 
-  name        = format(var.ssm_key_format, var.ssm_key_prefix, var.name, var.ssm_key_port)
+  name        = format(var.ssm_key_format, var.ssm_key_prefix, local.ssm_name_path, var.ssm_key_port)
   value       = var.database_port
   description = "RDS DB port"
   type        = "String"
@@ -94,6 +95,6 @@ resource "aws_ssm_parameter" "rds_database_port" {
 }
 
 output "rds_database_ssm_key_prefix" {
-  value       = local.ssm_enabled ? format(var.ssm_key_format, var.ssm_key_prefix, var.name, "") : null
+  value       = local.ssm_enabled ? format(var.ssm_key_format, var.ssm_key_prefix, local.ssm_name_path, "") : null
   description = "SSM prefix"
 }


### PR DESCRIPTION
## what
- Add output for KMS key alias
- Update SSM naming convention

## why
- Useful output for KMS key references
- When `var.name` doesnt exist, this path includes `null`. We want to optionally support setting `var.attributes` without a `var.name`

## references
- customer engagement
