### PR TITLE
Adds version upgrade variable input to component

### DIFF
--- a/modules/elasticache-redis/main.tf
+++ b/modules/elasticache-redis/main.tf
@@ -49,6 +49,7 @@ locals {
     transit_encryption_enabled       = var.transit_encryption_enabled
     apply_immediately                = var.apply_immediately
     automatic_failover_enabled       = var.automatic_failover_enabled
+    auto_minor_version_upgrade       = var.auto_minor_version_upgrade
     cloudwatch_metric_alarms_enabled = var.cloudwatch_metric_alarms_enabled
     auth_token_enabled               = var.auth_token_enabled
   }

--- a/modules/elasticache-redis/modules/redis_cluster/main.tf
+++ b/modules/elasticache-redis/modules/redis_cluster/main.tf
@@ -10,7 +10,7 @@ locals {
 
 module "redis" {
   source  = "cloudposse/elasticache-redis/aws"
-  version = "1.2.2"
+  version = "1.4.1"
 
   name = var.cluster_name
 
@@ -20,6 +20,7 @@ module "redis" {
   apply_immediately                    = var.cluster_attributes.apply_immediately
   at_rest_encryption_enabled           = var.cluster_attributes.at_rest_encryption_enabled
   auth_token                           = local.auth_token
+  auto_minor_version_upgrade           = var.cluster_attributes.auto_minor_version_upgrade
   automatic_failover_enabled           = var.cluster_attributes.automatic_failover_enabled
   availability_zones                   = var.cluster_attributes.availability_zones
   multi_az_enabled                     = var.cluster_attributes.multi_az_enabled

--- a/modules/elasticache-redis/modules/redis_cluster/variables.tf
+++ b/modules/elasticache-redis/modules/redis_cluster/variables.tf
@@ -60,6 +60,7 @@ variable "cluster_attributes" {
     transit_encryption_enabled      = bool
     apply_immediately               = bool
     automatic_failover_enabled      = bool
+    auto_minor_version_upgrade      = bool
     auth_token_enabled              = bool
   })
   description = "Cluster attributes"

--- a/modules/elasticache-redis/variables.tf
+++ b/modules/elasticache-redis/variables.tf
@@ -65,6 +65,12 @@ variable "automatic_failover_enabled" {
   description = "Enable automatic failover"
 }
 
+variable "auto_minor_version_upgrade" {
+  type        = bool
+  description = "Specifies whether minor version engine upgrades will be applied automatically to the underlying Cache Cluster instances during the maintenance window. Only supported if the engine version is 6 or higher."
+  default     = false
+}
+
 variable "cloudwatch_metric_alarms_enabled" {
   type        = bool
   description = "Boolean flag to enable/disable CloudWatch metrics alarms"


### PR DESCRIPTION
## what

- Adds the `auto_minor_version_upgrade` argument for the `aws_elasticache_replication_group` resource
- Updates the `redis` module version to `1.4.1`

## why

- `auto_minor_version_upgrade` argument is missing from the component
- Module is a few minor versions behind upstream

## references

- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_replication_group#auto_minor_version_upgrade
- https://github.com/cloudposse/terraform-aws-elasticache-redis/tree/main
- Release notes between `1.2.2` and `1.4.1`
  - https://github.com/cloudposse/terraform-aws-elasticache-redis/releases/tag/1.2.3
  - https://github.com/cloudposse/terraform-aws-elasticache-redis/releases/tag/1.3.0
  - https://github.com/cloudposse/terraform-aws-elasticache-redis/releases/tag/1.4.0
  - https://github.com/cloudposse/terraform-aws-elasticache-redis/releases/tag/1.4.1
