### PR TITLE
Update bats workflow

### DIFF
--- a/.github/workflows/bats.yml
+++ b/.github/workflows/bats.yml
@@ -1,7 +1,7 @@
 name: bats
 
 on:
-  pull_request_target:
+  pull_request:
     types: [labeled, opened, synchronize, unlabeled]
 
 jobs:
@@ -32,6 +32,7 @@ jobs:
         HEAD_REF: ${{ github.head_ref }}
       run: |
         # when running in test-harness, need to mark the directory safe for git operations
+        echo "/usr/share/terraform/1/bin/terraform" >> "$GITHUB_PATH"
         make git-safe-directory
         MODIFIED_MODULES=($(git diff --name-only origin/${BASE_REF} origin/${HEAD_REF} | xargs -n 1 dirname | sort | uniq | grep ^modules/ || true))
         if [ -z "$MODIFIED_MODULES" ]; then

--- a/.github/workflows/bats.yml
+++ b/.github/workflows/bats.yml
@@ -19,10 +19,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-        repository: ${{ github.event.pull_request.head.repo.full_name }}
-        # Check out the PR commit, not the merge commit
-        # Use `ref` instead of `sha` to enable pushing back to `ref`
-        ref: ${{ github.event.pull_request.head.ref }}
 
     - name: Run tests on modified modules
       id: get-modified-files

--- a/.github/workflows/bats.yml
+++ b/.github/workflows/bats.yml
@@ -28,7 +28,6 @@ jobs:
         HEAD_REF: ${{ github.head_ref }}
       run: |
         # when running in test-harness, need to mark the directory safe for git operations
-        echo "/usr/share/terraform/1/bin/terraform" >> "$GITHUB_PATH"
         make git-safe-directory
         MODIFIED_MODULES=($(git diff --name-only origin/${BASE_REF} origin/${HEAD_REF} | xargs -n 1 dirname | sort | uniq | grep ^modules/ || true))
         if [ -z "$MODIFIED_MODULES" ]; then


### PR DESCRIPTION
## what
* Replace `pull_request_target` by `pull_request`
* Use `terraform 1` for bats

## why
* Improve security 
* test-harness support terraform and opentofu, use terraform for bats