### PR TITLE
chore: update modules for spa-s3-cloudfront

### DIFF
--- a/modules/spa-s3-cloudfront/README.md
+++ b/modules/spa-s3-cloudfront/README.md
@@ -148,7 +148,7 @@ components:
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_acm_request_certificate"></a> [acm\_request\_certificate](#module\_acm\_request\_certificate) | cloudposse/acm-request-certificate/aws | 0.16.3 |
+| <a name="module_acm_request_certificate"></a> [acm\_request\_certificate](#module\_acm\_request\_certificate) | cloudposse/acm-request-certificate/aws | 0.18.0 |
 | <a name="module_dns_delegated"></a> [dns\_delegated](#module\_dns\_delegated) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
 | <a name="module_gha_assume_role"></a> [gha\_assume\_role](#module\_gha\_assume\_role) | ../account-map/modules/team-assume-role-policy | n/a |
 | <a name="module_gha_role_name"></a> [gha\_role\_name](#module\_gha\_role\_name) | cloudposse/label/null | 0.25.0 |
@@ -156,7 +156,7 @@ components:
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
 | <a name="module_lambda_edge"></a> [lambda\_edge](#module\_lambda\_edge) | cloudposse/cloudfront-s3-cdn/aws//modules/lambda@edge | 0.92.0 |
 | <a name="module_lambda_edge_functions"></a> [lambda\_edge\_functions](#module\_lambda\_edge\_functions) | cloudposse/config/yaml//modules/deepmerge | 1.0.2 |
-| <a name="module_spa_web"></a> [spa\_web](#module\_spa\_web) | cloudposse/cloudfront-s3-cdn/aws | 0.92.0 |
+| <a name="module_spa_web"></a> [spa\_web](#module\_spa\_web) | cloudposse/cloudfront-s3-cdn/aws | 0.95.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 | <a name="module_utils"></a> [utils](#module\_utils) | cloudposse/utils/aws | 1.3.0 |
 | <a name="module_waf"></a> [waf](#module\_waf) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |

--- a/modules/spa-s3-cloudfront/main.tf
+++ b/modules/spa-s3-cloudfront/main.tf
@@ -52,7 +52,7 @@ locals {
 # Create an ACM and explicitly set it to us-east-1 (requirement of CloudFront)
 module "acm_request_certificate" {
   source  = "cloudposse/acm-request-certificate/aws"
-  version = "0.16.3"
+  version = "0.18.0"
   providers = {
     aws = aws.us-east-1
   }
@@ -68,7 +68,7 @@ module "acm_request_certificate" {
 
 module "spa_web" {
   source  = "cloudposse/cloudfront-s3-cdn/aws"
-  version = "0.92.0"
+  version = "0.95.0"
 
   block_origin_public_access_enabled = local.block_origin_public_access_enabled
   encryption_enabled                 = var.origin_encryption_enabled


### PR DESCRIPTION
## what

- updated `cloudposse/cloudfront-s3-cdn/aws` in `spa-s3-cloudfront`
- updated `cloudposse/acm-request-certificate/aws` in `spa-s3-cloudfront`

## why

- essential bugfixes. Private cloudfront buckets do not work without
the bucket policy fix from `0.95.0` of the cloudfront module.

## references

- see [Cloudfront Bucket Policy
Fix](https://github.com/cloudposse/terraform-aws-cloudfront-s3-cdn/pull/311)
