### PR TITLE
feat(aurora-postgres): backup configs

### DIFF
--- a/modules/aurora-postgres/README.md
+++ b/modules/aurora-postgres/README.md
@@ -351,6 +351,9 @@ components:
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
 | <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |
 | <a name="input_vpc_component_name"></a> [vpc\_component\_name](#input\_vpc\_component\_name) | The name of the VPC component | `string` | `"vpc"` | no |
+| <a name="input_retention_period"></a> [retention\_period](#input\_retention\_period) | Number of days to retain backups for | `number` | `5` | no |
+| <a name="input_backup_window"></a> [backup\_window](#input\_backup\_window) | Daily time range during which the backups happen, UTC | `string` | `"07:00-09:00"` | no |
+
 
 ## Outputs
 

--- a/modules/aurora-postgres/cluster-regional.tf
+++ b/modules/aurora-postgres/cluster-regional.tf
@@ -53,6 +53,8 @@ module "aurora_postgres_cluster" {
   snapshot_identifier                  = var.snapshot_identifier
   allow_major_version_upgrade          = var.allow_major_version_upgrade
   ca_cert_identifier                   = var.ca_cert_identifier
+  retention_period                     = var.retention_period
+  backup_window                        = var.backup_window
 
   cluster_parameters = concat([
     {

--- a/modules/aurora-postgres/variables.tf
+++ b/modules/aurora-postgres/variables.tf
@@ -340,3 +340,15 @@ variable "cluster_parameters" {
   default     = []
   description = "List of DB cluster parameters to apply"
 }
+
+variable "retention_period" {
+  type        = number
+  default     = 5
+  description = "Number of days to retain backups for"
+}
+
+variable "backup_window" {
+  type        = string
+  default     = "07:00-09:00"
+  description = "Daily time range during which the backups happen, UTC"
+}


### PR DESCRIPTION
## what

The CloudPosse RDS cluster module https://github.com/cloudposse/terraform-aws-rds-cluster has these backup configurations that would be helpful to have!

## why

1. Allows me to set backup configurations
2. Without these inputs, the cluster is forced to use the default configs from the module
3. Allows me to set these variable values to `null` or empty when I don't want any backing up happening
4. Without these inputs to set it as empty values, there's a conflict when using RDS clusters with AWS Backup plans because the RDS resource maintains its backup values, while AWS Backup plans wants other values.

## references
- CloudPosse's RDS module
- 
<img width="1336" alt="image" src="https://github.com/cloudposse/terraform-aws-components/assets/35899715/5c2e96cf-7cd4-4e5d-aa1f-a8b6f3185c10">
- AWS Backup conflict with default backup values unless explictly set https://github.com/hashicorp/terraform-provider-aws/issues/33465
