### PR TITLE
Run update-changelog on public runners

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -12,9 +12,7 @@ permissions:
 
 jobs:
   update-changelog:
-    runs-on:
-      - "self-hosted"
-
+    runs-on: ["ubuntu-latest"]
     steps:
       - name: Current Release
         id: current-release


### PR DESCRIPTION
## what
* Run update-changelog on public runners

## why
* There is no reason to use self-hosted for this workflow. 
* We do not have configured self-hosted runners in that repo
