### PR TITLE
Add support for redis cluster replication group id definition

### DIFF
--- a/modules/elasticache-redis/main.tf
+++ b/modules/elasticache-redis/main.tf
@@ -76,6 +76,7 @@ module "redis_clusters" {
   parameters             = lookup(each.value, "parameters", null)
   parameter_group_name   = lookup(each.value, "parameter_group_name", null)
   cluster_attributes     = local.cluster_attributes
+  replication_group_id   = lookup(each.value, "replication_group_id", null)
 
   context = module.this.context
 }

--- a/modules/elasticache-redis/modules/redis_cluster/main.tf
+++ b/modules/elasticache-redis/modules/redis_cluster/main.tf
@@ -37,6 +37,7 @@ module "redis" {
   parameter                            = var.parameters
   parameter_group_name                 = var.parameter_group_name
   port                                 = var.cluster_attributes.port
+  replication_group_id                 = var.replication_group_id
   subnets                              = var.cluster_attributes.subnets
   transit_encryption_enabled           = var.cluster_attributes.transit_encryption_enabled
   snapshot_retention_limit             = var.cluster_attributes.snapshot_retention_limit

--- a/modules/elasticache-redis/modules/redis_cluster/variables.tf
+++ b/modules/elasticache-redis/modules/redis_cluster/variables.tf
@@ -91,3 +91,9 @@ variable "kms_alias_name_ssm" {
   default     = "alias/aws/ssm"
   description = "KMS alias name for SSM"
 }
+
+variable "replication_group_id" {
+  default     = ""
+  type        = string
+  description = "Name for the replication group id to be created"
+}

--- a/modules/elasticache-redis/variables.tf
+++ b/modules/elasticache-redis/variables.tf
@@ -110,3 +110,9 @@ variable "snapshot_retention_limit" {
   description = "The number of days for which ElastiCache will retain automatic cache cluster snapshots before deleting them."
   default     = 0
 }
+
+variable "replication_group_id" {
+  default     = ""
+  type        = string
+  description = "Name for the replication group id to be created"
+}


### PR DESCRIPTION
## what
The Cloudposse elasticache-redis module (https://github.com/cloudposse/terraform-aws-elasticache-redis/blob/main/main.tf#L92) references the ability to define a replication_group_id as a var, but we do not allow for that to be passed through from the reference module and submodule call.
<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

## why
In cases where the replication_group_id is not passed, the underlying code will attempt to create one. This can run into naming length limits (aws only allows a limit of 40 characters), so we should provide the ability to override it at all levels.
<!--
- Provide the justifications for the changes (e.g. business case).
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow).
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
