### PR TITLE
feat(elasticache-redis): add engine input for valkey support

### DIFF
--- a/modules/elasticache-redis/README.md
+++ b/modules/elasticache-redis/README.md
@@ -38,6 +38,7 @@ components:
             num_replicas: 1
             num_shards: 0
             replicas_per_shard: 0
+            engine: "redis"
             engine_version: 6.0.5
             instance_type: cache.t2.small
             parameters:
@@ -109,6 +110,7 @@ No resources.
 | <a name="input_at_rest_encryption_enabled"></a> [at\_rest\_encryption\_enabled](#input\_at\_rest\_encryption\_enabled) | Enable encryption at rest | `bool` | n/a | yes |
 | <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br>in the order they appear in the list. New attributes are appended to the<br>end of the list. The elements of the list are joined by the `delimiter`<br>and treated as a single ID element. | `list(string)` | `[]` | no |
 | <a name="input_auth_token_enabled"></a> [auth\_token\_enabled](#input\_auth\_token\_enabled) | Enable auth token | `bool` | `true` | no |
+| <a name="input_auto_minor_version_upgrade"></a> [auto\_minor\_version\_upgrade](#input\_auto\_minor\_version\_upgrade) | Specifies whether minor version engine upgrades will be applied automatically to the underlying Cache Cluster instances during the maintenance window. Only supported if the engine version is 6 or higher. | `bool` | `false` | no |
 | <a name="input_automatic_failover_enabled"></a> [automatic\_failover\_enabled](#input\_automatic\_failover\_enabled) | Enable automatic failover | `bool` | n/a | yes |
 | <a name="input_availability_zones"></a> [availability\_zones](#input\_availability\_zones) | Availability zone IDs | `list(string)` | `[]` | no |
 | <a name="input_cloudwatch_metric_alarms_enabled"></a> [cloudwatch\_metric\_alarms\_enabled](#input\_cloudwatch\_metric\_alarms\_enabled) | Boolean flag to enable/disable CloudWatch metrics alarms | `bool` | n/a | yes |

--- a/modules/elasticache-redis/README.md
+++ b/modules/elasticache-redis/README.md
@@ -69,6 +69,9 @@ components:
                 value: lK
 ```
 
+The `engine` can either be `redis` or `valkey`. For more information, see
+[why aws supports valkey](https://aws.amazon.com/blogs/opensource/why-aws-supports-valkey/).
+
 <!-- prettier-ignore-start -->
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements

--- a/modules/elasticache-redis/main.tf
+++ b/modules/elasticache-redis/main.tf
@@ -69,6 +69,7 @@ module "redis_clusters" {
   num_replicas           = lookup(each.value, "num_replicas", 1)
   num_shards             = lookup(each.value, "num_shards", 0)
   replicas_per_shard     = lookup(each.value, "replicas_per_shard", 0)
+  engine                 = lookup(each.value, "engine", "redis")
   engine_version         = each.value.engine_version
   create_parameter_group = lookup(each.value, "create_parameter_group", true)
   parameters             = lookup(each.value, "parameters", null)

--- a/modules/elasticache-redis/modules/redis_cluster/main.tf
+++ b/modules/elasticache-redis/modules/redis_cluster/main.tf
@@ -10,7 +10,7 @@ locals {
 
 module "redis" {
   source  = "cloudposse/elasticache-redis/aws"
-  version = "1.4.1"
+  version = "1.7.0"
 
   name = var.cluster_name
 
@@ -29,6 +29,7 @@ module "redis" {
   cluster_mode_replicas_per_node_group = var.replicas_per_shard
   cluster_size                         = var.num_replicas
   dns_subdomain                        = var.dns_subdomain
+  engine                               = var.engine
   engine_version                       = var.engine_version
   family                               = var.cluster_attributes.family
   instance_type                        = var.instance_type

--- a/modules/elasticache-redis/modules/redis_cluster/variables.tf
+++ b/modules/elasticache-redis/modules/redis_cluster/variables.tf
@@ -14,12 +14,12 @@ variable "create_parameter_group" {
 variable "engine" {
   type        = string
   default     = "redis"
-  description = "Name of the cache engine"
+  description = "Name of the cache engine to use: either `redis` or `valkey`"
 }
 
 variable "engine_version" {
   type        = string
-  description = "Redis Version"
+  description = "Version of the cache engine to use"
   default     = "6.0.5"
 }
 

--- a/modules/elasticache-redis/modules/redis_cluster/variables.tf
+++ b/modules/elasticache-redis/modules/redis_cluster/variables.tf
@@ -11,6 +11,12 @@ variable "create_parameter_group" {
   description = "Whether new parameter group should be created. Set to false if you want to use existing parameter group"
 }
 
+variable "engine" {
+  type        = string
+  default     = "redis"
+  description = "Name of the cache engine"
+}
+
 variable "engine_version" {
   type        = string
   description = "Redis Version"


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
- add engine input for valkey support

## why

<!--
- Provide the justifications for the changes (e.g. business case).
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
- Valkey is far cheaper than redis

<details><summary>Notes</summary>

- Design options
    1. Add a new key to `local.cluster_attributes` and add a variable to the component, default it to `redis`, and pass as an argument to the module as-is
        - We could shy away from the pattern to using `engine = var.engine` in the `local`.
    1. Allow `var.redis_clusters` to supply `engine` with a default for `redis` and pass to module as-is
    1. Same as option 2 but allow `local.cluster_attributes` to overwrite it
        - This might be best of both worlds however no other argument does this so it would be breaking the pattern
- Went with option 2 so the argument isn't a new requirement for everyone and it doesn't break consistency

</details>

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow).
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- https://github.com/cloudposse/terraform-aws-elasticache-redis/releases/tag/v1.7.0
- https://aws.amazon.com/blogs/opensource/why-aws-supports-valkey/
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_replication_group#engine
- https://github.com/hashicorp/terraform-provider-aws/issues/39641
- https://github.com/hashicorp/terraform-provider-aws/releases/tag/v5.73.0
- https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/Clusters.Create.html
- https://www.lastweekinaws.com/blog/aws-valkey-play-when-a-fork-becomes-a-price-cut/