### PR TITLE
chore(account-settings): upgrades budgets child-module to 0.5.1

### DIFF
--- a/modules/account-settings/README.md
+++ b/modules/account-settings/README.md
@@ -96,7 +96,7 @@ components:
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_budgets"></a> [budgets](#module\_budgets) | cloudposse/budgets/aws | 0.2.1 |
+| <a name="module_budgets"></a> [budgets](#module\_budgets) | cloudposse/budgets/aws | 0.5.1 |
 | <a name="module_iam_account_settings"></a> [iam\_account\_settings](#module\_iam\_account\_settings) | cloudposse/iam-account-settings/aws | 0.5.0 |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
 | <a name="module_service_quotas"></a> [service\_quotas](#module\_service\_quotas) | cloudposse/service-quotas/aws | 0.1.0 |

--- a/modules/account-settings/budgets.tf
+++ b/modules/account-settings/budgets.tf
@@ -1,6 +1,6 @@
 module "budgets" {
   source  = "cloudposse/budgets/aws"
-  version = "0.2.1"
+  version = "0.5.1"
   enabled = module.this.enabled && var.budgets_enabled
 
   budgets = var.budgets


### PR DESCRIPTION
## what

* Upgrades `terraform-aws-budgets` submodule usage in account-settings to 0.5.1

## why

* This enables passing `subscriber_email_addresses` to budgets for receiving emails

## references

* See fix in https://github.com/cloudposse/terraform-aws-budgets/pull/51