### PR TITLE
[eks/actions-runner-controller] Fix misconfigured document separators in Helm chart template

### DIFF
--- a/modules/eks/actions-runner-controller/CHANGELOG.md
+++ b/modules/eks/actions-runner-controller/CHANGELOG.md
@@ -1,4 +1,15 @@
-## PR [#1075](https://github.com/cloudposse/terraform-aws-components/pull/1075)
+## Release 1.470.1
+
+Components PR [#1077](https://github.com/cloudposse/terraform-aws-components/pull/1077)
+
+Bugfix:
+
+- Fix templating of document separators in Helm chart template. Affects users who are not using
+  `running_pod_annotations`.
+
+## Release 1.470.0
+
+Components PR [#1075](https://github.com/cloudposse/terraform-aws-components/pull/1075)
 
 New Features:
 

--- a/modules/eks/actions-runner-controller/charts/actions-runner/Chart.yaml
+++ b/modules/eks/actions-runner-controller/charts/actions-runner/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.3.1
 
 # This chart only deploys Resources for actions-runner-controller, so app version does not really apply.
 # We use Resource API version instead.

--- a/modules/eks/actions-runner-controller/charts/actions-runner/templates/runnerdeployment.yaml
+++ b/modules/eks/actions-runner-controller/charts/actions-runner/templates/runnerdeployment.yaml
@@ -12,6 +12,7 @@ we explicitly convert to boolean based on the string value */}}
        We keep the logic here in case we need to revert to the sidecar option. */}}
 {{- $use_dind_in_runner := $use_dind }}
 {{- if $use_pvc }}
+---
 # Persistent Volumes can be used for image caching
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -95,8 +96,8 @@ data:
       printf "Annotated pod at %s with annotations:\n  '%s'\n" "$AT" '{{ . | toJson }}'
     fi
 
----
 {{ end }}
+---
 apiVersion: actions.summerwind.dev/v1alpha1
 kind: RunnerDeployment
 metadata:

--- a/modules/eks/karpenter-node-pool/CHANGELOG.md
+++ b/modules/eks/karpenter-node-pool/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Components [PR #1076](https://github.com/cloudposse/terraform-aws-components/pull/1076)
+## Release 1.470.0
+
+Components PR [#1076](https://github.com/cloudposse/terraform-aws-components/pull/1076)
 
 - Allow specifying elements of `spec.template.spec.kubelet`
 - Make taint values optional

--- a/modules/eks/karpenter/CHANGELOG.md
+++ b/modules/eks/karpenter/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Components [PR #1076](https://github.com/cloudposse/terraform-aws-components/pull/1076)
+## Release 1.470.0
+
+Components PR [#1076](https://github.com/cloudposse/terraform-aws-components/pull/1076)
 
 #### Bugfix
 


### PR DESCRIPTION
## what

### `eks/actions-runner-controller`

-  Fix misconfigured document separators in Helm chart template

## why

- Runner Deployment manifest would be malformed if not using `running_pod_annotations`


## references

- Introduced in #1075 