### PR TITLE
Add explicit parameter store path

### DIFF
--- a/modules/eks/external-secrets-operator/main.tf
+++ b/modules/eks/external-secrets-operator/main.tf
@@ -48,9 +48,13 @@ module "external_secrets_operator" {
         actions = [
           "ssm:GetParameter*"
         ]
-        resources = [for parameter_store_path in var.parameter_store_paths : (
-          "arn:aws:ssm:${var.region}:${local.account}:parameter/${parameter_store_path}/*"
-        )]
+        resources = concat(
+          [for parameter_store_path in var.parameter_store_paths : (
+            "arn:aws:ssm:${var.region}:${local.account}:parameter/${parameter_store_path}/*"
+          )],
+          [for parameter_store_path in var.parameter_store_paths : (
+            "arn:aws:ssm:${var.region}:${local.account}:parameter/${parameter_store_path}"
+        )])
       },
       {
         sid    = "DescribeParameters"


### PR DESCRIPTION
## what

- Add the exact AWS SSM Parameter Store path for IAM permissions

## why

- When using the `find.path` value, ESO will begin the traversal at the exact path defined.
- `ssm:GetParametersByPath` needs permission to the "root" path, eg `arn:aws:ssm:us-west-2:123456789012:parameter/app`

## references

- https://external-secrets.io/latest/guides/getallsecrets/#searching-only-in-a-given-path
