### PR TITLE
[eks/actions-runner-controller] Add ability to dynamically annotate pods once they start a job

### DIFF
--- a/modules/eks/actions-runner-controller/charts/actions-runner/Chart.yaml
+++ b/modules/eks/actions-runner-controller/charts/actions-runner/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.2.0
 
 # This chart only deploys Resources for actions-runner-controller, so app version does not really apply.
 # We use Resource API version instead.

--- a/modules/eks/actions-runner-controller/charts/actions-runner/templates/runnerdeployment.yaml
+++ b/modules/eks/actions-runner-controller/charts/actions-runner/templates/runnerdeployment.yaml
@@ -1,34 +1,3 @@
-{{- if .Values.pvc_enabled }}
----
-# Persistent Volumes can be used for image caching
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: {{ .Values.release_name }}
-spec:
-  accessModes:
-    - ReadWriteMany
-  # StorageClassName comes from efs-controller and must be deployed first.
-  storageClassName: efs-sc
-  resources:
-    requests:
-      # EFS is not actually storage constrained, but this storage request is
-      # required. 100Gi is a ballpark for how much we initially request, but this
-      # may grow. We are responsible for docker pruning this periodically to
-      # save space.
-      storage: 100Gi
-{{- end }}
-{{- if .Values.docker_config_json_enabled }}
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ .Values.release_name }}-regcred
-type: kubernetes.io/dockerconfigjson
-data:
-  .dockerconfigjson: {{ .Values.docker_config_json }}
-{{- end }}
----
 apiVersion: actions.summerwind.dev/v1alpha1
 kind: RunnerDeployment
 metadata:
@@ -38,13 +7,13 @@ spec:
   # See https://github.com/actions-runner-controller/actions-runner-controller/issues/206#issuecomment-748601907
   # replicas: 1
   template:
-    {{- with index .Values "pod_annotations" }}
+    {{- with .Values.pod_annotations }}
     metadata:
       annotations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
     spec:
-      {{- if  .Values.docker_config_json_enabled }}
+      {{- if .Values.docker_config_json_enabled }}
       # secrets volumeMount are always mounted readOnly so config.json has to be copied to the correct directory
       # https://github.com/kubernetes/kubernetes/issues/62099
       # https://github.com/actions/actions-runner-controller/issues/2123#issuecomment-1527077517
@@ -82,14 +51,41 @@ spec:
       #  - effect: NoSchedule
       #    key: node-role.kubernetes.io/actions-runner
       #    operator: Exists
