### PR TITLE
Test version constrains

### DIFF
--- a/modules/eks/cluster/versions.tf
+++ b/modules/eks/cluster/versions.tf
@@ -12,12 +12,12 @@ terraform {
     }
     # We no longer use the Kubernetes provider, so we can remove it,
     # but since there are bugs in the current version, we keep this as a comment.
-    #   kubernetes = {
-    #     source = "hashicorp/kubernetes"
-    #     # Version 2.25 and higher have bugs, so we cannot allow them,
-    #     # but automation enforces that we have no upper limit.
-    #     # It is less critical here, because the Kubernetes provider is being removed entirely.
-    #     version = "2.24"
-    #   }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+      # Version 2.25 and higher have bugs, so we cannot allow them,
+      # but automation enforces that we have no upper limit.
+      # It is less critical here, because the Kubernetes provider is being removed entirely.
+      version = ">= 2.7.1, <= 2.24.0"
+    }
   }
 }


### PR DESCRIPTION
## what
* Test version constrains

## references
* DEV-2319 Need a way to make bats pin-providers test optional with new testing framework, possibly using special comment like BridgeCrew did