### PR TITLE
feat: support delete protection for dynamodb

### DIFF
--- a/modules/dynamodb/main.tf
+++ b/modules/dynamodb/main.tf
@@ -43,5 +43,7 @@ module "dynamodb_table" {
 
   enable_point_in_time_recovery = var.point_in_time_recovery_enabled
 
+  deletion_protection_enabled = var.deletion_protection_enabled
+
   context = module.this.context
 }

--- a/modules/dynamodb/variables.tf
+++ b/modules/dynamodb/variables.tf
@@ -174,6 +174,12 @@ variable "replicas" {
   description = "List of regions to create a replica table in"
 }
 
+variable "deletion_protection_enabled" {
+  type        = bool
+  default     = false
+  description = "Enable/disable DynamoDB table deletion protection"
+}
+
 variable "import_table" {
   type = object({
     # Valid values are GZIP, ZSTD and NONE


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

terraform-aws-dynamodb v0.36.0 supports delete protection on the table.  This Pull request exposes that upstream variable


## why

<!--
- Provide the justifications for the changes (e.g. business case).
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

Delete safe dynamodb tables in the dynamo component

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow).
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

https://github.com/cloudposse/terraform-aws-dynamodb/blob/0.36.0/variables.tf#L184-L188
