### PR TITLE
Added additional polices for vpn and kms - required by planner

### DIFF
--- a/modules/aws-team-roles/main.tf
+++ b/modules/aws-team-roles/main.tf
@@ -11,7 +11,9 @@ locals {
   # using an aws_iam_policy resource and then map it to the name you want to use in the
   # YAML configuration by adding an entry in `custom_policy_map`.
   supplied_custom_policy_map = {
-    eks_viewer = try(aws_iam_policy.eks_viewer[0].arn, null)
+    eks_viewer  = try(aws_iam_policy.eks_viewer[0].arn, null)
+    vpn_planner = try(aws_iam_policy.vpn_planner[0].arn, null)
+    kms_planner = try(aws_iam_policy.kms_planner[0].arn, null)
   }
   custom_policy_map = merge(local.supplied_custom_policy_map, local.overridable_additional_custom_policy_map)
 

--- a/modules/aws-team-roles/policy-kms-planner.tf.tf
+++ b/modules/aws-team-roles/policy-kms-planner.tf.tf
@@ -1,0 +1,36 @@
+locals {
+  kms_planner_enabled = contains(local.configured_policies, "kms_planner")
+}
+
+data "aws_iam_policy_document" "kms_planner_access" {
+  count = local.kms_planner_enabled ? 1 : 0
+
+  statement {
+    sid    = "AllowKMSDecrypt"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+    ]
+    resources = [
+      "*"
+    ]
+  }
+
+}
+
+data "aws_iam_policy_document" "kms_planner_access_aggregated" {
+  count = local.kms_planner_enabled ? 1 : 0
+
+  source_policy_documents = [
+    data.aws_iam_policy_document.kms_planner_access[0].json,
+  ]
+}
+
+resource "aws_iam_policy" "kms_planner" {
+  count = local.kms_planner_enabled ? 1 : 0
+
+  name   = format("%s-kms_planner", module.this.id)
+  policy = data.aws_iam_policy_document.kms_planner_access_aggregated[0].json
+
+  tags = module.this.tags
+}

--- a/modules/aws-team-roles/policy-vpn-planner.tf.tf
+++ b/modules/aws-team-roles/policy-vpn-planner.tf.tf
@@ -1,0 +1,36 @@
+locals {
+  vpn_planner_enabled = contains(local.configured_policies, "vpn_planner")
+}
+
+data "aws_iam_policy_document" "vpn_planner_access" {
+  count = local.vpn_planner_enabled ? 1 : 0
+
+  statement {
+    sid    = "AllowVPNReader"
+    effect = "Allow"
+    actions = [
+      "ec2:ExportClientVpnClientConfiguration",
+    ]
+    resources = [
+      "*"
+    ]
+  }
+
+}
+
+data "aws_iam_policy_document" "vpn_planner_access_aggregated" {
+  count = local.vpn_planner_enabled ? 1 : 0
+
+  source_policy_documents = [
+    data.aws_iam_policy_document.vpn_planner_access[0].json,
+  ]
+}
+
+resource "aws_iam_policy" "vpn_planner" {
+  count = local.vpn_planner_enabled ? 1 : 0
+
+  name   = format("%s-vpn_planner", module.this.id)
+  policy = data.aws_iam_policy_document.vpn_planner_access_aggregated[0].json
+
+  tags = module.this.tags
+}


### PR DESCRIPTION
## what
* Added VPN export reader policy
* Added KMS decrypt policy

## why
Policies required for gitops dynamic terraform roles planner

## references
* https://github.com/cloudposse/infra-live/actions/runs/10181554256/job/28167900030
* https://github.com/cloudposse/infra-live/actions/runs/10181554256/job/28164592870