+      {{- with .Values.node_selector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 
-      {{ if eq .Values.type "organization" }}
+      {{- with .Values.running_pod_annotations }}
+      # Run a pre-run hook to set pod annotations
+      # See https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/running-scripts-before-or-after-a-job#triggering-the-scripts
+      containers:
+        - name: runner
+          # ARC (Summerwind) has its own pre-run hook, so we do not want to set
+          #  env:
+          #  - name: ACTIONS_RUNNER_HOOK_JOB_STARTED
+          #    value: /hooks/pre-run.sh # triggers when a job is started, and sets the pod to NOT safe-to-evict
+          # Instead, its pre-run hook runs scripts in /etc/arc/hooks/job-started.d/
+          volumeMounts:
+            - name: hooks
+              mountPath: /etc/arc/hooks/job-started.d/
+      {{- end }}
+
+      {{- if eq .Values.type "organization" }}
       organization: {{ .Values.scope }}
       {{- end }}
-      {{ if eq .Values.type "repository" }}
+      {{- if eq .Values.type "repository" }}
       repository: {{ .Values.scope }}
       {{- end }}
-      {{ if index .Values "group" }}
+      {{- if index .Values "group" }}
       group: {{ .Values.group }}
       {{- end }}
       # You can use labels to create subsets of runners.
@@ -102,14 +98,6 @@ spec:
         - self-hosted
       {{- range .Values.labels }}
         - {{ . | quote }}
-      {{- end }}
-      {{- if gt ( len (index .Values "node_selector") ) 0 }}
-      nodeSelector:
-        {{- toYaml .Values.node_selector | nindent 8 }}
-      {{- end }}
-      {{- if gt ( len (index .Values "tolerations") ) 0 }}
-      tolerations:
-        {{- toYaml .Values.tolerations | nindent 8 }}
       {{- end }}
       # dockerdWithinRunnerContainer = false means access to a Docker daemon is provided by a sidecar container.
       dockerdWithinRunnerContainer: {{ .Values.dind_enabled }}
@@ -133,7 +121,7 @@ spec:
           {{- if index .Values.resources.requests "ephemeral_storage" }}
           ephemeral-storage: {{ .Values.resources.requests.ephemeral_storage }}
           {{- end }}
-      {{- if and .Values.dind_enabled .Values.storage }}
+      {{- if and .Values.dind_enabled .Values.docker_storage }}
       dockerVolumeMounts:
         - mountPath: /var/lib/docker
           name: docker-volume
@@ -150,10 +138,10 @@ spec:
         - mountPath: /home/runner/.docker
           name: docker-config-volume
         {{- end }}
-      {{- end }}
-      {{- if or (and .Values.dind_enabled .Values.storage) (.Values.pvc_enabled) (.Values.docker_config_json_enabled) }}
+      {{- end }}{{/* End of volumeMounts */}}
+      {{- if or (and .Values.dind_enabled .Values.docker_storage) (.Values.pvc_enabled) (.Values.docker_config_json_enabled) (not (empty .Values.running_pod_annotations)) }}
       volumes:
-      {{- if and .Values.dind_enabled .Values.storage }}
+        {{- if and .Values.dind_enabled .Values.docker_storage }}
         - name: docker-volume
           ephemeral:
             volumeClaimTemplate:
@@ -161,13 +149,13 @@ spec:
                 accessModes: [ "ReadWriteOnce" ] # Only 1 pod can connect at a time
                 resources:
                   requests:
-                    storage: {{ .Values.storage }}
-      {{- end }}
-      {{- if .Values.pvc_enabled }}
+                    storage: {{ .Values.docker_storage }}
+        {{- end }}
+        {{- if .Values.pvc_enabled }}
         - name: shared-volume
           persistentVolumeClaim:
             claimName: {{ .Values.release_name }}
-      {{- end }}
+        {{- end }}
         {{- if .Values.docker_config_json_enabled }}
         - name: docker-secret
           secret:
@@ -178,4 +166,88 @@ spec:
         - name: docker-config-volume
           emptyDir:
         {{- end }}
-      {{- end }}
+        {{- with .Values.running_pod_annotations }}
+        - name: hooks
+          configMap:
+            name: runner-hooks
+            defaultMode: 0755  # Set execute permissions for all files
+        {{- end }}
+      {{- end }}{{/* End of volumes */}}
+{{- if .Values.pvc_enabled }}
+---
+# Persistent Volumes can be used for image caching
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Values.release_name }}
+spec:
+  accessModes:
+    - ReadWriteMany
+  # StorageClassName comes from efs-controller and must be deployed first.
+  storageClassName: efs-sc
+  resources:
+    requests:
+      # EFS is not actually storage constrained, but this storage request is
+      # required. 100Gi is a ballpark for how much we initially request, but this
+      # may grow. We are responsible for docker pruning this periodically to
+      # save space.
+      storage: 100Gi
+{{- end }}
+{{- if .Values.docker_config_json_enabled }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.release_name }}-regcred
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ .Values.docker_config_json }}
+{{- end }}
+{{- with .Values.running_pod_annotations }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: runner-hooks
+data:
+  annotate.sh: |
+    #!/bin/bash
+
+    # If we had kubectl and a KUBECONFIG, we could do this:
+    #   kubectl annotate pod $HOSTNAME 'karpenter.sh/do-not-evict="true"' --overwrite
+    #   kubectl annotate pod $HOSTNAME 'karpenter.sh/do-not-disrupt="true"' --overwrite
+
+    # This is the same thing, the hard way
+
+    # Metadata about the pod
+    NAMESPACE=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
+    POD_NAME=$(hostname)
+
+    # Kubernetes API URL
+    API_URL="https://kubernetes.default.svc"
+
+    # Read the service account token
+    TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+
+    # Content type
+    CONTENT_TYPE="application/merge-patch+json"
+
+    PATCH_JSON=$(cat <<EOF
+    {
+      "metadata": {
+        "annotations":
+         {{- . | toJson | nindent 10 }}
+      }
+    }
+    EOF
+    )
+
+    # Use curl to patch the pod
+      curl -sSk -X PATCH \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "Content-Type: $CONTENT_TYPE" \
+    -H "Accept: application/json" \
+      -d "$PATCH_JSON" \
+      "$API_URL/api/v1/namespaces/$NAMESPACE/pods/$POD_NAME"  | jq .metadata.annotations
+
+{{ end }}

--- a/modules/eks/actions-runner-controller/charts/actions-runner/values.yaml
+++ b/modules/eks/actions-runner-controller/charts/actions-runner/values.yaml
@@ -2,32 +2,29 @@ type: "repository" # can be either 'organization' or 'repository'
 dind_enabled: true # If `true`, a Docker sidecar container will be deployed
 # To run Docker in Docker (dind), change image from summerwind/actions-runner to summerwind/actions-runner-dind
 image: summerwind/actions-runner-dind
-node_selector:
-  kubernetes.io/os: "linux"
-  kubernetes.io/arch: "amd64"
+
 #scope: "example/app"
-scale_down_delay_seconds: 300
-min_replicas: 1
-max_replicas: 2
+#scale_down_delay_seconds: 300
+#min_replicas: 1
+#max_replicas: 2
 #busy_metrics:
 #  scale_up_threshold: 0.75
 #  scale_down_threshold: 0.25
 #  scale_up_factor: 2
 #  scale_down_factor: 0.5
-resources:
-  limits:
-    cpu: 1.5
-    memory: 4Gi
-    # ephemeral_storage: "10Gi"
-  requests:
-    cpu: 0.5
-    memory: 1Gi
-    # ephemeral_storage: "10Gi"
+#resources:
+#  limits:
+#    cpu: 1
+#    memory: 1Gi
+#    ephemeral_storage: "10Gi"
+#  requests:
+#    cpu: 500m
+#    memory: 512Mi
+#    ephemeral_storage: "1Gi"
 
-storage: "10Gi"
 pvc_enabled: false
 webhook_driven_scaling_enabled: true
-webhook_startup_timeout: "30m"
+webhook_startup_timeout: "90m"
 pull_driven_scaling_enabled: false
 #labels:
 #  - "Ubuntu"

--- a/modules/eks/actions-runner-controller/resources/values.yaml
+++ b/modules/eks/actions-runner-controller/resources/values.yaml
@@ -1,7 +1,6 @@
 authSecret:
   create: false
   name: controller-manager
-replicaCount: 1
 scope:
   # If true, the controller will only watch custom resources in a single namespace,
   # which by default is the namespace the controller is in.
@@ -12,6 +11,7 @@ syncPeriod: 120s
 
 githubWebhookServer:
   enabled: false
+  syncPeriod: 120s
   secret:
     # Webhook secret, used to authenticate incoming webhook events from GitHub
     # When using Sops, stored in same SopsSecret as authSecret under key `github_webhook_secret_token`
@@ -23,16 +23,11 @@ githubWebhookServer:
     enabled: false
     annotations:
       alb.ingress.kubernetes.io/backend-protocol: HTTP
-      alb.ingress.kubernetes.io/group.name: common
+      # Use the default ingress, or uncomment and set the group name to use a different one
+      # alb.ingress.kubernetes.io/group.name: common
       alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80},{"HTTPS":443}]'
