### PR TITLE
upstream fixes for site-to-site-vpn

### DIFF
--- a/modules/site-to-site-vpn/README.md
+++ b/modules/site-to-site-vpn/README.md
@@ -136,9 +136,9 @@ atmos terraform apply site-to-site-vpn -s <stack>
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
-| <a name="module_site_to_site_vpn"></a> [site\_to\_site\_vpn](#module\_site\_to\_site\_vpn) | cloudposse/vpn-connection/aws | 1.3.1 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
+| <a name="module_vpn_connection"></a> [vpn\_connection](#module\_vpn\_connection) | cloudposse/vpn-connection/aws | 1.3.1 |
 
 ## Resources
 

--- a/modules/site-to-site-vpn/main.tf
+++ b/modules/site-to-site-vpn/main.tf
@@ -15,7 +15,7 @@ locals {
   ) : null
 }
 
-module "site_to_site_vpn" {
+module "vpn_connection" {
   source  = "cloudposse/vpn-connection/aws"
   version = "1.3.1"
 

--- a/modules/site-to-site-vpn/variables.tf
+++ b/modules/site-to-site-vpn/variables.tf
@@ -27,7 +27,6 @@ variable "vpn_gateway_amazon_side_asn" {
   type        = number
   description = "The Autonomous System Number (ASN) for the Amazon side of the VPN Gateway. If you don't specify an ASN, the Virtual Private Gateway is created with the default ASN"
   default     = null
-  nullable    = false
 }
 
 variable "vpn_connection_static_routes_only" {


### PR DESCRIPTION
## what

 - Couple issues remained
   - `null` variable (when set to `nullable=false`)
   - misnamed module
## why

 - Bugfixes

## references

#1144 