### PR TITLE
fix: ssosync artifact filepath extraction

### DIFF
--- a/modules/aws-ssosync/main.tf
+++ b/modules/aws-ssosync/main.tf
@@ -47,7 +47,7 @@ resource "null_resource" "extract_my_tgz" {
   count = local.enabled ? 1 : 0
 
   provisioner "local-exec" {
-    command = "tar -xzf ${path.module}/${local.download_artifact} -C ${path.module}/dist && ls -l ${path.module}/dist"
+    command = "tar -xzf ${path.module}/${local.download_artifact} -C ${path.module}/dist"
   }
 
   depends_on = [module.ssosync_artifact]

--- a/modules/aws-ssosync/main.tf
+++ b/modules/aws-ssosync/main.tf
@@ -47,7 +47,7 @@ resource "null_resource" "extract_my_tgz" {
   count = local.enabled ? 1 : 0
 
   provisioner "local-exec" {
-    command = "tar -xzf ${module.ssosync_artifact.file} -C dist"
+    command = "tar -xzf ${path.module}/${local.download_artifact} -C dist"
   }
 
   depends_on = [module.ssosync_artifact]

--- a/modules/aws-ssosync/main.tf
+++ b/modules/aws-ssosync/main.tf
@@ -47,7 +47,7 @@ resource "null_resource" "extract_my_tgz" {
   count = local.enabled ? 1 : 0
 
   provisioner "local-exec" {
-    command = "tar -xzf ${path.module}/${local.download_artifact} -C ${path.module}/dist"
+    command = "tar -xzf ${module.ssosync_artifact[0].file} -C ${path.module}/dist"
   }
 
   depends_on = [module.ssosync_artifact]

--- a/modules/aws-ssosync/main.tf
+++ b/modules/aws-ssosync/main.tf
@@ -47,7 +47,7 @@ resource "null_resource" "extract_my_tgz" {
   count = local.enabled ? 1 : 0
 
   provisioner "local-exec" {
-    command = "tar -xzf ${local.download_artifact} -C dist"
+    command = "tar -xzf ${module.ssosync_artifact.file} -C dist"
   }
 
   depends_on = [module.ssosync_artifact]

--- a/modules/aws-ssosync/main.tf
+++ b/modules/aws-ssosync/main.tf
@@ -47,7 +47,7 @@ resource "null_resource" "extract_my_tgz" {
   count = local.enabled ? 1 : 0
 
   provisioner "local-exec" {
-    command = "tar -xzf ${path.module}/${local.download_artifact} -C dist"
+    command = "tar -xzf ${path.module}/${local.download_artifact} -C ${path.module}/dist"
   }
 
   depends_on = [module.ssosync_artifact]
@@ -57,7 +57,7 @@ data "archive_file" "lambda" {
   count = local.enabled ? 1 : 0
 
   type        = "zip"
-  source_file = "dist/ssosync"
+  source_file = "${path.module}/dist/ssosync"
   output_path = "ssosync.zip"
 
   depends_on = [null_resource.extract_my_tgz]

--- a/modules/aws-ssosync/main.tf
+++ b/modules/aws-ssosync/main.tf
@@ -47,7 +47,7 @@ resource "null_resource" "extract_my_tgz" {
   count = local.enabled ? 1 : 0
 
   provisioner "local-exec" {
-    command = "tar -xzf ${path.module}/${local.download_artifact} -C ${path.module}/dist"
+    command = "tar -xzf ${path.module}/${local.download_artifact} -C ${path.module}/dist && ls -l ${path.module}/dist"
   }
 
   depends_on = [module.ssosync_artifact]


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
Fixes the ssosync module to use the absolute filepath when extracting the tar.  The code makes some assumptions that relative path works fine.  But when you get into nesting modules, you can run into errors.

## why

<!--
- Provide the justifications for the changes (e.g. business case).
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
* simple bug fix allows me to call this module directly

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow).
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
