### PR TITLE
External-Secrets: Add variable for decrypting aliased KMS keys

### DIFF
--- a/modules/eks/external-secrets-operator/README.md
+++ b/modules/eks/external-secrets-operator/README.md
@@ -126,6 +126,7 @@ components:
 |------|------|
 | [kubernetes_namespace.default](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
 | [aws_eks_cluster_auth.eks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster_auth) | data source |
+| [aws_kms_alias.kms_aliases](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_alias) | data source |
 | [kubernetes_resources.crd](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/data-sources/resources) | data source |
 
 ## Inputs
@@ -150,6 +151,7 @@ components:
 | <a name="input_environment"></a> [environment](#input\_environment) | ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | <a name="input_helm_manifest_experiment_enabled"></a> [helm\_manifest\_experiment\_enabled](#input\_helm\_manifest\_experiment\_enabled) | Enable storing of the rendered manifest for helm\_release so the full diff of what is changing can been seen in the plan | `bool` | `false` | no |
 | <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for keep the existing setting, which defaults to `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
+| <a name="input_kms_aliases_allow_decrypt"></a> [kms\_aliases\_allow\_decrypt](#input\_kms\_aliases\_allow\_decrypt) | A list of KMS aliases that the SecretStore is allowed to decrypt. | `list(string)` | `[]` | no |
 | <a name="input_kube_data_auth_enabled"></a> [kube\_data\_auth\_enabled](#input\_kube\_data\_auth\_enabled) | If `true`, use an `aws_eks_cluster_auth` data source to authenticate to the EKS cluster.<br>Disabled by `kubeconfig_file_enabled` or `kube_exec_auth_enabled`. | `bool` | `false` | no |
 | <a name="input_kube_exec_auth_aws_profile"></a> [kube\_exec\_auth\_aws\_profile](#input\_kube\_exec\_auth\_aws\_profile) | The AWS config profile for `aws eks get-token` to use | `string` | `""` | no |
 | <a name="input_kube_exec_auth_aws_profile_enabled"></a> [kube\_exec\_auth\_aws\_profile\_enabled](#input\_kube\_exec\_auth\_aws\_profile\_enabled) | If `true`, pass `kube_exec_auth_aws_profile` as the `profile` to `aws eks get-token` | `bool` | `false` | no |

--- a/modules/eks/external-secrets-operator/README.md
+++ b/modules/eks/external-secrets-operator/README.md
@@ -89,6 +89,8 @@ components:
         # chart_values:
         #   installCRDs: true
         chart_values: {}
+        kms_aliases_allow_decrypt: []
+        # - "alias/foo/bar"
 ```
 
 <!-- prettier-ignore-start -->

--- a/modules/eks/external-secrets-operator/variables.tf
+++ b/modules/eks/external-secrets-operator/variables.tf
@@ -34,3 +34,9 @@ variable "resources" {
   })
   description = "The cpu and memory of the deployment's limits and requests."
 }
+
+variable "kms_aliases_allow_decrypt" {
+  type        = list(string)
+  description = "A list of KMS aliases that the SecretStore is allowed to decrypt."
+  default     = []
+}


### PR DESCRIPTION
## what

* adds support for decrypting KMS keys by alias

## why

* it's a pain to lookup AWS KMS keys by arn or ID. so this adds alias support
