### PR TITLE
[eks/actions-runner-controller] Multiple bug fixes and enhancements

### DIFF
--- a/modules/eks/actions-runner-controller/CHANGELOG.md
+++ b/modules/eks/actions-runner-controller/CHANGELOG.md
@@ -1,0 +1,126 @@
+## PR [#1075](https://github.com/cloudposse/terraform-aws-components/pull/1075)
+
+New Features:
+
+- Add support for
+  [scheduled overrides](https://github.com/actions/actions-runner-controller/blob/master/docs/automatically-scaling-runners.md#scheduled-overrides)
+  of Runner Autoscaler min and max replicas.
+- Add option `tmpfs_enabled` to have runners use RAM-backed ephemeral storage (`tmpfs`, `emptyDir.medium: Memory`)
+  instead of disk-backed storage.
+- Add `wait_for_docker_seconds` to allow configuration of the time to wait for the Docker daemon to be ready before
+  starting the runner.
+- Add the ability to have the runner Pods add annotations to themselves once they start running a job. (Actually
+  released in release 1.454.0, but not documented until now.)
+
+Changes:
+
+- Previously, `syncPeriod`, which sets the period in which the controller reconciles the desired runners count, was set
+  to 120 seconds in `resources/values.yaml`. This setting has been removed, reverting to the default value of 1 minute.
+  You can still set this value by setting the `syncPeriod` value in the `values.yaml` file or by setting `syncPeriod` in
+  `var.chart_values`.
+- Previously, `RUNNER_GRACEFUL_STOP_TIMEOUT` was hardcoded to 90 seconds. That has been reduced to 80 seconds to expand
+  the buffer between that and forceful termination from 10 seconds to 20 seconds, increasing the chances the runner will
+  successfully deregister itself.
+- The inaccurately named `webhook_startup_timeout` has been replaced with `max_duration`. `webhook_startup_timeout` is
+  still supported for backward compatibility, but is deprecated.
+
+Bugfixes:
+
+- Create and deploy the webhook secret when an existing secret is not supplied
+- Restore proper order of operations in creating resources (broken in release 1.454.0 (PR #1055))
+- If `docker_storage` is set and `dockerdWithinRunnerContainer` is `true` (which is hardcoded to be the case), properly
+  mount the docker storage volume into the runner container rather than the (non-existent) docker sidecar container.
+
+### Discussion
+
+#### Scheduled overrides
+
+Scheduled overrides allow you to set different min and max replica values for the runner autoscaler at different times.
+This can be useful if you have predictable patterns of load on your runners. For example, you might want to scale down
+to zero at night and scale up during the day. This feature is implemented by adding a `scheduled_overrides` field to the
+`var.runners` map.
+
+See the
+[Actions Runner Controller documentation](https://github.com/actions/actions-runner-controller/blob/master/docs/automatically-scaling-runners.md#scheduled-overrides)
+for details on how they work and how to set them up.
+
+#### Use RAM instead of Disk via `tmpfs_enabled`
+
+The standard `gp3` EBS volume used for EC2 instance's disk storage is limited (unless you pay extra) to 3000 IOPS and
+125 MB/s throughput. This is fine for average workloads, but it does not scale with instance size. A `.48xlarge`
+instance could host 90 Pods, but all 90 would still be sharing the same single 3000 IOPS and 125 MB/s throughput EBS
+volume attached to the host. This can lead to severe performance issues, as the whole Node gets locked up waiting for
+disk I/O.
+
+To mitigate this issue, we have added the `tmpfs_enabled` option to the `runners` map. When set to `true`, the runner
+Pods will use RAM-backed ephemeral storage (`tmpfs`, `emptyDir.medium: Memory`) instead of disk-backed storage. This
+means the Pod's impact on the Node's disk I/O is limited to the overhead required to launch and manage the Pod (e.g.
+downloading the container image and writing logs to the disk). This can be a significant performance improvement,
+allowing you to run more Pods on a single Node without running into disk I/O bottlenecks. Without this feature enabled,
+you may be limited to running something like 14 Runners on an instance, regardless of instance size, due to disk I/O
+limits. With this feature enabled, you may be able to run 50-100 Runners on a single instance.
+
+The trade-off is that the Pod's data is stored in RAM, which increases its memory usage. Be sure to increase the amount
+of memory allocated to the runner Pod to account for this. This is generally not a problem, as Runners typically use a
+small enough amount of disk space that it can be reasonably stored in the RAM allocated to a single CPU in an EC2
+instance, so it is the CPU that remains the limiting factor in how many Runners can be run on an instance.
+
+:::warning You must configure a memory request for the runner Pod
+
+When using `tmpfs_enabled`, you must configure a memory request for the runner Pod. If you do not, a single Pod would be
+allowed to consume half the Node's memory just for its disk storage.
+
+:::
+
+#### Configure startup timeout via `wait_for_docker_seconds`
+
+When the runner starts and Docker-in-Docker is enabled, the runner waits for the Docker daemon to be ready before
+registering marking itself ready to run jobs. This is done by polling the Docker daemon every second until it is ready.
+The default timeout for this is 120 seconds. If the Docker daemon is not ready within that time, the runner will exit
+with an error. You can configure this timeout by setting `wait_for_docker_seconds` in the `runners` map.
+
+As a general rule, the Docker daemon should be ready within a few seconds of the runner starting. However, particularly
+when there are disk I/O issues (see the `tmpfs_enabled` feature above), the Docker daemon may take longer to respond.
+
+#### Add annotations to runner Pods once they start running a job
+
+You can now configure the runner Pods to add annotations to themselves once they start running a job. The idea is to
+allow you to have idle pods allow themselves to be interrupted, but then mark themselves as uninterruptible once they
+start running a job. This is done by setting the `running_pod_annotations` field in the `runners` map. For example:
+
+```yaml
+running_pod_annotations:
+  # Prevent Karpenter from evicting or disrupting the worker pods while they are running jobs
+  # As of 0.37.0, is not 100% effective due to race conditions.
+  "karpenter.sh/do-not-disrupt": "true"
+```
+
+As noted in the comments above, this was intended to prevent Karpenter from evicting or disrupting the worker pods while
+they are running jobs, while leaving Karpenter free to interrupt idle Runners. However, as of Karpenter 0.37.0, this is
+not 100% effective due to race conditions: Karpenter may decide to terminate the Node the Pod is running on but not
+signal the Pod before it accepts a job and starts running it. Without the availability of transactions or atomic
+operations, this is a difficult problem to solve, and will probably require a more complex solution than just adding
+annotations to the Pods. Nevertheless, this feature remains available for use in other contexts, as well as in the hope
+that it will eventually work with Karpenter.
+
+#### Bugfix: Deploy webhook secret when existing secret is not supplied
+
+Because deploying secrets with Terraform causes the secrets to be stored unencrypted in the Terraform state file, we
+give users the option of creating the configuration secret externally (e.g. via
+[SOPS](https://github.com/getsops/sops)). Unfortunately, at some distant time in the past, when we enabled this option,
+we broke this component insofar as the webhook secret was no longer being deployed when the user did not supply an
+existing secret. This PR fixes that.
+
+The consequence of this bug was that, since the webhook secret was not being deployed, the webhook did not reject
+unauthorized requests. This could have allowed an attacker to trigger the webhook and perform a DOS attack by killing
+jobs as soon as they were accepted from the queue. A more practical and unintentional consequence was if a repo webhook
+was installed alongside an org webhook, it would not keep guard against the webhook receiving the same payload twice if
+one of the webhooks was missing the secret or had the wrong secret.
+
+#### Bugfix: Restore proper order of operations in creating resources
+
+In release 1.454.0 (PR [#1055](https://github.com/cloudposse/terraform-aws-components/pull/1055)), we reorganized the
+RunnerDeployment template in the Helm chart to put the RunnerDeployment resource first, since it is the most important
+resource, merely to improve readability. Unfortunately, the order of operations in creating resources is important, and
+this change broke the deployment by deploying the RunnerDeployment before creating the resources it depends on. This PR
+restores the proper order of operations.

--- a/modules/eks/actions-runner-controller/charts/actions-runner/Chart.yaml
+++ b/modules/eks/actions-runner-controller/charts/actions-runner/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.3.0
 
 # This chart only deploys Resources for actions-runner-controller, so app version does not really apply.
 # We use Resource API version instead.

--- a/modules/eks/actions-runner-controller/charts/actions-runner/templates/horizontalrunnerautoscaler.yaml
+++ b/modules/eks/actions-runner-controller/charts/actions-runner/templates/horizontalrunnerautoscaler.yaml
@@ -10,6 +10,27 @@ spec:
     name: {{ .Values.release_name }}
   minReplicas: {{ .Values.min_replicas }}
   maxReplicas: {{ .Values.max_replicas }}
+  {{- with .Values.scheduled_overrides }}
+  scheduledOverrides:
+    {{- range . }}
+    - startTime: "{{ .start_time }}"
+      endTime: "{{ .end_time }}"
+      {{- with .recurrence_rule }}
+      recurrenceRule:
+        frequency: {{ .frequency }}
+        {{- if .until_time }}
+        untilTime: "{{ .until_time }}"
+        {{- end }}
+      {{- end }}
+      {{- with .min_replicas }}
+      minReplicas: {{ . }}
+      {{- end }}
+      {{- with .max_replicas }}
+      maxReplicas: {{ . }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+
   {{- if .Values.pull_driven_scaling_enabled }}
   metrics:
     - type: PercentageRunnersBusy
@@ -31,7 +52,7 @@ spec:
   - githubEvent:
       workflowJob: {}
     amount: 1
-    {{- if .Values.webhook_startup_timeout }}
-    duration: "{{ .Values.webhook_startup_timeout }}"
+    {{- if .Values.max_duration }}
+    duration: "{{ .Values.max_duration }}"
     {{- end }}
   {{- end }}

--- a/modules/eks/actions-runner-controller/charts/actions-runner/templates/runnerdeployment.yaml
+++ b/modules/eks/actions-runner-controller/charts/actions-runner/templates/runnerdeployment.yaml
@@ -1,7 +1,106 @@
+{{- $release_name := .Values.release_name }}
+{{- /* To avoid the situation where a value evaluates to
+a string value of "false", which has a boolean value of true,
+we explicitly convert to boolean based on the string value */}}
+{{- $use_tmpfs := eq (printf "%v" .Values.tmpfs_enabled) "true" }}
+{{- $use_pvc := eq (printf "%v" .Values.pvc_enabled) "true" }}
+{{- $use_dockerconfig := eq (printf "%v" .Values.docker_config_json_enabled) "true" }}
+{{- $use_dind := eq (printf "%v" .Values.dind_enabled) "true" }}
+{{- /* Historically, the docker daemon was run in a sidecar.
+       At some point, the option became available to use dockerdWithinRunnerContainer,
+       and we now default to that. In fact, at this moment, the sidecar option is not configurable.
+       We keep the logic here in case we need to revert to the sidecar option. */}}
+{{- $use_dind_in_runner := $use_dind }}
+{{- if $use_pvc }}
+# Persistent Volumes can be used for image caching
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ $release_name }}
+spec:
+  accessModes:
+    - ReadWriteMany
+  # StorageClassName comes from efs-controller and must be deployed first.
+  storageClassName: efs-sc
+  resources:
+    requests:
+      # EFS is not actually storage constrained, but this storage request is
+      # required. 100Gi is a ballpark for how much we initially request, but this
+      # may grow. We are responsible for docker pruning this periodically to
+      # save space.
+      storage: 100Gi
+{{- end }}
+{{- if $use_dockerconfig }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $release_name }}-regcred
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ .Values.docker_config_json }}
+{{- end }}
+{{- with .Values.running_pod_annotations }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $release_name }}-runner-hooks
+data:
+  annotate.sh: |
+    #!/bin/bash
+
+    # If we had kubectl and a KUBECONFIG, we could do this:
+    #   kubectl annotate pod $HOSTNAME 'karpenter.sh/do-not-evict="true"' --overwrite
+    #   kubectl annotate pod $HOSTNAME 'karpenter.sh/do-not-disrupt="true"' --overwrite
+
+    # This is the same thing, the hard way
+
+    # Metadata about the pod
+    NAMESPACE=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
+    POD_NAME=$(hostname)
+
+    # Kubernetes API URL
+    API_URL="https://kubernetes.default.svc"
+
+    # Read the service account token
+    TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+
+    # Content type
+    CONTENT_TYPE="application/merge-patch+json"
+
+    PATCH_JSON=$(cat <<'EOF'
+    {
+      "metadata": {
+        "annotations":
+         {{- . | toJson | nindent 10 }}
+      }
+    }
+    EOF
+    )
+
+    # Use curl to patch the pod
+    curl -sSk -X PATCH \
+      -H "Authorization: Bearer $TOKEN" \
+      -H "Content-Type: $CONTENT_TYPE" \
+      -H "Accept: application/json" \
+      -d "$PATCH_JSON" \
+      "$API_URL/api/v1/namespaces/$NAMESPACE/pods/$POD_NAME"  | jq .metadata.annotations \
+    && AT=$(date -u +"%Y-%m-%dT%H:%M:%S.%3Nz") || code=$?
+
+    if [ -z "$AT" ]; then
+      echo "Failed (curl exited with status ${code}) to annotate pod with annotations:\n  '%s'\n" '{{ . | toJson }}'
+      exit $code
+    else
+      printf "Annotated pod at %s with annotations:\n  '%s'\n" "$AT" '{{ . | toJson }}'
+    fi
+
+---
+{{ end }}
 apiVersion: actions.summerwind.dev/v1alpha1
 kind: RunnerDeployment
 metadata:
-  name: {{ .Values.release_name }}
+  name: {{ $release_name }}
 spec:
   # Do not use `replicas` with HorizontalRunnerAutoscaler
   # See https://github.com/actions-runner-controller/actions-runner-controller/issues/206#issuecomment-748601907
@@ -13,7 +112,7 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
     spec:
-      {{- if .Values.docker_config_json_enabled }}
+      {{- if $use_dockerconfig }}
       # secrets volumeMount are always mounted readOnly so config.json has to be copied to the correct directory
       # https://github.com/kubernetes/kubernetes/issues/62099
       # https://github.com/actions/actions-runner-controller/issues/2123#issuecomment-1527077517
@@ -38,8 +137,13 @@ spec:
         # It should be less than the terminationGracePeriodSeconds above so that it has time
         # to report its status and deregister itself from the runner pool.
         - name: RUNNER_GRACEFUL_STOP_TIMEOUT
-          value: "90"
-
+          value: "80"
+        {{- with .Values.wait_for_docker_seconds }}
+        # If Docker is taking too long to start (which is likely due to some other performance issue),
+        # increase the timeout from the default of 120 seconds.
+        - name: WAIT_FOR_DOCKER_SECONDS
+          value: "{{ . }}"
+        {{- end }}
       # You could reserve nodes for runners by labeling and tainting nodes with
       #   node-role.kubernetes.io/actions-runner
       # and then adding the following to this RunnerDeployment
@@ -96,16 +200,16 @@ spec:
         # to explicitly include the "self-hosted" label in order to match the
         # workflow_job to it.
         - self-hosted
-      {{- range .Values.labels }}
+        {{- range .Values.labels }}
         - {{ . | quote }}
-      {{- end }}
+        {{- end }}
       # dockerdWithinRunnerContainer = false means access to a Docker daemon is provided by a sidecar container.
-      dockerdWithinRunnerContainer: {{ .Values.dind_enabled }}
+      dockerdWithinRunnerContainer: {{ $use_dind_in_runner }}
       image: {{ .Values.image | quote }}
       imagePullPolicy: IfNotPresent
-      {{- if  .Values.docker_config_json_enabled }}
+      {{- if  $use_dockerconfig }}
       imagePullSecrets:
-        - name: {{ .Values.release_name }}-regcred
+        - name: {{ $release_name }}-regcred
       {{- end }}
       serviceAccountName: {{ .Values.service_account_name }}
       resources:
@@ -121,28 +225,48 @@ spec:
           {{- if index .Values.resources.requests "ephemeral_storage" }}
           ephemeral-storage: {{ .Values.resources.requests.ephemeral_storage }}
           {{- end }}
-      {{- if and .Values.dind_enabled .Values.docker_storage }}
+      {{- if and (not $use_dind_in_runner) (or .Values.docker_storage $use_tmpfs) }}
+      {{- /* dockerVolumeMounts are mounted into the docker sidecar, and ignored if running with dockerdWithinRunnerContainer */}}
       dockerVolumeMounts:
         - mountPath: /var/lib/docker
           name: docker-volume
       {{- end }}
-      {{- if  or (.Values.pvc_enabled) (.Values.docker_config_json_enabled) }}
+      {{- if or $use_pvc $use_dockerconfig $use_tmpfs }}
       volumeMounts:
-        {{- if .Values.pvc_enabled }}
+        {{- if and $use_dind_in_runner (or .Values.docker_storage $use_tmpfs) }}
+        - mountPath: /var/lib/docker
+          name: docker-volume
+        {{- end }}
+        {{- if $use_pvc }}
         - mountPath: /home/runner/work/shared
           name: shared-volume
         {{- end }}
-        {{- if .Values.docker_config_json_enabled }}
+        {{- if $use_dockerconfig }}
         - mountPath: /home/.docker/
           name: docker-secret
         - mountPath: /home/runner/.docker
           name: docker-config-volume
         {{- end }}
+        {{- if $use_tmpfs }}
+        - mountPath: /tmp
+          name: tmp
+        - mountPath: /runner/_work
+          name: work
+        {{- end }}
       {{- end }}{{/* End of volumeMounts */}}
-      {{- if or (and .Values.dind_enabled .Values.docker_storage) (.Values.pvc_enabled) (.Values.docker_config_json_enabled) (not (empty .Values.running_pod_annotations)) }}
+      {{- if or (and $use_dind (or .Values.docker_storage $use_tmpfs)) $use_pvc $use_dockerconfig (not (empty .Values.running_pod_annotations)) }}
       volumes:
-        {{- if and .Values.dind_enabled .Values.docker_storage }}
+        {{- if $use_tmpfs }}
+        - name: work
+          emptyDir:
+            medium: Memory
+        - name: tmp
+          emptyDir:
+            medium: Memory
+        {{- end }}
+        {{- if and $use_dind (or .Values.docker_storage $use_tmpfs) }}
         - name: docker-volume
+          {{- if .Values.docker_storage }}
           ephemeral:
             volumeClaimTemplate:
               spec:
@@ -150,16 +274,20 @@ spec:
                 resources:
                   requests:
                     storage: {{ .Values.docker_storage }}
+          {{- else }}
+          emptyDir:
+            medium: Memory
+          {{- end }}
         {{- end }}
-        {{- if .Values.pvc_enabled }}
+        {{- if $use_pvc }}
         - name: shared-volume
           persistentVolumeClaim:
-            claimName: {{ .Values.release_name }}
+            claimName: {{ $release_name }}
         {{- end }}
-        {{- if .Values.docker_config_json_enabled }}
+        {{- if $use_dockerconfig }}
         - name: docker-secret
           secret:
-            secretName: {{ .Values.release_name }}-regcred
+            secretName: {{ $release_name }}-regcred
             items:
               - key: .dockerconfigjson
                 path: config.json
@@ -169,85 +297,7 @@ spec:
         {{- with .Values.running_pod_annotations }}
         - name: hooks
           configMap:
-            name: runner-hooks
+            name: {{ $release_name }}-runner-hooks
             defaultMode: 0755  # Set execute permissions for all files
         {{- end }}
       {{- end }}{{/* End of volumes */}}
-{{- if .Values.pvc_enabled }}
----
-# Persistent Volumes can be used for image caching
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: {{ .Values.release_name }}
-spec:
-  accessModes:
-    - ReadWriteMany
-  # StorageClassName comes from efs-controller and must be deployed first.
-  storageClassName: efs-sc
-  resources:
-    requests:
-      # EFS is not actually storage constrained, but this storage request is
-      # required. 100Gi is a ballpark for how much we initially request, but this
-      # may grow. We are responsible for docker pruning this periodically to
-      # save space.
-      storage: 100Gi
-{{- end }}
-{{- if .Values.docker_config_json_enabled }}
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ .Values.release_name }}-regcred
-type: kubernetes.io/dockerconfigjson
-data:
-  .dockerconfigjson: {{ .Values.docker_config_json }}
-{{- end }}
-{{- with .Values.running_pod_annotations }}
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: runner-hooks
-data:
-  annotate.sh: |
-    #!/bin/bash
-
-    # If we had kubectl and a KUBECONFIG, we could do this:
-    #   kubectl annotate pod $HOSTNAME 'karpenter.sh/do-not-evict="true"' --overwrite
-    #   kubectl annotate pod $HOSTNAME 'karpenter.sh/do-not-disrupt="true"' --overwrite
-
-    # This is the same thing, the hard way
-
-    # Metadata about the pod
-    NAMESPACE=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
-    POD_NAME=$(hostname)
-
-    # Kubernetes API URL
-    API_URL="https://kubernetes.default.svc"
-
-    # Read the service account token
-    TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
-
-    # Content type
-    CONTENT_TYPE="application/merge-patch+json"
-
-    PATCH_JSON=$(cat <<EOF
-    {
-      "metadata": {
-        "annotations":
-         {{- . | toJson | nindent 10 }}
-      }
-    }
-    EOF
-    )
-
-    # Use curl to patch the pod
-      curl -sSk -X PATCH \
-    -H "Authorization: Bearer $TOKEN" \
-    -H "Content-Type: $CONTENT_TYPE" \
-    -H "Accept: application/json" \
-      -d "$PATCH_JSON" \
-      "$API_URL/api/v1/namespaces/$NAMESPACE/pods/$POD_NAME"  | jq .metadata.annotations
-
-{{ end }}

--- a/modules/eks/actions-runner-controller/charts/actions-runner/values.yaml
+++ b/modules/eks/actions-runner-controller/charts/actions-runner/values.yaml
@@ -24,7 +24,7 @@ image: summerwind/actions-runner-dind
 
 pvc_enabled: false
 webhook_driven_scaling_enabled: true
-webhook_startup_timeout: "90m"
+max_duration: "90m"
 pull_driven_scaling_enabled: false
 #labels:
 #  - "Ubuntu"

--- a/modules/eks/actions-runner-controller/main.tf
+++ b/modules/eks/actions-runner-controller/main.tf
@@ -153,6 +153,9 @@ module "actions_runner_controller" {
         enabled                   = var.webhook.enabled
         queueLimit                = var.webhook.queue_limit
         useRunnerGroupsVisibility = local.runner_groups_enabled
+        secret = {
+          create = local.create_secret
+        }
         ingress = {
           enabled = var.webhook.enabled
           hosts = [
@@ -230,10 +233,13 @@ module "actions_runner" {
       scale_down_delay_seconds       = each.value.scale_down_delay_seconds
       min_replicas                   = each.value.min_replicas
       max_replicas                   = each.value.max_replicas
+      scheduled_overrides            = each.value.scheduled_overrides
       webhook_driven_scaling_enabled = each.value.webhook_driven_scaling_enabled
-      webhook_startup_timeout        = lookup(each.value, "webhook_startup_timeout", "")
+      max_duration                   = coalesce(each.value.webhook_startup_timeout, each.value.max_duration, "1h")
+      wait_for_docker_seconds        = each.value.wait_for_docker_seconds
       pull_driven_scaling_enabled    = each.value.pull_driven_scaling_enabled
       pvc_enabled                    = each.value.pvc_enabled
+      tmpfs_enabled                  = each.value.tmpfs_enabled
       node_selector                  = each.value.node_selector
       affinity                       = each.value.affinity
       tolerations                    = each.value.tolerations

--- a/modules/eks/actions-runner-controller/outputs.tf
+++ b/modules/eks/actions-runner-controller/outputs.tf
@@ -1,6 +1,29 @@
 output "metadata" {
   value       = module.actions_runner_controller.metadata
   description = "Block status of the deployed release"
+
+  precondition {
+    condition = length([
+      for k, v in var.runners : k if v.webhook_startup_timeout != null && v.max_duration != null
+    ]) == 0
+    error_message = <<-EOT
+        The input var.runners[runner].webhook_startup_timeout is deprecated and replaced by var.runners[runner].max_duration.
+        You may not set both values at the same time, but the following runners have both values set:
+          ${join("\n  ", [for k, v in var.runners : k if v.webhook_startup_timeout != null && v.max_duration != null])}
+
+       EOT
+  }
+  precondition {
+    condition = length([
+      for k, v in var.runners : k if v.storage != null && v.docker_storage != null
+    ]) == 0
+    error_message = <<-EOT
+        The input var.runners[runner].storage is deprecated and replaced by var.runners[runner].docker_storage.
+        You may not set both values at the same time, but the following runners have both values set:
+          ${join("\n  ", [for k, v in var.runners : k if v.storage != null && v.docker_storage != null])}
+
+       EOT
+  }
 }
 
 output "metadata_action_runner_releases" {

--- a/modules/eks/actions-runner-controller/resources/values.yaml
+++ b/modules/eks/actions-runner-controller/resources/values.yaml
@@ -1,23 +1,24 @@
 authSecret:
   create: false
-  name: controller-manager
+  # Use default name, or set via var.existing_kubernetes_secret_name
 scope:
   # If true, the controller will only watch custom resources in a single namespace,
   # which by default is the namespace the controller is in.
   # This provides the ability to run multiple controllers in different namespaces
   # with different TOKENS to get around GitHub API rate limits, among other things.
   singleNamespace: true
-syncPeriod: 120s
+# syncPeriod sets the period in which the controller reconciles the desired runners count.
+# The default value is 60 seconds.
+# syncPeriod: 120s
 
 githubWebhookServer:
   enabled: false
-  syncPeriod: 120s
   secret:
     # Webhook secret, used to authenticate incoming webhook events from GitHub
     # When using Sops, stored in same SopsSecret as authSecret under key `github_webhook_secret_token`
+    # with name set via var.existing_kubernetes_secret_name. Otherwise, use default name.
     enabled: true
     create: false
-    name: "controller-manager"
   useRunnerGroupsVisibility: false
   ingress:
     enabled: false


### PR DESCRIPTION
## what

### New Features:

- Add support for [scheduled overrides](https://github.com/actions/actions-runner-controller/blob/master/docs/automatically-scaling-runners.md#scheduled-overrides) of Runner Autoscaler min and max replicas.
- Add option `tmpfs_enabled` to have runners use RAM-backed ephemeral storage (`tmpfs`, `emptyDir.medium: Memory`) instead of disk-backed storage.
- Add `wait_for_docker_seconds` to allow configuration of the time to wait for the Docker daemon to be ready before starting the runner.
- Enhance the ability to have the runner Pods add annotations to themselves once they start running a job.

### Changes:

- Previously, `syncPeriod`, which sets the period in which the controller reconciles the desired runners count, was set to 120 seconds in `resources/values.yaml`. This setting has been removed, reverting to the default value of 1 minute. You can still set this value by setting the `syncPeriod` value in the `values.yaml` file or by setting `syncPeriod` in `var.chart_values`.
- Previously, `RUNNER_GRACEFUL_STOP_TIMEOUT` was hardcoded to 90 seconds. That has been reduced to 80 seconds.
- The inaccurately named `webhook_startup_timeout` has been replaced with `max_duration`. `webhook_startup_timeout` is still supported for backward compatibility, but is deprecated.

### Bugfixes:

- Create and deploy the webhook secret when an existing secret is not supplied
- Restore proper order of operations in creating resources (broken in release 1.454.0 (PR #1055))
- If `docker_storage` is set and `dockerdWithinRunnerContainer` is `true` (which is hardcoded to be the case), properly mount the docker storage volume into the runner container rather than the (non-existent) docker sidecar container.

## why

### New Features:

- Enable having idle runners during work hours without having to pay for them during non-work hours.
- Enable packing more Runners onto an instance without being constrained by disk I/O.
- Allow for extended disk I/O waits when some Runner gets greedy.
- Intended to make idle Runners interruptible and running runners uninterruptible under Karpenter, but it does not work well enough for that. Still, we implemented the feature, so we might as well leave it in. Adds logging to help diagnose race conditions.

### Changes:

- More responsive scaling
- Increases the chances the runner will successfully deregister itself
- The old name was extremely confusing, while the new name is much more reflective of its impact

### Bugfixes:

- Restore intended operation

## references

- https://github.com/kubernetes-sigs/karpenter/issues/624
- https://github.com/kubernetes-sigs/karpenter/pull/1180
- https://github.com/kubernetes-sigs/karpenter/issues/651
