### PR TITLE
feat(elasticache-redis): allow specifying environment for dns-delegated component

### DIFF
--- a/modules/elasticache-redis/remote-state.tf
+++ b/modules/elasticache-redis/remote-state.tf
@@ -23,7 +23,7 @@ module "dns_delegated" {
   version = "1.5.0"
 
   component   = "dns-delegated"
-  environment = "gbl"
+  environment = var.dns_gbl_delegated_environment_name
 
   context = module.this.context
 }

--- a/modules/elasticache-redis/variables.tf
+++ b/modules/elasticache-redis/variables.tf
@@ -104,3 +104,9 @@ variable "eks_component_names" {
   description = "The names of the eks components"
   default     = []
 }
+
+variable "dns_gbl_delegated_environment_name" {
+  type        = string
+  description = "The name of the environment where global `dns_delegated` is provisioned"
+  default     = "gbl"
+}


### PR DESCRIPTION
## what

Add `dns_gbl_delegated_environment_name` (used throughout components) to specify environment of `dns-delegated` component.

## why

This change is necessary when deploying identical environments in multiple regions and using regional `dns-delegated` components rather than a single global one.