### PR TITLE
fix: Runs-On README

### DIFF
--- a/modules/runs-on/README.md
+++ b/modules/runs-on/README.md
@@ -72,8 +72,6 @@ vars:
         - runs-on
 ```
 
-<details><summary>Click to show full stack configuration</summary>
-
 ```yaml
 components:
 terraform:


### PR DESCRIPTION
## what
- Remove unclosed / unused summary

## why
- This is breaking the cloudposse/docs release pipelines

## references
- https://github.com/cloudposse/docs/actions/runs/11380845724