### PR TITLE
Fix Update changelog workflow

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -94,11 +94,11 @@ jobs:
 
             function trimPath(relativePath) {
               return relativePath
-                .replace('components/terraform/', '')
+                .replace('modules/', '')
                 .replace('/CHANGELOG.md', '');
             }
 
-            const currentChangeLogFiles = findChangelogs('./current/components');
+            const currentChangeLogFiles = findChangelogs('./current/modules');
             const components = [];
 
             for (let i = 0; i < currentChangeLogFiles.length; i++) {


### PR DESCRIPTION
## what
* Fix modules path from `components/terraform` to `modules`

## why 
* It seems that `components/terraform` was testing value. In actual repo components are in `modules` directory

## references
* DEV-2556 Investigate release issues with terraform-aws-components