-      alb.ingress.kubernetes.io/load-balancer-name: k8s-common
       alb.ingress.kubernetes.io/scheme: internet-facing
       alb.ingress.kubernetes.io/ssl-redirect: '443'
       alb.ingress.kubernetes.io/target-type: ip
-      kubernetes.io/ingress.class: alb
     podDisruptionBudget:
       maxUnavailable: "60%"
-
-nodeSelector:
-  kubernetes.io/os: "linux"
-  kubernetes.io/arch: "amd64"


### PR DESCRIPTION
## what

For `eks/actions-runner-controller`
- Add ability to dynamically annotate pods once they start a job
- Add ability to specify runner pod affinities and anti-affinities
- Deprecate `storage` in favor of `docker_storage` to configure how much disk space to allocate for the Docker daemon
- Miscellaneous cleanups of inputs and chart 

## why

- Allow idle runners to be evicted by Karpenter for purposes of node consolidation, while preventing running runners from being interrupted
- Allow runners to have more control over where they are placed
- The term "storage" is too vague, and could reasonably be expected to configure the worker storage, but in fact it only configures the Docker storage. (Storage size for the optional PVC is still hardcoded at 100Gi.)
- Make chart a bit more readable and maintainable

## references

- https://github.com/actions/actions-runner-controller/issues/3558

