### PR TITLE
Add Variable for dynamic dns component lookup

### DIFF
--- a/modules/eks/external-dns/README.md
+++ b/modules/eks/external-dns/README.md
@@ -68,6 +68,7 @@ components:
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_additional_dns_components"></a> [additional\_dns\_components](#module\_additional\_dns\_components) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
 | <a name="module_dns_gbl_delegated"></a> [dns\_gbl\_delegated](#module\_dns\_gbl\_delegated) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
 | <a name="module_dns_gbl_primary"></a> [dns\_gbl\_primary](#module\_dns\_gbl\_primary) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
 | <a name="module_eks"></a> [eks](#module\_eks) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
@@ -100,6 +101,7 @@ components:
 | <a name="input_create_namespace"></a> [create\_namespace](#input\_create\_namespace) | Create the namespace if it does not yet exist. Defaults to `false`. | `bool` | `null` | no |
 | <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between ID elements.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
 | <a name="input_descriptor_formats"></a> [descriptor\_formats](#input\_descriptor\_formats) | Describe additional descriptors to be output in the `descriptors` output map.<br>Map of maps. Keys are names of descriptors. Values are maps of the form<br>`{<br>   format = string<br>   labels = list(string)<br>}`<br>(Type is `any` so the map values can later be enhanced to provide additional options.)<br>`format` is a Terraform format string to be passed to the `format()` function.<br>`labels` is a list of labels, in order, to pass to `format()` function.<br>Label values will be normalized before being passed to `format()` so they will be<br>identical to how they appear in `id`.<br>Default is `{}` (`descriptors` output will be empty). | `any` | `{}` | no |
+| <a name="input_dns_components"></a> [dns\_components](#input\_dns\_components) | A list of additional DNS components to search for ZoneIDs | <pre>list(object({<br>    component   = string,<br>    environment = optional(string)<br>  }))</pre> | `[]` | no |
 | <a name="input_dns_gbl_delegated_environment_name"></a> [dns\_gbl\_delegated\_environment\_name](#input\_dns\_gbl\_delegated\_environment\_name) | The name of the environment where global `dns_delegated` is provisioned | `string` | `"gbl"` | no |
 | <a name="input_dns_gbl_primary_environment_name"></a> [dns\_gbl\_primary\_environment\_name](#input\_dns\_gbl\_primary\_environment\_name) | The name of the environment where global `dns_primary` is provisioned | `string` | `"gbl"` | no |
 | <a name="input_eks_component_name"></a> [eks\_component\_name](#input\_eks\_component\_name) | The name of the eks component | `string` | `"eks/cluster"` | no |

--- a/modules/eks/external-dns/main.tf
+++ b/modules/eks/external-dns/main.tf
@@ -9,7 +9,8 @@ locals {
   txt_prefix      = var.txt_prefix != "" ? format("%s-", local.txt_owner) : ""
   zone_ids = compact(concat(
     values(module.dns_gbl_delegated.outputs.zones)[*].zone_id,
-    values(module.dns_gbl_primary.outputs.zones)[*].zone_id
+    values(module.dns_gbl_primary.outputs.zones)[*].zone_id,
+    flatten([for k, v in module.additional_dns_components : [for i, j in v.outputs.zones : j.zone_id]])
   ))
 }
 

--- a/modules/eks/external-dns/remote-state.tf
+++ b/modules/eks/external-dns/remote-state.tf
@@ -36,3 +36,14 @@ module "dns_gbl_primary" {
     zones = {}
   }
 }
+
+module "additional_dns_components" {
+  for_each = { for obj in var.dns_components : obj.component => obj }
+  source   = "cloudposse/stack-config/yaml//modules/remote-state"
+  version  = "1.5.0"
+
+  component   = each.value.component
+  environment = coalesce(each.value.environment, "gbl")
+
+  context = module.this.context
+}

--- a/modules/eks/external-dns/variables.tf
+++ b/modules/eks/external-dns/variables.tf
@@ -132,6 +132,16 @@ variable "dns_gbl_primary_environment_name" {
   default     = "gbl"
 }
 
+
+variable "dns_components" {
+  type = list(object({
+    component   = string,
+    environment = optional(string)
+  }))
+  description = "A list of additional DNS components to search for ZoneIDs"
+  default     = []
+}
+
 variable "publish_internal_services" {
   type        = bool
   description = "Allow external-dns to publish DNS records for ClusterIP services"


### PR DESCRIPTION
## what
* Adds input for dynamic component lookup for `external-dns`

## why

* External DNS needs a policy that contains each hosted zone. we lookup only `dns-primary` and `dns-delegated` currently. This changes it so we can support a list of objects to enhance that lookup.

e.g.
```yaml
        dns_components: 
          - component: dns-primary
          - component: dns-delegated
          - component: dns-delegated/abc
          - component: dns-delegated/123
```