### PR TITLE
EKS IDP roles added reader

### DIFF
--- a/modules/eks/idp-roles/charts/idp-roles/Chart.yaml
+++ b/modules/eks/idp-roles/charts/idp-roles/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.1.0"
+appVersion: "0.2.0"

--- a/modules/eks/idp-roles/charts/idp-roles/templates/clusterrole-reader-extra.yaml
+++ b/modules/eks/idp-roles/charts/idp-roles/templates/clusterrole-reader-extra.yaml
@@ -1,0 +1,42 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: "{{ .Values.reader_cluster_role }}-extra"
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-reader: "true"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - list
+      - get
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - list
+      - get
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - storageclasses
+    verbs:
+      - list
+      - get
+  - apiGroups:
+      - karpenter.k8s.aws
+    resources:
+      - ec2nodeclasses
+    verbs:
+      - list
+      - get
+  - apiGroups:
+      - karpenter.sh
+    resources:
+      - nodepools
+    verbs:
+      - list
+      - get

--- a/modules/eks/idp-roles/charts/idp-roles/templates/clusterrole-reader.yaml
+++ b/modules/eks/idp-roles/charts/idp-roles/templates/clusterrole-reader.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.reader_cluster_role | quote }}
+aggregationRule:
+  clusterRoleSelectors:
+    - matchLabels:
+        rbac.authorization.k8s.io/aggregate-to-view: "true"
+    - matchLabels:
+        rbac.authorization.k8s.io/aggregate-to-observer: "true"
+    - matchLabels:
+        rbac.authorization.k8s.io/aggregate-to-reader: "true"

--- a/modules/eks/idp-roles/charts/idp-roles/templates/clusterrolebinding-reader.yaml
+++ b/modules/eks/idp-roles/charts/idp-roles/templates/clusterrolebinding-reader.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.reader_crb_name | quote }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Values.reader_cluster_role | quote }}
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: {{ .Values.reader_client_role | quote }}
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: {{ .Values.reader_client_role | quote }}

--- a/modules/eks/idp-roles/charts/idp-roles/values.yaml
+++ b/modules/eks/idp-roles/charts/idp-roles/values.yaml
@@ -27,3 +27,8 @@ poweruser_client_role: "idp:poweruser"
 observer_crb_name: "idp-observer"
 observer_cluster_role: "idp-observer"
 observer_client_role: "idp:observer"
+
+# Reader
+reader_crb_name: "idp-reader"
+reader_cluster_role: "idp-reader"
+reader_client_role: "idp:reader"


### PR DESCRIPTION
## what
* Added `reader` role for `eks/idp-roles`

## why
* Required for dynamic terraform roles to read k8s resources

## references
* https://github.com/cloudposse/infra-live/actions/runs/10146129540/job/28057016517
