### PR TITLE
Update eks/cluster to use eks-node-group v3

### DIFF
--- a/modules/eks/cluster/CHANGELOG.md
+++ b/modules/eks/cluster/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Components PR [#1069](https://github.com/cloudposse/terraform-aws-components/pull/1069)
+
+Update `cloudposse/eks-node-group/aws` to v3.0.0
+
+- Enable use of Amazon Linux 2023
+- Other bug fixes and improvements
+- See https://github.com/cloudposse/terraform-aws-eks-node-group/releases/tag/3.0.0
+
 ## Release 1.455.1
 
 Components PR [#1057](https://github.com/cloudposse/terraform-aws-components/pull/1057)

--- a/modules/eks/cluster/modules/node_group_by_az/main.tf
+++ b/modules/eks/cluster/modules/node_group_by_az/main.tf
@@ -38,7 +38,7 @@ locals {
 
 module "eks_node_group" {
   source  = "cloudposse/eks-node-group/aws"
-  version = "2.12.0"
+  version = "3.0.0"
 
   enabled = local.enabled
 


### PR DESCRIPTION
## what

- Update `eks/cluster` to use [eks-node-group v3](https://github.com/cloudposse/terraform-aws-eks-node-group/releases/tag/3.0.0)

## why

- Support Amazon Linux 2023 on EKS
- Other bug fixes and improvements

## references

- https://github.com/cloudposse/terraform-aws-eks-node-group/releases/tag/3.0.0
