### PR TITLE
fix(`eks/loki`): Remove Unnecessary `compact`

### DIFF
--- a/modules/eks/loki/main.tf
+++ b/modules/eks/loki/main.tf
@@ -123,7 +123,7 @@ module "loki" {
         # For new installations, schema config doesnt change. See the following:
         # https://grafana.com/docs/loki/latest/operations/storage/schema/#new-loki-installs
         schemaConfig = {
-          configs = compact(concat(var.default_schema_config, var.additional_schema_config))
+          configs = concat(var.default_schema_config, var.additional_schema_config)
         }
         storage = {
           bucketNames = {


### PR DESCRIPTION
## what
- Removed `compact` from the `eks/loki` component list of objects for schema config

## why
- Fix terraform when one of this lists isnt defined

## references
- n/a
