### PR TITLE
Allow for enabling IPv6 in VPCs

### DIFF
--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -148,7 +148,8 @@ module "subnets" {
   ipv4_cidr_block                 = [module.vpc.vpc_cidr_block]
   ipv4_cidrs                      = var.ipv4_cidrs
   ipv6_enabled                    = length(local.vpc_ipv6_cidr_blocks) > 0
-  ipv6_cidrs                      = local.vpc_ipv6_cidr_blocks
+  disable_private_ipv6            = var.disable_private_ipv6
+  disable_public_ipv6             = var.disable_public_ipv6
   igw_id                          = var.public_subnets_enabled ? [module.vpc.igw_id] : []
   map_public_ip_on_launch         = var.map_public_ip_on_launch
   max_subnet_count                = local.max_subnet_count

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -63,6 +63,8 @@ locals {
     security_group_ids  = [module.endpoint_security_groups[local.interface_endpoint_security_group_key].id]
     subnet_ids          = module.subnets.private_subnet_ids
   } }
+
+  vpc_ipv6_cidr_blocks = compact(concat([module.vpc.vpc_ipv6_cidr_block], module.vpc.additional_ipv6_cidr_blocks))
 }
 
 module "utils" {
@@ -114,7 +116,7 @@ module "endpoint_security_groups" {
       to_port          = 65535
       protocol         = "-1" # allow ping
       cidr_blocks      = compact(concat([module.vpc.vpc_cidr_block], module.vpc.additional_cidr_blocks))
-      ipv6_cidr_blocks = compact(concat([module.vpc.vpc_ipv6_cidr_block], module.vpc.additional_ipv6_cidr_blocks))
+      ipv6_cidr_blocks = local.vpc_ipv6_cidr_blocks
       description      = "Ingress from VPC to ${each.value}"
     }]
   }
@@ -145,7 +147,8 @@ module "subnets" {
   availability_zone_ids           = local.availability_zone_ids
   ipv4_cidr_block                 = [module.vpc.vpc_cidr_block]
   ipv4_cidrs                      = var.ipv4_cidrs
-  ipv6_enabled                    = false
+  ipv6_enabled                    = length(local.vpc_ipv6_cidr_blocks) > 0
+  ipv6_cidrs                      = local.vpc_ipv6_cidr_blocks
   igw_id                          = var.public_subnets_enabled ? [module.vpc.igw_id] : []
   map_public_ip_on_launch         = var.map_public_ip_on_launch
   max_subnet_count                = local.max_subnet_count

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -89,6 +89,18 @@ variable "ipv4_cidrs" {
   }
 }
 
+variable "disable_private_ipv6" {
+  type        = bool
+  default     = false
+  description = "Allow for selectively disabling IPv6 addresses in private subnets only"
+}
+
+variable "disable_private_ipv6" {
+  type        = bool
+  default     = false
+  description = "Allow for selectively disabling IPv6 addresses in public subnets only"
+}
+
 variable "assign_generated_ipv6_cidr_block" {
   type        = bool
   description = "When `true`, assign AWS generated IPv6 CIDR block to the VPC.  Conflicts with `ipv6_ipam_pool_id`."


### PR DESCRIPTION
## what

IPv6 support was explicitly disabled in this module. This PR enables it!

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

## why

<!--
- Provide the justifications for the changes (e.g. business case).
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow).
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
Requires https://github.com/cloudposse/terraform-aws-dynamic-subnets/pull/217